### PR TITLE
make clusterId optional in storageClass

### DIFF
--- a/driver/csiplugin/controllerserver.go
+++ b/driver/csiplugin/controllerserver.go
@@ -415,6 +415,9 @@ func (cs *ScaleControllerServer) CreateVolume(ctx context.Context, req *csi.Crea
 	}
 
 	if scaleVol.IsFilesetBased {
+		if scaleVol.ClusterId == "" {
+			scaleVol.ClusterId = PCid
+		}
 		conn, err := cs.GetConnFromClusterID(scaleVol.ClusterId)
 
 		if err != nil {

--- a/driver/csiplugin/gpfs_util.go
+++ b/driver/csiplugin/gpfs_util.go
@@ -70,7 +70,6 @@ func getScaleVolumeOptions(volOptions map[string]string) (*scaleVolume, error) {
 
 	volBckFs, fsSpecified := volOptions[connectors.UserSpecifiedVolBackendFs]
 	volDirPath, volDirPathSpecified := volOptions[connectors.UserSpecifiedVolDirPath]
-	clusterId, clusterIdSpecified := volOptions[connectors.UserSpecifiedClusterId]
 	uid, uidSpecified := volOptions[connectors.UserSpecifiedUid]
 	gid, gidSpecified := volOptions[connectors.UserSpecifiedGid]
 	fsType, fsTypeSpecified := volOptions[connectors.UserSpecifiedFilesetType]
@@ -103,10 +102,6 @@ func getScaleVolumeOptions(volOptions map[string]string) (*scaleVolume, error) {
 	if !fsTypeSpecified && !volDirPathSpecified {
 		fsTypeSpecified = true
 		fsType = independentFileset
-	}
-
-	if clusterIdSpecified && clusterId == "" {
-		clusterIdSpecified = false
 	}
 
 	if uidSpecified && uid == "" {

--- a/driver/csiplugin/gpfs_util.go
+++ b/driver/csiplugin/gpfs_util.go
@@ -81,7 +81,6 @@ func getScaleVolumeOptions(volOptions map[string]string) (*scaleVolume, error) {
 	scaleVol.VolDirBasePath = ""
 	scaleVol.InodeLimit = ""
 	scaleVol.FilesetType = ""
-	scaleVol.ClusterId = ""
 
 	if fsSpecified && volBckFs == "" {
 		fsSpecified = false
@@ -175,16 +174,6 @@ func getScaleVolumeOptions(volOptions map[string]string) (*scaleVolume, error) {
 	}
 	if fsTypeSpecified {
 		scaleVol.IsFilesetBased = true
-	}
-
-	/* cluster Id not mandatory for LW volumes */
-
-	if scaleVol.IsFilesetBased {
-		if clusterIdSpecified {
-			scaleVol.ClusterId = clusterId
-		} else {
-			return &scaleVolume{}, status.Error(codes.InvalidArgument, "clusterId must be specified in storageClass")
-		}
 	}
 
 	/* Get UID/GID */


### PR DESCRIPTION
fixes #16 
clusterId is optional in storageClass
if not specified Primary clusterId will be used to create volumes.