### PR TITLE
Fix provisioner name in examples 

### DIFF
--- a/driver/examples/dynamic/fileset/storageclassfileset_dependent.yaml
+++ b/driver/examples/dynamic/fileset/storageclassfileset_dependent.yaml
@@ -7,5 +7,5 @@ parameters:
     volBackendFs: "gpfs0"
     clusterId: "7118073361626808055"
     filesetType: "dependent"
-    parentFileset: "pvc-9c93ffc6-b113-47b4-bbb4-29306f567f2b"
+    parentFileset: "independent-fileset-gpfs0-fset1"
 reclaimPolicy: Delete

--- a/driver/examples/static/static_pv.yaml
+++ b/driver/examples/static/static_pv.yaml
@@ -8,6 +8,6 @@ spec:
   accessModes:
     - ReadWriteMany
   csi:
-    driver: ibm-spectrum-scale-csi
+    driver: spectrumscale.csi.ibm.com
     volumeHandle: "clusterID;FSUID;path=/gpfs/fs1/staticdir"
 

--- a/tools/generate_pv_yaml.sh
+++ b/tools/generate_pv_yaml.sh
@@ -74,7 +74,7 @@ spec:
   accessModes:
     - ${accessmode}
   csi:
-    driver: ibm-spectrum-scale-csi
+    driver: spectrumscale.csi.ibm.com
     volumeHandle: ${volhandle}
   ${STORAGECLASS}
 EOL


### PR DESCRIPTION
Fixes #133 
Fixed Provisioner name in the examples and generate_pv.yaml
Fixed parent fileset name to avoid confusion. 