### PR TITLE
Adding git commit label to image labels

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -34,10 +34,11 @@ env:
     - IMAGE_FQN_OPERATOR=${IMAGE_REPO_OPERATOR}:${IMAGE_TAG}
     - IMAGE_VERSION=${IMAGE_TAG}
     # Add image label to expire nightlies
+    - COMMIT_ARG= "--build-arg GIT_COMMIT=$(git log -1 --format=%h)"
     - IMAGE_LABEL=$(
         if [[ $TRAVIS_EVENT_TYPE == 'cron' ]];
         then
-            echo "--label version=${IMAGE_VERSION} --label quay.expires-after=2w";
+            echo "GIT_COMMIT=$(git log -1 --format=%h)  --label version=${IMAGE_VERSION} --label quay.expires-after=2w";
         else
             echo "--label version=${IMAGE_VERSION}";
         fi
@@ -153,7 +154,7 @@ jobs:
         - go mod vendor
       script:
         - go test -v -race ./...
-        - docker build ${IMAGE_LABEL} --build-arg GOFLAGS=${GOFLAGS} -f Dockerfile -t ${REPO_NAME_DRIVER} .
+        - docker build ${IMAGE_LABEL} ${COMMIT_ARG} --build-arg GOFLAGS=${GOFLAGS} -f Dockerfile -t ${REPO_NAME_DRIVER} .
       before_deploy:
         - echo "$QUAY_BOT_PASSWORD" | docker login -u "$QUAY_BOT_USERNAME" --password-stdin quay.io
         - docker tag ${REPO_NAME_DRIVER} ${IMAGE_FQN_DRIVER}
@@ -173,7 +174,7 @@ jobs:
         - operator-sdk version
       script:       
         - cd ${BUILD_DIR_OPERATOR}
-        - operator-sdk build ${REPO_NAME_OPERATOR} --image-build-args "${IMAGE_LABEL}"
+        - operator-sdk build ${REPO_NAME_OPERATOR} --image-build-args "${IMAGE_LABEL} ${COMMIT_ARG}"
       before_deploy:
         - echo "$QUAY_BOT_PASSWORD" | docker login -u "$QUAY_BOT_USERNAME" --password-stdin quay.io
         - docker tag ${REPO_NAME_OPERATOR} ${IMAGE_FQN_OPERATOR}

--- a/driver/build/Dockerfile
+++ b/driver/build/Dockerfile
@@ -21,7 +21,7 @@ LABEL name="IBM Spectrum Scale CSI driver" \
       release="1" \
       run='docker run ibm-spectrum-scale-csi-driver' \
       summary="An implementation of CSI Plugin for the IBM Spectrum Scale product."\
-      description="CSI Plugin for IBM Spectrum Scale"\
+      description="An implementation of CSI Plugin for the IBM Spectrum Scale product."\
       maintainers="IBM Spectrum Scale"\
       git_commit=$GIT_COMMIT
 

--- a/driver/build/Dockerfile
+++ b/driver/build/Dockerfile
@@ -9,6 +9,7 @@ RUN go mod download
 
 COPY . .
 ARG GOFLAGS
+ARG GIT_COMMIT
 RUN CGO_ENABLED=0 GOOS=linux go build -a -ldflags '-extldflags "-static"' -o _output/ibm-spectrum-scale-csi ./cmd/ibm-spectrum-scale-csi
 RUN chmod +x _output/ibm-spectrum-scale-csi
 
@@ -21,7 +22,9 @@ LABEL name="IBM Spectrum Scale CSI driver" \
       run='docker run ibm-spectrum-scale-csi-driver' \
       summary="An implementation of CSI Plugin for the IBM Spectrum Scale product."\
       description="CSI Plugin for IBM Spectrum Scale"\
-      maintainers="IBM Spectrum Scale"
+      maintainers="IBM Spectrum Scale"\
+      git_commit=$GIT_COMMIT
+
 COPY licenses /licenses
 COPY --from=builder /go/src/github.com/IBM/ibm-spectrum-scale-csi/driver/_output/ibm-spectrum-scale-csi /ibm-spectrum-scale-csi
 ENTRYPOINT ["/ibm-spectrum-scale-csi"]

--- a/operator/build/Dockerfile
+++ b/operator/build/Dockerfile
@@ -8,6 +8,8 @@ ARG CSI_ATTACHER_IMAGE
 ARG CSI_PROVISIONER_IMAGE
 ARG CSI_NODE_REGISTRAR_IMAGE
 ARG CSI_DRIVER_IMAGE
+ARG GIT_COMMIT
+
 
 ENV CSI_ATTACHER_IMAGE $CSI_ATTACHER_IMAGE
 ENV CSI_PROVISIONER_IMAGE $CSI_PROVISIONER_IMAGE
@@ -20,7 +22,8 @@ LABEL name="IBM Spectrum Scale CSI Operator" \
       release="1" \
       run='docker run ibm-spectrum-scale-csi-operator' \
       summary="An Ansible based operator to run and manage the deployment of the IBM Spectrum Scale CSI Driver." \
-      description="An Ansible based operator to run and manage the deployment of the IBM Spectrum Scale CSI Driver." 
+      description="An Ansible based operator to run and manage the deployment of the IBM Spectrum Scale CSI Driver." \
+      git_commit=$GIT_COMMIT
 
 COPY hacks/health_check.sh .
 COPY licenses /licenses


### PR DESCRIPTION
Fixes #152. Adds a `git_commit` label  to the image tags for both the operator and driver images. 