### PR TITLE
Restart Statefulsets on cluster changes

### DIFF
--- a/operator/roles/csi-scale/templates/csi-plugin-attacher.yaml.j2
+++ b/operator/roles/csi-scale/templates/csi-plugin-attacher.yaml.j2
@@ -50,6 +50,8 @@ spec:
             - "--resync=10m" # Added
             - "--timeout=2m"
           env:
+            - name: CHECKSUM
+              value: "{{cluster_checksum}}"
             - name: ADDRESS
               value: /var/lib/kubelet/plugins/ibm-spectrum-scale-csi/csi.sock
           imagePullPolicy: "IfNotPresent"

--- a/operator/roles/csi-scale/templates/csi-plugin-provisioner.yaml.j2
+++ b/operator/roles/csi-scale/templates/csi-plugin-provisioner.yaml.j2
@@ -50,6 +50,8 @@ spec:
             - "--worker-threads=10"
             - "--v=5" # Debugging
           env:
+            - name: CHECKSUM
+              value: "{{cluster_checksum}}"
             - name: ADDRESS
               value: /var/lib/kubelet/plugins/ibm-spectrum-scale-csi/csi.sock
           imagePullPolicy: "IfNotPresent"


### PR DESCRIPTION
This PR adds an update to the template for the statefulsets to track the checksum of the cluster configuration. This is an attempt to resolve the issue in #173 where the statefulset had issues  communicating to the GUI server.

---

 Closes #173