### PR TITLE
Remove calls to binaries, and switch to scratch base image

### DIFF
--- a/driver/build/Dockerfile
+++ b/driver/build/Dockerfile
@@ -13,7 +13,7 @@ RUN CGO_ENABLED=0 GOOS=linux go build -a -ldflags '-extldflags "-static"' -o _ou
 RUN chmod +x _output/ibm-spectrum-scale-csi
 
 
-FROM registry.access.redhat.com/ubi8-minimal:latest
+FROM scratch
 LABEL name="IBM Spectrum Scale CSI driver" \
       vendor="ibm" \
       version="1.1.0" \

--- a/driver/build/multi-arch.Dockerfile
+++ b/driver/build/multi-arch.Dockerfile
@@ -15,7 +15,7 @@ RUN CGO_ENABLED=0 GOOS=$TARGETOS GOARCH=$TARGETARCH go build -a -ldflags '-extld
 RUN chmod +x _output/ibm-spectrum-scale-csi
 
 
-FROM registry.access.redhat.com/ubi8-minimal:latest
+FROM scratch
 LABEL name="IBM Spectrum Scale CSI driver" \
       vendor="ibm" \
       version="1.1.0" \

--- a/driver/csiplugin/gpfs_util.go
+++ b/driver/csiplugin/gpfs_util.go
@@ -17,14 +17,11 @@
 package scale
 
 import (
-	"bytes"
 	"fmt"
-	"os/exec"
 	"strconv"
 	"strings"
 
 	"github.com/IBM/ibm-spectrum-scale-csi/driver/csiplugin/connectors"
-	"github.com/golang/glog"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 )
@@ -208,20 +205,6 @@ func getScaleVolumeOptions(volOptions map[string]string) (*scaleVolume, error) {
 		}
 	}
 	return scaleVol, nil
-}
-
-func executeCmd(command string, args []string) ([]byte, error) {
-	glog.V(5).Infof("gpfs_util executeCmd")
-
-	cmd := exec.Command(command, args...)
-	var stdout bytes.Buffer
-	var stderr bytes.Buffer
-
-	cmd.Stdout = &stdout
-	cmd.Stderr = &stderr
-	err := cmd.Run()
-	stdOut := stdout.Bytes()
-	return stdOut, err
 }
 
 func ConvertToBytes(inputStr string) (uint64, error) {


### PR DESCRIPTION
```release-notes
- use FROM scratch instead of ubi8
- remove calls to external binaries, when go-lang std library can do the job
```

The only reason we need ubi8 is because we call out to ```/bin/rmdir``` and ```/bin/ln```.  Also, even ubi8-minimal is 100MB+, which is a huge inflation compared to just the go-lang binary (~14MB).

So, this has two important driving factors:

1. **eliminating ubi8**, eliminates any issues with potential security scans - having to update base images, packages, etc
2. **eliminating ubi8**, shrinks our final image size by an order of magnitute

```
➜  driver git:(use_scratch) (peach:test-pods-github)docker images quay.io/ibm-spectrum-scale-dev/ibm-spectrum-scale-csi-driver:v1.1.0
REPOSITORY                                                     TAG                 IMAGE ID            CREATED             SIZE
quay.io/ibm-spectrum-scale-dev/ibm-spectrum-scale-csi-driver   v1.1.0              79b8717289bd        3 days ago          120MB

➜  driver git:(use_scratch) (peach:test-pods-github)docker history quay.io/ibm-spectrum-scale-dev/ibm-spectrum-scale-csi-driver:v1.1.0
IMAGE               CREATED             CREATED BY                                      SIZE                COMMENT
79b8717289bd        3 days ago          /bin/sh -c #(nop)  LABEL version=v1.1.0         0B                  
<missing>           3 days ago          /bin/sh -c #(nop)  ENTRYPOINT ["/ibm-spectru…   0B                  
<missing>           3 days ago          /bin/sh -c #(nop) COPY file:0d19473d37222981…   14.3MB              
<missing>           3 days ago          /bin/sh -c #(nop) COPY dir:c1ac0552ab432e553…   13B                 
<missing>           3 days ago          /bin/sh -c #(nop)  LABEL name=IBM Spectrum S…   0B                  
<missing>           2 weeks ago                                                         4.23kB              
<missing>           2 weeks ago                                                         106MB               Imported from -

➜  driver git:(use_scratch) (peach:test-pods-github)docker history scratch_driver:latest                                              
IMAGE               CREATED             CREATED BY                                      SIZE                COMMENT
39c73d2c0a52        17 minutes ago      /bin/sh -c #(nop)  ENTRYPOINT ["/ibm-spectru…   0B                  
d17dc4682228        18 minutes ago      /bin/sh -c #(nop) COPY file:1039ec690c00c077…   14.1MB              
ab140542d821        18 minutes ago      /bin/sh -c #(nop) COPY dir:330a0a499290ff90b…   13B                 
f5e8cfa9b054        18 minutes ago      /bin/sh -c #(nop)  LABEL name=IBM Spectrum S…   0B  
```