### PR TITLE
Bumping default to 1.0.1

### DIFF
--- a/operator/roles/csi-scale/defaults/main.yml
+++ b/operator/roles/csi-scale/defaults/main.yml
@@ -21,7 +21,7 @@ provisioner: "quay.io/k8scsi/csi-provisioner:v1.0.0"
 
 # Due to camelCase these get loaded differently in the operator.
 driverRegistrar: "{{ driver_registrar | default('quay.io/k8scsi/csi-node-driver-registrar:v1.0.1') }}"
-spectrumScale:   "{{ spectrum_scale   | default('quay.io/ibm-spectrum-scale/ibm-spectrum-scale-csi-driver:v1.0.0') }}"
+spectrumScale:   "{{ spectrum_scale   | default('quay.io/ibm-spectrum-scale/ibm-spectrum-scale-csi-driver:v1.0.1') }}"
 
 # Set defaults for the secret counter and hostpath.
 secretCounter: "{{ secret_counter |  default(-1) }}"


### PR DESCRIPTION
Bumps the default version of  the driver  in the operator defaults (won't pass until driver is in  quay).