### PR TITLE
[WIP] depends on #66 - override image defaults with ENV variables

### DIFF
--- a/operator/build/multi-arch.Dockerfile
+++ b/operator/build/multi-arch.Dockerfile
@@ -16,3 +16,8 @@ COPY hacks/health_check.sh .
 COPY licenses /licenses
 COPY watches.yaml ${HOME}/watches.yaml
 COPY roles/ ${HOME}/roles/
+
+ENV CSI_ATTACHER_IMAGE=registry.scale-peach.fyre.ibm.com/external-attacher:latest
+ENV CSI_PROVISIONER_IMAGE=registry.scale-peach.fyre.ibm.com/external-provisioner:latest
+ENV CSI_NODE_REGISTRAR_IMAGE=registry.scale-peach.fyre.ibm.com/node-driver-registrar:latest
+ENV CSI_DRIVER_IMAGE=registry.scale-peach.fyre.ibm.com/ibm-spectrum-scale-csi-driver:latest

--- a/operator/build/multi-arch.Dockerfile
+++ b/operator/build/multi-arch.Dockerfile
@@ -4,6 +4,16 @@
 FROM quay.io/mew2057/ansible-operator:$TARGETARCH
 MAINTAINER jdunham@us.ibm.com
 
+ARG CSI_ATTACHER_IMAGE
+ARG CSI_PROVISIONER_IMAGE
+ARG CSI_NODE_REGISTRAR_IMAGE
+ARG CSI_DRIVER_IMAGE
+
+ENV CSI_ATTACHER_IMAGE $CSI_ATTACHER_IMAGE
+ENV CSI_PROVISIONER_IMAGE $CSI_PROVISIONER_IMAGE
+ENV CSI_NODE_REGISTRAR_IMAGE $CSI_NODE_REGISTRAR_IMAGE
+ENV CSI_DRIVER_IMAGE $CSI_DRIVER_IMAGE
+
 LABEL name="IBM Spectrum Scale CSI Operator" \
       vendor="ibm" \
       version="1.0.1" \
@@ -16,8 +26,3 @@ COPY hacks/health_check.sh .
 COPY licenses /licenses
 COPY watches.yaml ${HOME}/watches.yaml
 COPY roles/ ${HOME}/roles/
-
-ENV CSI_ATTACHER_IMAGE=registry.scale-peach.fyre.ibm.com/external-attacher:latest
-ENV CSI_PROVISIONER_IMAGE=registry.scale-peach.fyre.ibm.com/external-provisioner:latest
-ENV CSI_NODE_REGISTRAR_IMAGE=registry.scale-peach.fyre.ibm.com/node-driver-registrar:latest
-ENV CSI_DRIVER_IMAGE=registry.scale-peach.fyre.ibm.com/ibm-spectrum-scale-csi-driver:latest

--- a/operator/roles/csi-scale/defaults/main.yml
+++ b/operator/roles/csi-scale/defaults/main.yml
@@ -16,10 +16,11 @@ namespace: '{{ meta.namespace | default("default") }}'
 storage-class: "ibm-spectrum-scale-csi"
 
 # Image defaults
-attacher:    "{{ lookup('env', 'CSI_ATTACHER_IMAGE') | default('quay.io/k8scsi/csi-attacher:v1.0.0') }}"
-provisioner: "{{ lookup('env', 'CSI_PROVISIONER_IMAGE') | default('quay.io/k8scsi/csi-provisioner:v1.0.0') }}"
-driverRegistrar: "{{ lookup('env', 'CSI_NODE_REGISTRAR_IMAGE') | default('quay.io/k8scsi/csi-node-driver-registrar:v1.0.1') }}"
-spectrumScale:   "{{ lookup('env', 'CSI_DRIVER_IMAGE') | default('quay.io/ibm-spectrum-scale/ibm-spectrum-scale-csi-driver:v1.0.1') }}"
+attacher:    "{{ lookup('env', 'CSI_ATTACHER_IMAGE') | default('quay.io/k8scsi/csi-attacher:v1.0.0', true) }}"
+provisioner: "{{ lookup('env', 'CSI_PROVISIONER_IMAGE') | default('quay.io/k8scsi/csi-provisioner:v1.0.0', true) }}"
+# Due to camelCase these get loaded differently in the operator.
+driverRegistrar: "{{ driver_registrar | default(lookup('env', 'CSI_NODE_REGISTRAR_IMAGE')) | default('quay.io/k8scsi/csi-node-driver-registrar:v1.0.1', true) }}"
+spectrumScale:   "{{ spectrum_scale | default(lookup('env', 'CSI_DRIVER_IMAGE')) | default('quay.io/ibm-spectrum-scale/ibm-spectrum-scale-csi-driver:v1.0.1', true) }}"
 
 # Set defaults for the secret counter and hostpath.
 secretCounter: "{{ secret_counter |  default(-1) }}"

--- a/operator/roles/csi-scale/defaults/main.yml
+++ b/operator/roles/csi-scale/defaults/main.yml
@@ -16,12 +16,10 @@ namespace: '{{ meta.namespace | default("default") }}'
 storage-class: "ibm-spectrum-scale-csi"
 
 # Image defaults
-attacher:    "quay.io/k8scsi/csi-attacher:v1.0.0"
-provisioner: "quay.io/k8scsi/csi-provisioner:v1.0.0"
-
-# Due to camelCase these get loaded differently in the operator.
-driverRegistrar: "{{ driver_registrar | default('quay.io/k8scsi/csi-node-driver-registrar:v1.0.1') }}"
-spectrumScale:   "{{ spectrum_scale   | default('quay.io/ibm-spectrum-scale/ibm-spectrum-scale-csi-driver:v1.0.1') }}"
+attacher:    "{{ lookup('env', 'CSI_ATTACHER_IMAGE') | default('quay.io/k8scsi/csi-attacher:v1.0.0') }}"
+provisioner: "{{ lookup('env', 'CSI_PROVISIONER_IMAGE') | default('quay.io/k8scsi/csi-provisioner:v1.0.0') }}"
+driverRegistrar: "{{ lookup('env', 'CSI_NODE_REGISTRAR_IMAGE') | default('quay.io/k8scsi/csi-node-driver-registrar:v1.0.1') }}"
+spectrumScale:   "{{ lookup('env', 'CSI_DRIVER_IMAGE') | default('quay.io/ibm-spectrum-scale/ibm-spectrum-scale-csi-driver:v1.0.1') }}"
 
 # Set defaults for the secret counter and hostpath.
 secretCounter: "{{ secret_counter |  default(-1) }}"
@@ -46,4 +44,3 @@ nodeMapping: "{{ _csi_ibm_com_csiscaleoperator.spec.nodeMapping | default([])}}"
 # State of driver in the cluster (might not be needed).
 #state: absent
 state: present
-


### PR DESCRIPTION
```release-notes
add ARG's for image overrides in multi-arch Dockerfile, so CI/CD can bake nightly operator that defaults to nightly driver
add ENV's for image overrides in operator image, so testers may override image defaults by adding container env in the operator deployment
```

