### PR TITLE
Bump golangci-lint timeout from default of 1m to 3m

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,3 +1,6 @@
+run:
+  timeout: 3m
+
 linters-settings:
 
   funlen:


### PR DESCRIPTION
Sometimes on a slow machine golangci-lint might error due to passing the timeout of 1 minute.  This is mostly for CI/CD that it might be an issue