### PR TITLE
Correcting image name in Dockerfile

### DIFF
--- a/operator/build/Dockerfile
+++ b/operator/build/Dockerfile
@@ -12,7 +12,7 @@ LABEL name="IBM Spectrum Scale CSI Operator" \
 COPY build/health_check.sh .
 COPY licenses /licenses
 COPY watches.yaml ${HOME}/watches.yaml
-COPY build/_output/bin/operator ${OPERATOR}
+COPY build/_output/bin/ibm-spectrum-scale-csi-operator ${OPERATOR}
 COPY roles/ ${HOME}/roles/
 
 

--- a/operator/build/Dockerfile.s390x
+++ b/operator/build/Dockerfile.s390x
@@ -12,7 +12,7 @@ LABEL name="IBM Spectrum Scale CSI Operator" \
 COPY build/health_check.sh .
 COPY licenses /licenses
 COPY watches.yaml ${HOME}/watches.yaml
-COPY build/_output/bin/operator ${OPERATOR}
+COPY build/_output/bin/ibm-spectrum-scale-csi-operator ${OPERATOR}
 COPY roles/ ${HOME}/roles/
 
 


### PR DESCRIPTION
Manual operator build with "operator-sdk build csi-scale-operator" was failing with "path not found". Image name had to be corrected from "operator" to "ibm-spectrum-scale-csi-operator" in Dockerfile.

Signed-off-by: Smita Raut <smita.raut@in.ibm.com>