### PR TITLE
Attacher Fix for Remote FS

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,5 @@
 # IBM Spectrum Scale CSI (Container Storage Interface)
 
-[![Documentation Status](https://readthedocs.org/projects/ibm-spectrum-scale-csi/badge/?version=latest)](https://ibm-spectrum-scale-csi.readthedocs.io/en/latest/?badge=latest)
-
 [Official Knowledge Center Documentation](https://www.ibm.com/support/knowledgecenter/en/STXKQY_5.0.4/com.ibm.spectrum.scale.csi.v5r04.doc/bl1csi_kc_landing.html)
 
 
@@ -14,13 +12,17 @@ If you are looking to deploy released versions of the IBM Spectrum Scale CSI Ope
   * OpenShift - Under Operator -> OperatorHub in the OpenShift Console, search 'IBM Spectrum Scale CSI" and install
   * Kubernetes -  See the project on [OperatorHub.io - ibm-spectrum-scale-csi-operator](https://operatorhub.io/operator/ibm-spectrum-scale-csi-operator)
 
+## Support
+
+IBM Spectrum Scale CSI driver is part of the IBM Spectrum Scale offering. Please follow the [IBM support procedure](https://www.ibm.com/mysupport/s/) for any issues with the driver.
+
 ## Report Bugs 
 
 To file issues, suggestions, new features, etc., Open an [Issue](https://github.com/IBM/ibm-spectrum-scale-csi/issues).
 
-## Getting Started and Documentation 
+## Developer Getting Started 
 
-To get started, see our [Documentation](https://ibm-spectrum-scale-csi.rtfd.io/)
+To get started, see our [Developer Documentation](https://ibm-spectrum-scale-csi.rtfd.io/)
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -20,16 +20,9 @@ IBM Spectrum Scale CSI driver is part of the IBM Spectrum Scale offering. Please
 
 To file issues, suggestions, new features, etc., Open an [Issue](https://github.com/IBM/ibm-spectrum-scale-csi/issues).
 
-## Developer Getting Started 
-
-To get started, see our [Developer Documentation](https://ibm-spectrum-scale-csi.rtfd.io/)
-
 ## Contributing
 
 We welcome contributions to this project, see [Contributing](CONTRIBUTING.md) for more details.
 
-## Troubleshooting
-
-See the [Troubleshooting](https://ibm-spectrum-scale-csi.readthedocs.io/en/latest/troubleshoot/index.html) section for more information.
 
 

--- a/README.md
+++ b/README.md
@@ -18,7 +18,11 @@ IBM Spectrum Scale CSI driver is part of the IBM Spectrum Scale offering. Please
 
 ## Report Bugs 
 
-To file issues, suggestions, new features, etc., Open an [Issue](https://github.com/IBM/ibm-spectrum-scale-csi/issues).
+For help with urgent situations, please use the IBM PMR process.  All Spectrum Scale customers using CSI, 
+who also have ongoing support contracts, are entitled to the PMR process.  Feature requests through the official RFE channels are also encouraged.
+
+For non-urgent issues, suggestions, recommendations, feel free to open an issue in [github](https://github.com/IBM/ibm-spectrum-scale-csi/issues).
+Issues will be addressed as team availability permits.
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -2,6 +2,9 @@
 
 [![Documentation Status](https://readthedocs.org/projects/ibm-spectrum-scale-csi/badge/?version=latest)](https://ibm-spectrum-scale-csi.readthedocs.io/en/latest/?badge=latest)
 
+[Official Knowledge Center Documentation](https://www.ibm.com/support/knowledgecenter/en/STXKQY_5.0.4/com.ibm.spectrum.scale.csi.v5r04.doc/bl1csi_kc_landing.html)
+
+
 The IBM Spectrum Scale Container Storage Interface (CSI) project enables container orchestrators, such as Kubernetes and OpenShift, to manage the life-cycle of persistent storage.
 
 This project contains an ansible-based operator to run and manage the deployment of the IBM Spectrum Scale CSI Driver. 

--- a/operator/deploy/olm-catalog/ibm-spectrum-scale-csi-operator/1.1.0/ibm-spectrum-scale-csi-operator.v1.1.0.clusterserviceversion.yaml
+++ b/operator/deploy/olm-catalog/ibm-spectrum-scale-csi-operator/1.1.0/ibm-spectrum-scale-csi-operator.v1.1.0.clusterserviceversion.yaml
@@ -244,7 +244,7 @@ spec:
     "\nThe IBM Spectrum Scale CSI Operator runs within a Kubernetes cluster
     providing a means to \ndeploy and manage the CSI plugin for spectrum scale. For
     more in depth documentation please refer\nto the [knowledge center]( https://www.ibm.com/support/knowledgecenter/STXKQY_5.0.4/com.ibm.spectrum.scale.csi.v5r04.doc/bl1csi_kc_landing.html)
-    \n\nThis operator should be used to deploy 
+    \n\nThis operator should be used to deploy
     the CSI plugin.\n\nThe configuration process
     is as follows:\n\n1. [Spectrum Scale GUI Setup](#spectrum-scale-gui-setup)\n2.
     [Custom Resource Configuration](#custom-resource-configuration)\n\nSpectrum Scale
@@ -465,8 +465,8 @@ spec:
   labels:
     operator: ibm-spectrum-scale-csi-operator
   links:
-    - name: IBM CSI Spectrum Scale Knowledge Center 
-      url:  https://www.ibm.com/support/knowledgecenter/STXKQY_5.0.4/com.ibm.spectrum.scale.csi.v5r04.doc/bl1csi_kc_landing.html
+    - name: IBM CSI Spectrum Scale Knowledge Center
+      url: https://www.ibm.com/support/knowledgecenter/STXKQY_5.0.4/com.ibm.spectrum.scale.csi.v5r04.doc/bl1csi_kc_landing.html
     - name: CSI Developer Documentation
       url: https://kubernetes-csi.github.io/docs/
   maintainers:

--- a/operator/deploy/olm-catalog/ibm-spectrum-scale-csi-operator/1.1.0/ibm-spectrum-scale-csi-operator.v1.1.0.clusterserviceversion.yaml
+++ b/operator/deploy/olm-catalog/ibm-spectrum-scale-csi-operator/1.1.0/ibm-spectrum-scale-csi-operator.v1.1.0.clusterserviceversion.yaml
@@ -48,7 +48,7 @@ metadata:
     description:
       An operator for deploying and managing the IBM CSI Spectrum Scale
       Driver.
-    repository: https://github.com/IBM/ibm-spectrum-scale-csi-operator/
+    repository: https://github.com/IBM/ibm-spectrum-scale-csi/
     support: IBM
   labels:
     app.kubernetes.io/instance: ibm-spectrum-scale-csi-operator
@@ -271,7 +271,7 @@ spec:
     \ \n  ```\n\nCustom Resource Configuration\n-----------------------------\n\nThe
     bundled Custom Resource example represents the minimum settings needed to run
     the operator.\nIf your environment needs more advanced settings (e.g. remote clusters,
-    node mapping, etc.) please\nrefer to the sample [Custom Resource](https://github.com/IBM/ibm-spectrum-scale-csi-operator/blob/v1.1.0/stable/ibm-spectrum-scale-csi-operator-bundle/operators/ibm-spectrum-scale-csi-operator/deploy/crds/csiscaleoperators.csi.ibm.com.cr.yaml).\n\n\n"
+    node mapping, etc.) please\nrefer to the sample [Custom Resource](https://raw.githubusercontent.com/IBM/ibm-spectrum-scale-csi/v1.1.0/operator/deploy/crds/csiscaleoperators.csi.ibm.com.cr.yaml).\n\n\n"
   displayName: IBM Spectrum Scale CSI Plugin Operator
   icon:
     - base64data: iVBORw0KGgoAAAANSUhEUgAAAGQAAABnCAMAAADBqBfIAAAAsVBMVEUAAACIyVeGxlaGx1aGxlaMylyM0FmJyliPymKOymGGxlaHx1aHx1iHx1eKylqKy1qGx1aHyFeKylmMyV6Gx1aGxlaHyFeMzFyGx1aHx1aIyViKylmLyluGx1aIyFiJylmHx1aIyViJylmLyluIyFeIyVeJylmMy16HyFeIyFeIyViJyliHyFeIyVeHyFeIyFeIyViIyViKylqHyFeIyVeJylmIyViIyFeLy1qFxVWHx1f7ghN0AAAAOXRSTlMAC2qj/JM5qx0juuRL2A8E6s0oQvX4phPy7oJGGd6PMdFhIQmYiVwGtJ5V275usH14Zi3Dc1E9xzb8nESrAAAEv0lEQVRo3u2a6VbiQBCFC4zImrCEsCSGJawOO4iW7/9gM8hAlV1JJNCc45kz3z8HmZvu2rpvhJ+J+WLBvVk1sVKFu9Ir4AEnB3cj94Z/qbfhPpgPBhKFF9CPlW7iV976oJlRCQWGkwWNVCdIsBW1lqCLho9EtwPLOv34rCk06RaesT8r0XNYCsw0VE2myySW5ulf8yw0gxTcyCuecfo8E55pLXAzFTxSqcEXUstTBrzDzXSOO9UDQXaBBwaggSlifdiAMPZviGUPriW7pgz+eMrFdMw5rTmdrE21P4wOlWJsEZlwoosl9/I29do8BBoSssY/THIXRvpvm4qo5fYsPJvGhWPV+BdUjeecm3kAEvdQHgMTJP65oX3XaSyfNYylXOT2NLPGIoysb5ZqseVdZh12LjZkWqfGWBRbkEfiyYsMRpfPCnVLgl0ZOfk9KBTZzPlop76drvJA4sqpNWiI6WnTp+UiCIZsTwuih2wWGEJ5l1KrZsrns7LW9wJv6KAQDPki2+wHWX39GRIOcNIUjIloU/MCS4feGPoOsl8XG/vCfj1cpNIR4WTpUB8e96f2hoQvQrOy40RkHVX5Uy9y9IVntrp1oIbGMSJFPnKgDia2/92ajBN9pDCIFskqfZxVRnkeyEUSE+Wk93ihyHuJBeNxDJJMBYlhKrmI98SrewMCkXjNdUKR1EoUQzjjgc1Cs08iErTYAy4tiGPDqs9oJxBJ0fceU2LgitBQOj9cIzLriHou4SAr73jXi8ihUf0cGvbKkqPmWhF1mHu+fQrxCBSerhXJKMf7AhKL6j1Eal3lnuV7ukVyExTYc0uniNluYhiVokaRCUbh6hPJYxTFnyaSrR1wQZtItfYJhKBJhPgv8l/kXxIZ/TpQ0Vfx61+fhB5TdbeVHyeyr6CALu23ilDQyihZZAG0iJARaSgSpVcATSKEt0BGaw2gUYRwuyeJ+kMAmkQc1Vewei08sO0LL+P5WhFsrUzVUhiE2fTvE8QrRE48vwpPryeakI94kwgasw3EQ55LMhHYz5AYeHHGUondl9rmZSLkYMqbr2TjoDCnE4hAqm2zwitCCCbd5cmcvkiEyD1wm6wKDLnY9RguFFHTP0MeinAe98z4sIdqqvuRIpjPCh+WP22aJfJD6IWI+mm0CNq+pXpdflPe6M02El03wg+VIicKa/muyfjqoVi877dWolqZzwicFyS2G/Fk3GXxMyXhqMjr9pGy8rh89k1zwkNpYRh5GQxKhzD32C3wj9XQWI91ISE9l832u0aR2vH/QBqqymmiKR7Em9qsNjMQjjdAYtYJ8VCIRzOuURZGQMSF2NgJJ39ejzSnG/ybQxGMKMPV6IR1K+65cKwu5U0fBFHm5hTCyG3tdnhDFo0yltwUMeaFWArCmR5r2YILcSuIO0hIw0B72IAEpPOUPdteEL3qxYZqnRplYkbkYKoESwNnoIFGgU5aoc3mVYPIkF7thFvPrTHcSt8+j78RMLJ0hNjBrYyMsH4UfDGn4Wb6E97QPHFbaaZBBy6fEb4FnYp4e6b7zyTKCyQo6TQQOCwG/DSuF2mnGr0x6ITmMzFtwF2Y05x/q8K9MJ2/we+BXuRrh/puDPfFcqdZ+In8Bg8Knr3O+ZToAAAAAElFTkSuQmCC

--- a/operator/deploy/olm-catalog/ibm-spectrum-scale-csi-operator/1.1.0/ibm-spectrum-scale-csi-operator.v1.1.0.clusterserviceversion.yaml
+++ b/operator/deploy/olm-catalog/ibm-spectrum-scale-csi-operator/1.1.0/ibm-spectrum-scale-csi-operator.v1.1.0.clusterserviceversion.yaml
@@ -251,13 +251,13 @@ spec:
     GUI Setup \n------------------------\n> **NOTE:** This step only needs to be preformed
     once per GUI.\n\n> **WARNING:** If your daemonset pods (driver pods) do not come
     up, generally this means you have a  secret that  has not been defined in the
-    correct namespace.\n\n1. Ensure the Spectrum Scale GUI is running by pointing
+    correct namespace.\n\n1\\. Ensure the Spectrum Scale GUI is running by pointing
     your browser to the IP hosting the GUI:\n\n    ![](https://user-images.githubusercontent.com/1195452/67230992-6d2d9700-f40c-11e9-96d5-3f0e5bcb2d9a.png)\n\n
     \   > If you do not see a login follow on screen instructions, or review the [GUI
-    Documentation](https://www.ibm.com/support/knowledgecenter/en/STXKQY_5.0.3/com.ibm.spectrum.scale.v5r03.doc/bl1ins_quickrefforgui.htm)\n\n\n3.
+    Documentation](https://www.ibm.com/support/knowledgecenter/en/STXKQY_5.0.3/com.ibm.spectrum.scale.v5r03.doc/bl1ins_quickrefforgui.htm)\n\n\n2\\.
     Create a CsiAdmin group account on in the GUI (currently requires a CLI call):\n\n
     \  ```\n\n   export USERNAME=\"SomeUser\"\n   export PASSWORD=\"SomePassword\"\n
-    \  /usr/lpp/mmfs/gui/cli/mkuser ${USERNAME} -p ${PASSWORD} -g CsiAdmin\n\n   ```\n\n3.
+    \  /usr/lpp/mmfs/gui/cli/mkuser ${USERNAME} -p ${PASSWORD} -g CsiAdmin\n\n   ```\n\n3\\.
     Create a Kubernetes secret for the `CsiAdmin` user:\n\n  ```\n\n  export USERNAME_B64=$(echo
     $USERNAME | base64)\n  export PASSWORD_B64=$(echo $PASSWORD | base64)\n  export
     OPERATOR_NAMESPACE=\"ibm-spectrum-scale-csi-driver\"  # Set this to the namespace

--- a/operator/deploy/olm-catalog/ibm-spectrum-scale-csi-operator/1.1.0/ibm-spectrum-scale-csi-operator.v1.1.0.clusterserviceversion.yaml
+++ b/operator/deploy/olm-catalog/ibm-spectrum-scale-csi-operator/1.1.0/ibm-spectrum-scale-csi-operator.v1.1.0.clusterserviceversion.yaml
@@ -254,7 +254,7 @@ spec:
     correct namespace.\n\n1\\. Ensure the Spectrum Scale GUI is running by pointing
     your browser to the IP hosting the GUI:\n\n    ![](https://user-images.githubusercontent.com/1195452/67230992-6d2d9700-f40c-11e9-96d5-3f0e5bcb2d9a.png)\n\n
     \   > If you do not see a login follow on screen instructions, or review the [GUI
-    Documentation](https://www.ibm.com/support/knowledgecenter/en/STXKQY_5.0.3/com.ibm.spectrum.scale.v5r03.doc/bl1ins_quickrefforgui.htm)\n\n\n2\\.
+    Documentation]( https://www.ibm.com/support/knowledgecenter/en/STXKQY_5.0.4/com.ibm.spectrum.scale.v5r04.doc/bl1ins_quickrefforgui.htm)\n\n\n2\\.
     Create a CsiAdmin group account on in the GUI (currently requires a CLI call):\n\n
     \  ```\n\n   export USERNAME=\"SomeUser\"\n   export PASSWORD=\"SomePassword\"\n
     \  /usr/lpp/mmfs/gui/cli/mkuser ${USERNAME} -p ${PASSWORD} -g CsiAdmin\n\n   ```\n\n3\\.
@@ -472,8 +472,6 @@ spec:
   maintainers:
     - email: jdunham@us.ibm.com
       name: John Dunham
-    - email: yadayada@in.ibm.com
-      name: Yadavendra Yadav
   maturity: alpha
   provider:
     name: IBM

--- a/operator/deploy/olm-catalog/ibm-spectrum-scale-csi-operator/1.1.0/ibm-spectrum-scale-csi-operator.v1.1.0.clusterserviceversion.yaml
+++ b/operator/deploy/olm-catalog/ibm-spectrum-scale-csi-operator/1.1.0/ibm-spectrum-scale-csi-operator.v1.1.0.clusterserviceversion.yaml
@@ -243,8 +243,9 @@ spec:
   description:
     "\nThe IBM Spectrum Scale CSI Operator runs within a Kubernetes cluster
     providing a means to \ndeploy and manage the CSI plugin for spectrum scale. For
-    more in depth documentation please refer\nto the [README](https://github.com/IBM/ibm-spectrum-scale-csi-operator/blob/v1.1.0/README.md).\n\nThis
-    operator should be used to deploy the CSI plugin.\n\nThe configuration process
+    more in depth documentation please refer\nto the [github repository](https://github.com/IBM/ibm-spectrum-scale-csi) 
+    which has links to official documentation.\n\nThis operator should be used to deploy 
+    the CSI plugin.\n\nThe configuration process
     is as follows:\n\n1. [Spectrum Scale GUI Setup](#spectrum-scale-gui-setup)\n2.
     [Custom Resource Configuration](#custom-resource-configuration)\n\nSpectrum Scale
     GUI Setup \n------------------------\n> **NOTE:** This step only needs to be preformed

--- a/operator/deploy/olm-catalog/ibm-spectrum-scale-csi-operator/1.1.0/ibm-spectrum-scale-csi-operator.v1.1.0.clusterserviceversion.yaml
+++ b/operator/deploy/olm-catalog/ibm-spectrum-scale-csi-operator/1.1.0/ibm-spectrum-scale-csi-operator.v1.1.0.clusterserviceversion.yaml
@@ -243,8 +243,8 @@ spec:
   description:
     "\nThe IBM Spectrum Scale CSI Operator runs within a Kubernetes cluster
     providing a means to \ndeploy and manage the CSI plugin for spectrum scale. For
-    more in depth documentation please refer\nto the [github repository](https://github.com/IBM/ibm-spectrum-scale-csi) 
-    which has links to official documentation.\n\nThis operator should be used to deploy 
+    more in depth documentation please refer\nto the [knowledge center]( https://www.ibm.com/support/knowledgecenter/STXKQY_5.0.4/com.ibm.spectrum.scale.csi.v5r04.doc/bl1csi_kc_landing.html)
+    \n\nThis operator should be used to deploy 
     the CSI plugin.\n\nThe configuration process
     is as follows:\n\n1. [Spectrum Scale GUI Setup](#spectrum-scale-gui-setup)\n2.
     [Custom Resource Configuration](#custom-resource-configuration)\n\nSpectrum Scale
@@ -465,8 +465,8 @@ spec:
   labels:
     operator: ibm-spectrum-scale-csi-operator
   links:
-    - name: IBM CSI Spectrum Scale Operator Documentation
-      url: https://ibm-spectrum-scale-csi-operator.readthedocs.io/en/latest/
+    - name: IBM CSI Spectrum Scale Knowledge Center 
+      url:  https://www.ibm.com/support/knowledgecenter/STXKQY_5.0.4/com.ibm.spectrum.scale.csi.v5r04.doc/bl1csi_kc_landing.html
     - name: CSI Developer Documentation
       url: https://kubernetes-csi.github.io/docs/
   maintainers:

--- a/operator/roles/csi-scale/templates/cluster-role-attacher.yaml.j2
+++ b/operator/roles/csi-scale/templates/cluster-role-attacher.yaml.j2
@@ -47,3 +47,20 @@ rules:
   - watch
   - update
   - patch
+- apiGroups:
+  - storage.k8s.io
+  resources:
+  - csinodes
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ''
+  resources:
+  - nodes
+  verbs:
+  - get
+  - list
+  - watch
+


### PR DESCRIPTION
Closes #145 

The attacher cluster role was missing the `csinodes` resource rules. 

