### PR TITLE
Fixing some typos in the k8s subscription

### DIFF
--- a/docs/source/developers/olm.rst
+++ b/docs/source/developers/olm.rst
@@ -23,6 +23,7 @@ To subscribe to these applicaions via OLM, the code repository provides three YA
 
 * Used for OLM subscription to the master stream in raw k8s.
 * Created in the `marketplace` namespace.
+* **WARNING** : Currently disabled, as master has some issues for upgrade.
 
 ``tools/olm/operator-source-k8s-dev.yaml``
 

--- a/tools/olm/operator-source-k8s-dev.yaml
+++ b/tools/olm/operator-source-k8s-dev.yaml
@@ -20,10 +20,10 @@ metadata:
 spec:
   type: appregistry
   endpoint: https://quay.io/cnr
-  registryNamespace:  ibm-spectrum-scale-dev
+  registryNamespace: ibm-spectrum-scale-dev
 
 ---
-apiVersion: operators.coreos.com/v1alpha2
+apiVersion: operators.coreos.com/v1
 kind: OperatorGroup
 metadata:
   name: operator-group
@@ -36,11 +36,11 @@ spec:
 apiVersion: operators.coreos.com/v1alpha1
 kind: Subscription
 metadata:
-  name: oper-sub
+  name: ibm-spectrum-scale-csi-sub
   namespace: marketplace
 spec:
   channel: stable
   name: ibm-spectrum-scale-csi-dev
-  source: ibm-spectrum-scale-csi-dev
+  source: ibm-spectrum-scale-csi
   sourceNamespace: marketplace
 

--- a/tools/olm/operator-source-k8s-master.yaml
+++ b/tools/olm/operator-source-k8s-master.yaml
@@ -23,7 +23,7 @@ spec:
   registryNamespace:  ibm-spectrum-scale-dev
 
 ---
-apiVersion: operators.coreos.com/v1alpha2
+apiVersion: operators.coreos.com/v1
 kind: OperatorGroup
 metadata:
   name: operator-group
@@ -36,11 +36,11 @@ spec:
 apiVersion: operators.coreos.com/v1alpha1
 kind: Subscription
 metadata:
-  name: oper-sub
+  name: ibm-spectrum-scale-csi-master-sub
   namespace: marketplace
 spec:
   channel: stable
   name: ibm-spectrum-scale-csi-master
-  source: ibm-spectrum-scale-csi-master
+  source: ibm-spectrum-scale-csi
   sourceNamespace: marketplace
 


### PR DESCRIPTION
A Simple Fix for the k8s subscription, because it looks like we had some typos that could  interfere with subscriptions.