### PR TITLE
Add check for filesystem type before creating fileset

### DIFF
--- a/driver/csiplugin/connectors/connectors.go
+++ b/driver/csiplugin/connectors/connectors.go
@@ -48,6 +48,7 @@ type SpectrumScaleConnector interface {
 	MountFilesystem(filesystemName string, nodeName string) error
 	UnmountFilesystem(filesystemName string, nodeName string) error
 	GetFilesystemName(filesystemUUID string) (string, error)
+	GetFilesystemType(filesystemUUID string) (string, error)
 	CheckIfFileDirPresent(filesystemName string, relPath string) (bool, error)
 	CreateSymLink(SlnkfilesystemName string, TargetFs string, relativePath string, LnkPath string) error
 	GetFsUid(filesystemName string) (string, error)

--- a/driver/csiplugin/connectors/rest_v2.go
+++ b/driver/csiplugin/connectors/rest_v2.go
@@ -641,7 +641,7 @@ func (s *spectrumRestV2) UnmountFilesystem(filesystemName string, nodeName strin
 	return nil
 }
 
-func (s *spectrumRestV2) GetFilesystemName(filesystemUUID string) (string, error) {
+func (s *spectrumRestV2) GetFilesystemName(filesystemUUID string) (string, error) { //nolint:dupl
 	glog.V(4).Infof("rest_v2 GetFilesystemName. UUID: %s", filesystemUUID)
 
 	getFilesystemNameURL := utils.FormatURL(s.endpoint, fmt.Sprintf("scalemgmt/v2/filesystems?filter=uuid=%s", filesystemUUID))

--- a/driver/csiplugin/connectors/rest_v2.go
+++ b/driver/csiplugin/connectors/rest_v2.go
@@ -660,6 +660,25 @@ func (s *spectrumRestV2) GetFilesystemName(filesystemUUID string) (string, error
 	return getFilesystemNameURLResponse.FileSystems[0].Name, nil
 }
 
+func (s *spectrumRestV2) GetFilesystemType(filesystemName string) (string, error) {
+	glog.V(4).Infof("rest_v2 GetFilesystemType. Name: %s", filesystemName)
+
+	getFilesystemTypeURL := utils.FormatURL(s.endpoint, fmt.Sprintf("scalemgmt/v2/filesystems/%s", filesystemName))
+	getFilesystemTypeURLResponse := GetFilesystemResponse_v2{}
+
+	err := s.doHTTP(getFilesystemTypeURL, "GET", &getFilesystemTypeURLResponse, nil)
+	if err != nil {
+		glog.Errorf("Unable to get filesystem type for Name %s: %v", filesystemName, err)
+		return "", err
+	}
+
+	if len(getFilesystemTypeURLResponse.FileSystems) == 0 {
+		glog.Errorf("Unable to fetch filesystem name details for %s", filesystemName)
+		return "", fmt.Errorf("Unable to fetch filesystem name details for %s", filesystemName)
+	}
+	return getFilesystemTypeURLResponse.FileSystems[0].Type, nil
+}
+
 func (s *spectrumRestV2) GetFsUid(filesystemName string) (string, error) {
 	getFilesystemURL := fmt.Sprintf("%s%s%s", s.endpoint, "scalemgmt/v2/filesystems/", filesystemName)
 	getFilesystemResponse := GetFilesystemResponse_v2{}

--- a/driver/csiplugin/connectors/rest_v2.go
+++ b/driver/csiplugin/connectors/rest_v2.go
@@ -676,6 +676,7 @@ func (s *spectrumRestV2) GetFilesystemType(filesystemName string) (string, error
 		glog.Errorf("Unable to fetch filesystem name details for %s", filesystemName)
 		return "", fmt.Errorf("Unable to fetch filesystem name details for %s", filesystemName)
 	}
+
 	return getFilesystemTypeURLResponse.FileSystems[0].Type, nil
 }
 

--- a/driver/csiplugin/connectors/rest_v2.go
+++ b/driver/csiplugin/connectors/rest_v2.go
@@ -660,7 +660,7 @@ func (s *spectrumRestV2) GetFilesystemName(filesystemUUID string) (string, error
 	return getFilesystemNameURLResponse.FileSystems[0].Name, nil
 }
 
-func (s *spectrumRestV2) GetFilesystemType(filesystemName string) (string, error) {
+func (s *spectrumRestV2) GetFilesystemType(filesystemName string) (string, error) { //nolint:dupl
 	glog.V(4).Infof("rest_v2 GetFilesystemType. Name: %s", filesystemName)
 
 	getFilesystemTypeURL := utils.FormatURL(s.endpoint, fmt.Sprintf("scalemgmt/v2/filesystems/%s", filesystemName))

--- a/driver/csiplugin/controllerserver.go
+++ b/driver/csiplugin/controllerserver.go
@@ -32,9 +32,11 @@ import (
 )
 
 const (
-	no       = "no"
-	yes      = "yes"
-	notFound = "NOT_FOUND"
+	no                   = "no"
+	yes                  = "yes"
+	notFound             = "NOT_FOUND"
+	filesystemTypeLocal  = "local"
+	filesystemTypeRemote = "remote"
 )
 
 type ScaleControllerServer struct {
@@ -219,6 +221,16 @@ func (cs *ScaleControllerServer) GetTargetPathforFset(scVol *scaleVolume) (strin
 
 func (cs *ScaleControllerServer) CreateFilesetBasedVol(scVol *scaleVolume) (string, error) { //nolint:gocyclo,funlen
 	opt := make(map[string]interface{})
+
+	//Fileset can not be created if filesystem is remote.
+	fsType, err := scVol.Connector.GetFilesystemType(scVol.VolBackendFs)
+	if err != nil {
+		return "", status.Error(codes.Internal, fmt.Sprintf("Unable to check filesystem type of [%v]. Error [%v]", scVol.VolBackendFs, err))
+	}
+
+	if fsType == filesystemTypeRemote {
+		return "", status.Error(codes.Internal, fmt.Sprintf("filesystem [%v] is not local to cluster [%v]", scVol.VolBackendFs, scVol.ClusterId))
+	}
 
 	isFsMounted, err := scVol.Connector.IsFilesystemMounted(scVol.VolBackendFs)
 
@@ -420,7 +432,6 @@ func (cs *ScaleControllerServer) CreateVolume(ctx context.Context, req *csi.Crea
 			glog.V(3).Infof("clusterID not provided in storage Class using Primary ClusterID. Volume Name [%v]", scaleVol.VolName)
 		}
 		conn, err := cs.GetConnFromClusterID(scaleVol.ClusterId)
-
 		if err != nil {
 			return nil, err
 		}

--- a/driver/csiplugin/controllerserver.go
+++ b/driver/csiplugin/controllerserver.go
@@ -35,7 +35,6 @@ const (
 	no                   = "no"
 	yes                  = "yes"
 	notFound             = "NOT_FOUND"
-	filesystemTypeLocal  = "local"
 	filesystemTypeRemote = "remote"
 )
 


### PR DESCRIPTION
## Summary of Changes
Filesystem type check before creating fileset based volume. 

## Unit Tests
Create storage class with remote filesystem without cluster id, it should fail with proper error

## Documentation Updates
NA

## Upgrade Considerations
NA 

## Linked Issues
fixes #182 