### PR TITLE
Changes to build the operator manually and travisCI to pass in operator piece.

### DIFF
--- a/.travis-pub.yml
+++ b/.travis-pub.yml
@@ -50,7 +50,7 @@ jobs:
       script:
         - pip install ansible
         # Testing that the generated files match the deploy/*.yaml files, it they do not match, fail Travis
-        - ansible-playbook ${TRAVIS_BUILD_DIR}/ansible/generate-playbook.yaml --extra-vars "travis_testing=true"
+        - ansible-playbook ${TRAVIS_BUILD_DIR}/tools/ansible/generate-playbook.yaml --extra-vars "travis_testing=true"
         - pip install operator-courier
         - cd ${CSI_OP_BUILD_DIR}
         - python hacks/package_operator.py -d ${OLM_MANIFEST}  -o /tmp/operator --nozip 
@@ -61,7 +61,7 @@ jobs:
       script:
         - sudo pip install docker
         - docker version
-        - ${TRAVIS_BUILD_DIR}/scripts/ci/install_operator-sdk.sh
+        - ${TRAVIS_BUILD_DIR}/tools/scripts/ci/install_operator-sdk.sh
         - cd ${CSI_OP_BUILD_DIR}
         - operator-sdk version
         - go version
@@ -81,8 +81,8 @@ jobs:
       before_install:
         - sudo pip install docker
         - pip install openshift
-        - ${TRAVIS_BUILD_DIR}/scripts/ci/install_minikube.sh
-        - ${TRAVIS_BUILD_DIR}/scripts/ci/install_operator-sdk.sh
+        - ${TRAVIS_BUILD_DIR}/tools/scripts/ci/install_minikube.sh
+        - ${TRAVIS_BUILD_DIR}/tools/scripts/ci/install_operator-sdk.sh
         - kubectl version
         - cd ${CSI_OP_BUILD_DIR}
         - eval $(minikube docker-env) # Popping this out, because I don't think the script is working.
@@ -100,8 +100,8 @@ jobs:
     - before_install:
         - sudo pip install docker
         - pip install pyyaml molecule openshift docker jmespath kubernetes-validate
-        - ${TRAVIS_BUILD_DIR}/scripts/ci/install_minikube.sh
-        - ${TRAVIS_BUILD_DIR}/scripts/ci/install_operator-sdk.sh
+        - ${TRAVIS_BUILD_DIR}/tools/scripts/ci/install_minikube.sh
+        - ${TRAVIS_BUILD_DIR}/tools/scripts/ci/install_operator-sdk.sh
         - kubectl version
         - cd ${CSI_OP_BUILD_DIR}
         - eval $(minikube docker-env) # Popping this out, because I don't think the script is working.
@@ -114,7 +114,7 @@ jobs:
         - kubectl create -f deploy/namespace.yaml
         - molecule test -s test-local
 
-          #- ${TRAVIS_BUILD_DIR}/scripts/ci/fold_ouput.sh cluster.info.2 "cluster information"  kubectl cluster-info dump
+          #- ${TRAVIS_BUILD_DIR}/tools/scripts/ci/fold_ouput.sh cluster.info.2 "cluster information"  kubectl cluster-info dump
 notifications:
   email:
     - jdunham@us.ibm.com

--- a/.travis-pub.yml
+++ b/.travis-pub.yml
@@ -53,7 +53,7 @@ jobs:
         - ansible-playbook ${TRAVIS_BUILD_DIR}/tools/ansible/generate-playbook.yaml --extra-vars "travis_testing=true"
         - pip install operator-courier
         - cd ${CSI_OP_BUILD_DIR}
-        - python operator/hacks/package_operator.py -d ${OLM_MANIFEST}  -o /tmp/operator --nozip 
+        - python hacks/package_operator.py -d ${OLM_MANIFEST}  -o /tmp/operator --nozip 
         - operator-courier --verbose verify --ui_validate_io /tmp/operator
 
     - stage: build
@@ -91,11 +91,11 @@ jobs:
       script: 
         # Print environment 
         # Build the image, clear and restore the finalizers.
-        - python operator/hacks/clear_finalizers.py
-        - python operator/hacks/change_deploy_image.py -i ${DOCKER_REPO} --ifnotpresent
+        - python hacks/clear_finalizers.py
+        - python hacks/change_deploy_image.py -i ${DOCKER_REPO} --ifnotpresent
         - kubectl create -f deploy/namespace.yaml
         - operator-sdk scorecard --config .osdk-scorecard.yaml
-        - python  operator/hacks/clear_finalizers.py --restore
+        - python hacks/clear_finalizers.py --restore
         
     - before_install:
         - sudo pip install docker
@@ -110,7 +110,7 @@ jobs:
       name: "Test: molecule"
       script: 
         #  This needs to be built before we can test with molecule for reasons.
-        - python operator/hacks/change_deploy_image.py -i ${LOCAL_IMAGE} --ifnotpresent
+        - python hacks/change_deploy_image.py -i ${LOCAL_IMAGE} --ifnotpresent
         - kubectl create -f deploy/namespace.yaml
         - molecule test -s test-local
 

--- a/.travis-pub.yml
+++ b/.travis-pub.yml
@@ -53,7 +53,7 @@ jobs:
         - ansible-playbook ${TRAVIS_BUILD_DIR}/tools/ansible/generate-playbook.yaml --extra-vars "travis_testing=true"
         - pip install operator-courier
         - cd ${CSI_OP_BUILD_DIR}
-        - python hacks/package_operator.py -d ${OLM_MANIFEST}  -o /tmp/operator --nozip 
+        - python operator/hacks/package_operator.py -d ${OLM_MANIFEST}  -o /tmp/operator --nozip 
         - operator-courier --verbose verify --ui_validate_io /tmp/operator
 
     - stage: build
@@ -91,11 +91,11 @@ jobs:
       script: 
         # Print environment 
         # Build the image, clear and restore the finalizers.
-        - python hacks/clear_finalizers.py
-        - python hacks/change_deploy_image.py -i ${DOCKER_REPO} --ifnotpresent
+        - python operator/hacks/clear_finalizers.py
+        - python operator/hacks/change_deploy_image.py -i ${DOCKER_REPO} --ifnotpresent
         - kubectl create -f deploy/namespace.yaml
         - operator-sdk scorecard --config .osdk-scorecard.yaml
-        - python  hacks/clear_finalizers.py --restore
+        - python  operator/hacks/clear_finalizers.py --restore
         
     - before_install:
         - sudo pip install docker
@@ -110,7 +110,7 @@ jobs:
       name: "Test: molecule"
       script: 
         #  This needs to be built before we can test with molecule for reasons.
-        - python hacks/change_deploy_image.py -i ${LOCAL_IMAGE} --ifnotpresent
+        - python operator/hacks/change_deploy_image.py -i ${LOCAL_IMAGE} --ifnotpresent
         - kubectl create -f deploy/namespace.yaml
         - molecule test -s test-local
 

--- a/.travis-pub.yml
+++ b/.travis-pub.yml
@@ -18,7 +18,7 @@ env:
     - LOCAL_IMAGE="csi.ibm.com/csi-scale-operator:testing"
 
     - OPERATOR_SDK="https://github.com/operator-framework/operator-sdk/releases/download/${OP_VER}/operator-sdk-${OP_VER}-x86_64-linux-gnu"
-    - CSI_OP_BUILD_DIR="${TRAVIS_BUILD_DIR}/stable/ibm-spectrum-scale-csi-operator-bundle/operators/ibm-spectrum-scale-csi-operator"
+    - CSI_OP_BUILD_DIR="${TRAVIS_BUILD_DIR}/operator"
 
 
     - OPERATOR_NAME=ibm-spectrum-scale-csi-operator

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,6 @@
-# <<<<<<< HEAD
 services: docker
 sudo: required
 dist: xenial
-#group: bluezone
 language: go
 go:
   - 1.13.x
@@ -159,80 +157,3 @@ jobs:
           #- ${TRAVIS_BUILD_DIR}/scripts/ci/fold_ouput.sh cluster.info.2 "cluster information"  kubectl cluster-info dump
 notifications:
   email: false
-# =======
-os: linux
-dist: xenial
-services: docker
-
-language: go
-go:
-  - "1.13"
-
-env:
-  global:
-    - REPO_OWNER=$(dirname $TRAVIS_REPO_SLUG)
-    - REPO_NAME=$(basename $TRAVIS_REPO_SLUG)
-   
-    # Grab quay username from 'user+bot_token'
-    - IMAGE_REPO_OWNER=${QUAY_BOT_USERNAME%%\+*}
-    # Format quay image target
-    - IMAGE_REPO=quay.io/${IMAGE_REPO_OWNER}/${REPO_NAME}
-    # Add image tag
-    - IMAGE_TAG=$( 
-        if [[ $TRAVIS_EVENT_TYPE == 'cron' ]]; 
-        then 
-            echo "nightly-${TRAVIS_BUILD_ID}-`date -u +%F`"; 
-        else
-            echo $TRAVIS_BRANCH; 
-        fi
-      )
-    # Add image repo and tag
-    - IMAGE_FQN=${IMAGE_REPO}:${IMAGE_TAG}
-    - IMAGE_VERSION=${IMAGE_TAG}
-    # Add image label to expire nightlies
-    - IMAGE_LABEL=$(
-        if [[ $TRAVIS_EVENT_TYPE == 'cron' ]];
-        then
-            echo "--label version=${IMAGE_VERSION} --label quay.expires-after=2w";
-        else
-            echo "--label version=${IMAGE_VERSION}";
-        fi
-      )
-
-stages:
-  - lint
-  - test
-
-jobs:
-  fast_finish: true
-  include:
-    # Lint with with .golangci.yml configuration
-    - stage: lint
-      before_install:
-        - >-
-          curl -sfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh |
-          sh -s -- -b $(go env GOPATH)/bin v1.21.0 # pinned
-      script:
-        - golangci-lint run
-
-    - stage: test
-      env:
-        - GOFLAGS="-mod=vendor" #this should not be required in Go 1.14, see https://github.com/golang/go/issues/33848
-      before_script:
-        - go mod vendor
-      script:
-        - go test -v -race ./...
-        - docker build ${IMAGE_LABEL} --build-arg GOFLAGS=${GOFLAGS} -f Dockerfile.msb -t ${REPO_NAME} .
-      before_deploy:
-          - echo "$QUAY_BOT_PASSWORD" | docker login -u "$QUAY_BOT_USERNAME" --password-stdin quay.io
-          - docker tag ${REPO_NAME} ${IMAGE_FQN}
-      deploy:
-        - provider: script
-          script: docker push ${IMAGE_FQN}
-          on:
-            all_branches: true
-            condition: -n "$QUAY_BOT_USERNAME" && -n "$QUAY_BOT_PASSWORD"
-
-notifications:
-  email: false
-# >>>>>>> old_driver/devel

--- a/.travis.yml
+++ b/.travis.yml
@@ -53,7 +53,7 @@ jobs:
         - ansible-playbook ${TRAVIS_BUILD_DIR}/tools/ansible/generate-playbook.yaml --extra-vars "travis_testing=true"
         - pip install operator-courier
         - cd ${CSI_OP_BUILD_DIR}
-        - python operator/hacks/package_operator.py -d ${OLM_MANIFEST}  -o /tmp/operator --nozip 
+        - python hacks/package_operator.py -d ${OLM_MANIFEST}  -o /tmp/operator --nozip 
         - operator-courier --verbose verify --ui_validate_io /tmp/operator
 
     - name: "Lint: CASE"
@@ -131,11 +131,11 @@ jobs:
       script: 
         # Print environment 
         # Build the image, clear and restore the finalizers.
-        - python operator/hacks/clear_finalizers.py
-        - python operator/hacks/change_deploy_image.py -i ${DOCKER_REPO} --ifnotpresent
+        - python hacks/clear_finalizers.py
+        - python hacks/change_deploy_image.py -i ${DOCKER_REPO} --ifnotpresent
         - kubectl create -f deploy/namespace.yaml
         - operator-sdk scorecard --config .osdk-scorecard.yaml
-        - python  operator/hacks/clear_finalizers.py --restore
+        - python  hacks/clear_finalizers.py --restore
         
     - before_install:
         - sudo pip install docker
@@ -150,7 +150,7 @@ jobs:
       name: "Test: molecule"
       script: 
         #  This needs to be built before we can test with molecule for reasons.
-        - python operator/hacks/change_deploy_image.py -i ${LOCAL_IMAGE} --ifnotpresent
+        - python hacks/change_deploy_image.py -i ${LOCAL_IMAGE} --ifnotpresent
         - kubectl create -f deploy/namespace.yaml
         - molecule test -s test-local
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -53,7 +53,7 @@ jobs:
         - ansible-playbook ${TRAVIS_BUILD_DIR}/tools/ansible/generate-playbook.yaml --extra-vars "travis_testing=true"
         - pip install operator-courier
         - cd ${CSI_OP_BUILD_DIR}
-        - python hacks/package_operator.py -d ${OLM_MANIFEST}  -o /tmp/operator --nozip 
+        - python operator/hacks/package_operator.py -d ${OLM_MANIFEST}  -o /tmp/operator --nozip 
         - operator-courier --verbose verify --ui_validate_io /tmp/operator
 
     - name: "Lint: CASE"
@@ -131,11 +131,11 @@ jobs:
       script: 
         # Print environment 
         # Build the image, clear and restore the finalizers.
-        - python hacks/clear_finalizers.py
-        - python hacks/change_deploy_image.py -i ${DOCKER_REPO} --ifnotpresent
+        - python operator/hacks/clear_finalizers.py
+        - python operator/hacks/change_deploy_image.py -i ${DOCKER_REPO} --ifnotpresent
         - kubectl create -f deploy/namespace.yaml
         - operator-sdk scorecard --config .osdk-scorecard.yaml
-        - python  hacks/clear_finalizers.py --restore
+        - python  operator/hacks/clear_finalizers.py --restore
         
     - before_install:
         - sudo pip install docker
@@ -150,7 +150,7 @@ jobs:
       name: "Test: molecule"
       script: 
         #  This needs to be built before we can test with molecule for reasons.
-        - python hacks/change_deploy_image.py -i ${LOCAL_IMAGE} --ifnotpresent
+        - python operator/hacks/change_deploy_image.py -i ${LOCAL_IMAGE} --ifnotpresent
         - kubectl create -f deploy/namespace.yaml
         - molecule test -s test-local
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -50,7 +50,7 @@ jobs:
       script:
         - pip install ansible
         # Testing that the generated files match the deploy/*.yaml files, it they do not match, fail Travis
-        - ansible-playbook ${TRAVIS_BUILD_DIR}/ansible/generate-playbook.yaml --extra-vars "travis_testing=true"
+        - ansible-playbook ${TRAVIS_BUILD_DIR}/tools/ansible/generate-playbook.yaml --extra-vars "travis_testing=true"
         - pip install operator-courier
         - cd ${CSI_OP_BUILD_DIR}
         - python hacks/package_operator.py -d ${OLM_MANIFEST}  -o /tmp/operator --nozip 
@@ -100,7 +100,7 @@ jobs:
       script:
         - sudo pip install docker
         - docker version
-        - ${TRAVIS_BUILD_DIR}/scripts/ci/install_operator-sdk.sh
+        - ${TRAVIS_BUILD_DIR}/tools/scripts/ci/install_operator-sdk.sh
         - cd ${CSI_OP_BUILD_DIR}
         - operator-sdk version
         - go version
@@ -121,8 +121,8 @@ jobs:
       before_install:
         - sudo pip install docker
         - pip install openshift
-        - ${TRAVIS_BUILD_DIR}/scripts/ci/install_minikube.sh
-        - ${TRAVIS_BUILD_DIR}/scripts/ci/install_operator-sdk.sh
+        - ${TRAVIS_BUILD_DIR}/tools/scripts/ci/install_minikube.sh
+        - ${TRAVIS_BUILD_DIR}/tools/scripts/ci/install_operator-sdk.sh
         - kubectl version
         - cd ${CSI_OP_BUILD_DIR}
         - eval $(minikube docker-env) # Popping this out, because I don't think the script is working.
@@ -140,8 +140,8 @@ jobs:
     - before_install:
         - sudo pip install docker
         - pip install pyyaml molecule openshift docker jmespath kubernetes-validate
-        - ${TRAVIS_BUILD_DIR}/scripts/ci/install_minikube.sh
-        - ${TRAVIS_BUILD_DIR}/scripts/ci/install_operator-sdk.sh
+        - ${TRAVIS_BUILD_DIR}/tools/scripts/ci/install_minikube.sh
+        - ${TRAVIS_BUILD_DIR}/tools/scripts/ci/install_operator-sdk.sh
         - kubectl version
         - cd ${CSI_OP_BUILD_DIR}
         - eval $(minikube docker-env) # Popping this out, because I don't think the script is working.
@@ -154,6 +154,6 @@ jobs:
         - kubectl create -f deploy/namespace.yaml
         - molecule test -s test-local
 
-          #- ${TRAVIS_BUILD_DIR}/scripts/ci/fold_ouput.sh cluster.info.2 "cluster information"  kubectl cluster-info dump
+          #- ${TRAVIS_BUILD_DIR}/tools/scripts/ci/fold_ouput.sh cluster.info.2 "cluster information"  kubectl cluster-info dump
 notifications:
   email: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,7 @@ env:
     - LOCAL_IMAGE="csi.ibm.com/csi-scale-operator:testing"
 
     - OPERATOR_SDK="https://github.com/operator-framework/operator-sdk/releases/download/${OP_VER}/operator-sdk-${OP_VER}-x86_64-linux-gnu"
-    - CSI_OP_BUILD_DIR="${TRAVIS_BUILD_DIR}/stable/ibm-spectrum-scale-csi-operator-bundle/operators/ibm-spectrum-scale-csi-operator"
+    - CSI_OP_BUILD_DIR="${TRAVIS_BUILD_DIR}/operator"
 
 
     - OPERATOR_NAME=ibm-spectrum-scale-csi-operator

--- a/README.operator.md
+++ b/README.operator.md
@@ -25,7 +25,7 @@ export IBM_DIR="$GOPATH/src/github.com/IBM"
 # Ensure the dir is present then clone.
 mkdir -p ${IBM_DIR}
 cd ${IBM_DIR}
-git clone https://github.com/IBM/ibm-spectrum-scale-csi-operator.git
+git clone https://github.com/IBM/ibm-spectrum-scale-csi.git
 ```
 
 ### Development environment setup
@@ -33,7 +33,7 @@ git clone https://github.com/IBM/ibm-spectrum-scale-csi-operator.git
 To help configure and resolve dependencies to build the csi-operator, a ansible playbook is provided.  You can run the following to invoke the playbook:
 
 ``` bash
-ansible-playbook $GOPATH/src/github.com/IBM/ibm-spectrum-scale-csi-operator/ansible/dev-env-playbook.yaml
+ansible-playbook $GOPATH/src/github.com/IBM/ibm-spectrum-scale-csi/tools/ansible/dev-env-playbook.yaml
 ```
 
 ### Building the image
@@ -42,8 +42,8 @@ To build the image the user must navigate to the operator directory (This direct
 
 ``` bash
 # IBM_DIR is defined in the previous step
-export OPERATOR_DIR="$IBM_DIR/ibm-spectrum-scale-csi-operator"
-cd ${OPERATOR_DIR}/stable/ibm-spectrum-scale-csi-operator-bundle/operators/ibm-spectrum-scale-csi-operator
+export OPERATOR_DIR="$IBM_DIR/ibm-spectrum-scale-csi/operator"
+cd ${OPERATOR_DIR}
 
 export GO111MODULE="on"
 operator-sdk build csi-scale-operator
@@ -90,7 +90,7 @@ hacks/change_deploy_image.py -i quay.io/<your-user>/ibm-spectrum-scale-csi-opera
 If you've built the image as outlined above and tagged it, you can easily run the following to deploy the operator manually, for openshift use "oc" instead of "kubectl"
 
 ``` bash
-cd ${OPERATOR_DIR}/stable/ibm-spectrum-scale-csi-operator-bundle/operators/ibm-spectrum-scale-csi-operator
+cd ${OPERATOR_DIR}/
 
 kubectl apply -f deploy/namespace.yaml
 kubectl apply -f deploy/service_account.yaml
@@ -115,13 +115,13 @@ At this point the operator is running and ready for use!
 The following will subscribe the [quay.io](quay.io) version of the operator assuming OLM is installed.
 
 ``` bash
-cd ${OPERATOR_DIR}/stable/ibm-spectrum-scale-csi-operator-bundle/operators/ibm-spectrum-scale-csi-operator
+cd ${OPERATOR_DIR}/
 
 kubectl apply -f deploy/olm-scripts/operator-source.yaml
 ```
 > **NOTE**: Kubernetes use `kubectl` command, replace with `oc` if deploying in OpenShift.
 ```
-cd ${OPERATOR_DIR}/stable/ibm-spectrum-scale-csi-operator-bundle/operators/ibm-spectrum-scale-csi-operator
+cd ${OPERATOR_DIR}/
 
 oc apply -f deploy/olm-scripts/operator-source-oc.yaml
 ```

--- a/README.operator.md
+++ b/README.operator.md
@@ -139,12 +139,12 @@ Before starting the plugin, add any secrets to the appropriate namespace.  The S
 kubectl apply -f secrets.yaml -n ibm-spectrum-scale-csi-driver
 ```
 
-A sample of the file is provided [deploy/crds/ibm-spectrum-scale-csi-operator-cr.yaml](stable/ibm-spectrum-scale-csi-operator-bundle/operators/ibm-spectrum-scale-csi-operator/deploy/crds/ibm-spectrum-scale-csi-operator-cr.yaml). 
+A sample of the file is provided [operator/deploy/crds/ibm-spectrum-scale-csi-operator-cr.yaml](operator/deploy/crds/ibm-spectrum-scale-csi-operator-cr.yaml). 
 
 Modify this file to match the properties in your environment, then:
 
-  * To start the CSI plugin, run: `kubectl apply -f deploy/crds/ibm-spectrum-scale-csi-operator-cr.yaml` 
-  * To stop the CSI plugin, run: `kubectl delete -f deploy/crds/ibm-spectrum-scale-csi-operator-cr.yaml` 
+  * To start the CSI plugin, run: `kubectl apply -f operator/deploy/crds/ibm-spectrum-scale-csi-operator-cr.yaml` 
+  * To stop the CSI plugin, run: `kubectl delete -f operator/deploy/crds/ibm-spectrum-scale-csi-operator-cr.yaml` 
 
 ## Uninstalling the CSI Operator
 

--- a/operator/build/Dockerfile
+++ b/operator/build/Dockerfile
@@ -21,7 +21,7 @@ COPY build/health_check.sh .
 #RUN chmod 777 ./health_check.sh
 COPY licenses /licenses
 COPY watches.yaml ${HOME}/watches.yaml
-COPY build/_output/bin/ibm-spectrum-scale-csi-operator ${OPERATOR}
+COPY build/_output/bin/operator ${OPERATOR}
 COPY roles/ ${HOME}/roles/
 
 

--- a/tools/ansible/generate-playbook.yaml
+++ b/tools/ansible/generate-playbook.yaml
@@ -3,8 +3,8 @@
   gather_facts: false
 
   vars:
-    repo_root_dir: "{{ playbook_dir }}/../"
-    operator_dir: "{{ repo_root_dir }}/stable/ibm-spectrum-scale-csi-operator-bundle/operators/ibm-spectrum-scale-csi-operator"
+    repo_root_dir: "{{ playbook_dir }}/../../"
+    operator_dir: "{{ repo_root_dir }}/operator"
 
     generated_dir: "{{ repo_root_dir }}/generated/installer"
   

--- a/tools/scripts/ci/ci-env
+++ b/tools/scripts/ci/ci-env
@@ -5,7 +5,7 @@ export QUAY_USERNAME="mew2057"
 
 export OPERATOR_SDK="https://github.com/operator-framework/operator-sdk/releases/download/${OP_VER}/operator-sdk-${OP_VER}-x86_64-linux-gnu"
 export 
-export CSI_OP_BUILD_DIR="${TRAVIS_BUILD_DIR}/stable/ibm-spectrum-scale-csi-operator-bundle/operators/ibm-spectrum-scale-csi-operator"
+export CSI_OP_BUILD_DIR="${TRAVIS_BUILD_DIR}/operator"
 export DOCKER_REPO="quay.io/${QUAY_USERNAME}/ibm-spectrum-scale-csi-operator:v0.9.1"
 
 export OPERATOR_NAME=ibm-spectrum-scale-csi-operator


### PR DESCRIPTION
```
[root@c943f4n01-pvt operator]# operator-sdk build csi-scale-operator
INFO[0005] Building OCI image csi-scale-operator
Sending build context to Docker daemon 43.92 MB
Step 1/8 : FROM quay.io/operator-framework/ansible-operator:v0.11.0
 ---> 9a7b807df8cf
Step 2/8 : MAINTAINER jdunham@us.ibm.com
 ---> Using cache
 ---> 5fc5eba820c8
Step 3/8 : LABEL name "IBM Spectrum Scale CSI Operator" vendor "ibm" version "1.0.1" release "1" run 'docker run ibm-spectrum-scale-csi-operator' summary "An Ansible based operator to run and manage the deployment of the IBM Spectrum Scale CSI Driver." description "An Ansible based operator to run and manage the deployment of the IBM Spectrum Scale CSI Driver."
 ---> Using cache
 ---> a540a1661b4c
Step 4/8 : COPY build/health_check.sh .
 ---> Using cache
 ---> 97e130a612f9
Step 5/8 : COPY licenses /licenses
 ---> Using cache
 ---> 8eb4115c8ab8
Step 6/8 : COPY watches.yaml ${HOME}/watches.yaml
 ---> Using cache
 ---> 1869254ccd10
Step 7/8 : COPY build/_output/bin/operator ${OPERATOR}
 ---> Using cache
 ---> e0a798c57a8b
Step 8/8 : COPY roles/ ${HOME}/roles/
 ---> Using cache
 ---> 51d785e50a5a
Successfully built 51d785e50a5a
INFO[0006] Operator build complete.
```