### PR TITLE
Fix for invalid secrets hanging create/delete of Custom Resources

### DIFF
--- a/operator/molecule/default/tests/basic_tests.yaml
+++ b/operator/molecule/default/tests/basic_tests.yaml
@@ -2,4 +2,5 @@
 - include_tasks: 'test_node_selectors.yaml'
 - include_tasks: 'test_secrets.yaml'
 - include_tasks: 'test_rbac.yaml'
+- include_tasks: 'test_creation.yaml'
 

--- a/operator/molecule/default/tests/test_creation.yaml
+++ b/operator/molecule/default/tests/test_creation.yaml
@@ -1,0 +1,49 @@
+---
+- name: Set secret values
+  set_fact:
+    secret_pass: "cGFzc3dvcmQ=" # "password"
+    secret_user: "dXNlcm5hbWU=" # "username"
+    secret_name: "secret1"      # TODO move this code to global for the molecule test.
+
+- name: Ensure environment is ready
+  block:
+  - name: Delete the csi.ibm.com/v1.CSIScaleOperator
+    k8s:
+      state: absent
+      namespace: '{{ namespace }}'
+      definition: '{{ custom_resource }}'
+      validate:
+        strict: yes
+        fail_on_error: yes
+  - name: Clear the secret if present
+    k8s:  
+      state: absent
+      namespace: "{{ namespace }}"
+      definition: 
+        apiVersion: "v1"
+        kind: "Secret"
+        metadata:
+          name: "{{ secret_name }}"
+
+- name: Test creation
+  block:
+  - name: Create the csi.ibm.com/v1.CSIScaleOperator without a valid secret
+    k8s:
+      state: present
+      namespace: '{{ namespace }}'
+      definition: '{{ custom_resource }}'
+      validate:
+        strict: yes
+        fail_on_error: yes
+
+  - name: Wait 60s for reconciliation to run and failure to be detected.
+    k8s_facts:
+      api_version: '{{ custom_resource.apiVersion }}'
+      kind: '{{ custom_resource.kind }}'
+      namespace: '{{ namespace }}'
+      name: '{{ custom_resource.metadata.name }}'
+    register: cr
+    until:
+    - "'Failed' in (cr | json_query('resources[].status.conditions[].reason'))"
+    delay: 6
+    retries: 10

--- a/operator/roles/csi-scale/tasks/cluster_check.yml
+++ b/operator/roles/csi-scale/tasks/cluster_check.yml
@@ -5,7 +5,7 @@
     namespace: "{{ lookup( 'vars','namespace' ) }}"
     name : "{{ item.secrets }}"
   register: results
-  failed_when: results is not defined
+  failed_when: results is not defined or results.results is not defined or (results.results|length==0)
 
 - name: "Label unlabled secrets"
   include_tasks: password_label.yml

--- a/operator/roles/csi-scale/tasks/cluster_check.yml
+++ b/operator/roles/csi-scale/tasks/cluster_check.yml
@@ -5,7 +5,7 @@
     namespace: "{{ lookup( 'vars','namespace' ) }}"
     name : "{{ item.secrets }}"
   register: results
-  failed_when: results is not defined or results.results is not defined or (results.results|length==0)
+  failed_when: results is not defined or results.resources is not defined or (results.resources|length==0)
 
 - name: "Label unlabled secrets"
   include_tasks: password_label.yml

--- a/operator/roles/csi-scale/tasks/main.yml
+++ b/operator/roles/csi-scale/tasks/main.yml
@@ -21,13 +21,10 @@
   - name: "Ensure the clusters are valid"
     include_tasks: cluster_check.yml
     loop: "{{ clustersCamelCase }}"
+    when: 'state == "present"'
   rescue:
-  - name: "Assert cluster check failure is legal"
-    assert: 
-      that:
-        - state != "present"
-      fail_msg: "Cluster check failed when setting state to present, exiting"
-      success_msg: "Cluster check failed when setting state to absent, continuing"
+    - name: "Cluster check failed when setting state to present, exiting"
+      meta: end_play
 
 - name: "Generate final secret checksum"
   set_fact:


### PR DESCRIPTION
Resolves #42. 

- Refined the operator plays to  skip secret checks on delete.
- Improved operator plays  handle invalid secrets more correctly (old logic was faulty).
- Adds a test to create a custom resource without a valid secret.