### PR TITLE
Snapshotting tool fails to process olm operators.

### DIFF
--- a/tools/spectrum-scale-driver-snap.sh
+++ b/tools/spectrum-scale-driver-snap.sh
@@ -113,7 +113,7 @@ done
 
 
 # kubectl logs on operator pods
-operatorName=`$cmd get deployment -l product=ibm-spectrum-scale-csi --namespace $ns  |grep -v NAME |awk '{print $1}'`
+operatorName=`$cmd get deployment ibm-spectrum-scale-csi-operator  --namespace $ns  |grep -v NAME |awk '{print $1}'`
 if [[ "$operatorName" == "ibm-spectrum-scale-csi-operator" ]]; then
    describeCSIScaleOperator="$cmd describe CSIScaleOperator --namespace $ns"
    echo "$describeCSIScaleOperator"


### PR DESCRIPTION
Fixing a problem  with how the snapshotting tool handles operators provisioned with OLM. Discovered when debugging a snapshot.

@gandhisanjayv  @Jainbrt - It looks like the  snapshot tool doesn't gather on olm, do we have any test automation  to verify all the  files  are created?