### PR TITLE
Avoid confusion by forcing the user to set an OPERATOR_NAMESPACE variable

### DIFF
--- a/docs/source/get-started/prereq.rst
+++ b/docs/source/get-started/prereq.rst
@@ -27,9 +27,10 @@ If you do not see a login or on-screen instructions, review the `GUI Documentati
 
   export USERNAME_B64=$(echo $USERNAME | base64)
   export PASSWORD_B64=$(echo $PASSWORD | base64)
-  export OPERATOR_NAMESPACE="ibm-spectrum-scale-csi-driver"  # Set this to the namespace you deploy the operator in.
-  
 
+  # Set the following to the target namespace to deploy the operator in.
+  export OPERATOR_NAMESPACE="SomeNamespace" 
+  
   cat << EOF > /tmp/csisecret.yaml
   apiVersion: v1
   data:


### PR DESCRIPTION
Resolves #68 

In operatorhub.io, the operator is deployed into a namespace called "my-ibm-spectrum..."  

To help avoid confusion, mimic the user/pass format above in that document page, and force the user to set the OPERATOR_NAMESPACE variable by defaulting to "SomeNamespace", which should indicate an invalid namespace.  