### PR TITLE
Verify Primary fs is mounted on GUI node during initialisation and volume creation

### DIFF
--- a/driver/csiplugin/connectors/connectors.go
+++ b/driver/csiplugin/connectors/connectors.go
@@ -27,7 +27,7 @@ type SpectrumScaleConnector interface {
 	GetClusterId() (string, error)
 	//Filesystem operations
 	GetFilesystemMountDetails(filesystemName string) (MountInfo, error)
-	IsFilesystemMounted(filesystemName string) (bool, error)
+	IsFilesystemMountedOnGUINode(filesystemName string) (bool, error)
 	ListFilesystems() ([]string, error)
 	GetFilesystemMountpoint(filesystemName string) (string, error)
 	//Fileset operations

--- a/driver/csiplugin/connectors/connectors.go
+++ b/driver/csiplugin/connectors/connectors.go
@@ -29,6 +29,7 @@ type SpectrumScaleConnector interface {
 	GetFilesystemMountDetails(filesystemName string) (MountInfo, error)
 	IsFilesystemMountedOnGUINode(filesystemName string) (bool, error)
 	ListFilesystems() ([]string, error)
+	GetFilesystemDetails(filesystemName string) (FileSystem_v2, error)
 	GetFilesystemMountpoint(filesystemName string) (string, error)
 	//Fileset operations
 	CreateFileset(filesystemName string, filesetName string, opts map[string]interface{}) error
@@ -48,7 +49,6 @@ type SpectrumScaleConnector interface {
 	MountFilesystem(filesystemName string, nodeName string) error
 	UnmountFilesystem(filesystemName string, nodeName string) error
 	GetFilesystemName(filesystemUUID string) (string, error)
-	GetFilesystemType(filesystemUUID string) (string, error)
 	CheckIfFileDirPresent(filesystemName string, relPath string) (bool, error)
 	CreateSymLink(SlnkfilesystemName string, TargetFs string, relativePath string, LnkPath string) error
 	GetFsUid(filesystemName string) (string, error)

--- a/driver/csiplugin/connectors/resources.go
+++ b/driver/csiplugin/connectors/resources.go
@@ -342,6 +342,7 @@ type MountInfo struct {
 	RemoteDeviceName string   `json:"remoteDeviceName,omitempty"`
 	NodesMounted     []string `json:"nodesMountedReadWrite,omitempty"`
 	ReadOnly         bool     `json:"readOnly,omitempty"`
+	Status           string   `json:"status,omitempty"`
 }
 
 type QuotaInfo struct {

--- a/driver/csiplugin/connectors/rest_v2.go
+++ b/driver/csiplugin/connectors/rest_v2.go
@@ -671,24 +671,24 @@ func (s *spectrumRestV2) GetFilesystemName(filesystemUUID string) (string, error
 	return getFilesystemNameURLResponse.FileSystems[0].Name, nil
 }
 
-func (s *spectrumRestV2) GetFilesystemType(filesystemName string) (string, error) { //nolint:dupl
-	glog.V(4).Infof("rest_v2 GetFilesystemType. Name: %s", filesystemName)
+func (s *spectrumRestV2) GetFilesystemDetails(filesystemName string) (FileSystem_v2, error) { //nolint:dupl
+	glog.V(4).Infof("rest_v2 GetFilesystemDetails. Name: %s", filesystemName)
 
-	getFilesystemTypeURL := utils.FormatURL(s.endpoint, fmt.Sprintf("scalemgmt/v2/filesystems/%s", filesystemName))
-	getFilesystemTypeURLResponse := GetFilesystemResponse_v2{}
+	getFilesystemDetailsURL := utils.FormatURL(s.endpoint, fmt.Sprintf("scalemgmt/v2/filesystems/%s", filesystemName))
+	getFilesystemDetailsURLResponse := GetFilesystemResponse_v2{}
 
-	err := s.doHTTP(getFilesystemTypeURL, "GET", &getFilesystemTypeURLResponse, nil)
+	err := s.doHTTP(getFilesystemDetailsURL, "GET", &getFilesystemDetailsURLResponse, nil)
 	if err != nil {
-		glog.Errorf("Unable to get filesystem type for Name %s: %v", filesystemName, err)
-		return "", err
+		glog.Errorf("Unable to get filesystem details for filesystem %s: %v", filesystemName, err)
+		return FileSystem_v2{}, err
 	}
 
-	if len(getFilesystemTypeURLResponse.FileSystems) == 0 {
-		glog.Errorf("Unable to fetch filesystem name details for %s", filesystemName)
-		return "", fmt.Errorf("Unable to fetch filesystem name details for %s", filesystemName)
+	if len(getFilesystemDetailsURLResponse.FileSystems) == 0 {
+		glog.Errorf("Unable to fetch filesystem details for %s", filesystemName)
+		return FileSystem_v2{}, fmt.Errorf("Unable to fetch filesystem details for %s", filesystemName)
 	}
 
-	return getFilesystemTypeURLResponse.FileSystems[0].Type, nil
+	return getFilesystemDetailsURLResponse.FileSystems[0], nil
 }
 
 func (s *spectrumRestV2) GetFsUid(filesystemName string) (string, error) {

--- a/driver/csiplugin/connectors/rest_v2.go
+++ b/driver/csiplugin/connectors/rest_v2.go
@@ -183,8 +183,8 @@ func (s *spectrumRestV2) GetFilesystemMountDetails(filesystemName string) (Mount
 	}
 }
 
-func (s *spectrumRestV2) IsFilesystemMounted(filesystemName string) (bool, error) {
-	glog.V(4).Infof("rest_v2 IsFilesystemMounted. filesystemName: %s", filesystemName)
+func (s *spectrumRestV2) IsFilesystemMountedOnGUINode(filesystemName string) (bool, error) {
+	glog.V(4).Infof("rest_v2 IsFilesystemMountedOnGUINode. filesystemName: %s", filesystemName)
 
 	mountURL := utils.FormatURL(s.endpoint, fmt.Sprintf("scalemgmt/v2/filesystems/%s", filesystemName))
 	mountResponse := GetFilesystemResponse_v2{}

--- a/driver/csiplugin/controllerserver.go
+++ b/driver/csiplugin/controllerserver.go
@@ -36,6 +36,7 @@ const (
 	yes                  = "yes"
 	notFound             = "NOT_FOUND"
 	filesystemTypeRemote = "remote"
+	filesystemMounted    = "mounted"
 )
 
 type ScaleControllerServer struct {
@@ -238,7 +239,7 @@ func (cs *ScaleControllerServer) CreateFilesetBasedVol(scVol *scaleVolume) (stri
 	// if filesystem is remote, check it is mounted on remote GUI node.
 	if cs.Driver.primary.PrimaryCid != scVol.ClusterId {
 		glog.V(4).Infof("check if volumes filesystem [%v] is mounted on remote GUI of cluster [%v]", scVol.VolBackendFs, scVol.ClusterId)
-		if fsDetails.Mount.Status != "mounted" {
+		if fsDetails.Mount.Status != filesystemMounted {
 			glog.Errorf(" filesystem [%v] is [%v] on remote GUI of cluster [%v]", scVol.VolBackendFs, fsDetails.Mount.Status, scVol.ClusterId)
 			return "", status.Error(codes.Internal, fmt.Sprintf("Filesystem %v in cluster %v is not mounted", scVol.VolBackendFs, scVol.ClusterId))
 		}
@@ -442,7 +443,7 @@ func (cs *ScaleControllerServer) CreateVolume(ctx context.Context, req *csi.Crea
 		return nil, status.Error(codes.Internal, fmt.Sprintf("Unable to get Mount Details for FS [%v] in Primary cluster", scaleVol.VolBackendFs))
 	}
 
-	if mountInfo.Status != "mounted" {
+	if mountInfo.Status != filesystemMounted {
 		glog.Errorf("volume filesystem %s is not mounted on GUI node of Primary cluster", scaleVol.VolBackendFs)
 		return nil, status.Error(codes.Internal, fmt.Sprintf("volume filesystem %s is not mounted on GUI node of Primary cluster", scaleVol.VolBackendFs))
 	}

--- a/driver/csiplugin/controllerserver.go
+++ b/driver/csiplugin/controllerserver.go
@@ -235,7 +235,6 @@ func (cs *ScaleControllerServer) CreateFilesetBasedVol(scVol *scaleVolume) (stri
 	}
 
 	// if filesystem is remote, check it is mounted on remote GUI node.
-	glog.V(4).Infof("DEEBUG cs.Driver.primary.PrimaryCid [%v]; scVol.ClusterId [%v]", cs.Driver.primary.PrimaryCid, scVol.ClusterId)
 	if cs.Driver.primary.PrimaryCid != scVol.ClusterId {
 		glog.V(4).Infof("check if volumes filesystem [%v] is mounted on remote GUI of cluster [%v]", scVol.PrimaryFS, scVol.ClusterId)
 		isFsMounted, err := scVol.Connector.IsFilesystemMountedOnGUINode(scVol.VolBackendFs)

--- a/driver/csiplugin/gpfs.go
+++ b/driver/csiplugin/gpfs.go
@@ -208,15 +208,24 @@ func (driver *ScaleDriver) PluginInitialize() (map[string]connectors.SpectrumSca
 		if cluster.Primary != (settings.Primary{}) {
 			scaleConnMap["primary"] = sc
 
-			// check if primary filesystem exists and mounted on atleast one node
+			// check if primary filesystem exists
 			fsMount, err := sc.GetFilesystemMountDetails(cluster.Primary.GetPrimaryFs())
 			if err != nil {
 				glog.Errorf("Error in getting filesystem details for %s", cluster.Primary.GetPrimaryFs())
 				return nil, scaleConfig, cluster.Primary, err
 			}
-			if fsMount.NodesMounted == nil || len(fsMount.NodesMounted) == 0 {
-				return nil, scaleConfig, cluster.Primary, fmt.Errorf("Primary filesystem not mounted on any node")
+
+			// check if filesystem is mounted on GUI node
+			isFsMounted, err := sc.IsFilesystemMounted(cluster.Primary.GetPrimaryFs())
+			if err != nil {
+				glog.Errorf("Error in getting filesystem mount details for %s on Primary cluster", cluster.Primary.GetPrimaryFs())
+				return nil, scaleConfig, cluster.Primary, err
 			}
+			if !isFsMounted {
+				glog.Errorf("Primary filesystem %s is not mounted on GUI node of Primary cluster", cluster.Primary.GetPrimaryFs())
+				return nil, scaleConfig, cluster.Primary, fmt.Errorf("Primary filesystem %s not mounted on GUI node Primary cluster", cluster.Primary.GetPrimaryFs())
+			}
+
 			// In case primary fset value is not specified in configuation then use default
 			if scaleConfig.Clusters[i].Primary.PrimaryFset == "" {
 				scaleConfig.Clusters[i].Primary.PrimaryFset = DefaultPrimaryFileset
@@ -250,10 +259,19 @@ func (driver *ScaleDriver) PluginInitialize() (map[string]connectors.SpectrumSca
 		}
 
 		glog.Infof("remote fsMount = %v", fsMount)
-		if fsMount.NodesMounted == nil || len(fsMount.NodesMounted) == 0 {
-			return scaleConnMap, scaleConfig, primaryInfo, fmt.Errorf("Primary filesystem not mounted on any node on cluster %s", primaryInfo.RemoteCluster)
-		}
 		fsmount = fsMount.MountPoint
+
+		// check if filesystem is mounted on GUI node
+		isPfsMounted, err := sconn.IsFilesystemMounted(fs)
+		if err != nil {
+			glog.Errorf("Error in getting filesystem mount details for %s from cluster %s", fs, primaryInfo.RemoteCluster)
+			return scaleConnMap, scaleConfig, primaryInfo, err
+		}
+
+		if !isPfsMounted {
+			glog.Errorf("Filesystem %s is not mounted on GUI node of cluster %s", fs, primaryInfo.RemoteCluster)
+			return scaleConnMap, scaleConfig, primaryInfo, fmt.Errorf("Filesystem %s is not mounted on GUI node of cluster %s", fs, primaryInfo.RemoteCluster)
+		}
 	}
 
 	fsetlinkpath, err := driver.CreatePrimaryFileset(sconn, fs, fsmount, primaryInfo.PrimaryFset, primaryInfo.GetInodeLimit())

--- a/driver/csiplugin/gpfs.go
+++ b/driver/csiplugin/gpfs.go
@@ -216,7 +216,7 @@ func (driver *ScaleDriver) PluginInitialize() (map[string]connectors.SpectrumSca
 			}
 
 			// check if filesystem is mounted on GUI node
-			isFsMounted, err := sc.IsFilesystemMounted(cluster.Primary.GetPrimaryFs())
+			isFsMounted, err := sc.IsFilesystemMountedOnGUINode(cluster.Primary.GetPrimaryFs())
 			if err != nil {
 				glog.Errorf("Error in getting filesystem mount details for %s on Primary cluster", cluster.Primary.GetPrimaryFs())
 				return nil, scaleConfig, cluster.Primary, err
@@ -262,7 +262,7 @@ func (driver *ScaleDriver) PluginInitialize() (map[string]connectors.SpectrumSca
 		fsmount = fsMount.MountPoint
 
 		// check if filesystem is mounted on GUI node
-		isPfsMounted, err := sconn.IsFilesystemMounted(fs)
+		isPfsMounted, err := sconn.IsFilesystemMountedOnGUINode(fs)
 		if err != nil {
 			glog.Errorf("Error in getting filesystem mount details for %s from cluster %s", fs, primaryInfo.RemoteCluster)
 			return scaleConnMap, scaleConfig, primaryInfo, err


### PR DESCRIPTION
## Summary of Changes
Check if Primary filesystem is mount on GUI before creating fileset in initialisation and volume creation
Following checks are added 
1.During initialisation 
 - Primary filesystem is mounted on Primary Cluster GUI
- Primary filesystem is mounted on Remote Cluster GUI

2. During volume Creation 
- Primary Filesystem is mounted on Primary cluster GUI
- Volume filesystem is mounted on Primary cluster GUI
- Volume filesystem is mounted on Remote Cluster GUI if volume type is fileset and volume filesystem is remotely mounted

## Unit Tests
- Try CSI Driver deployment with primary fs unmount on GUI(single cluster + remote cluster setup)
- Try CSI Driver deployment with primary fs mounted on GUI((single cluster + remote cluster setup))
- Try volume creation when primary filesystem unmounted on GUI node
- Try volume creation when volume filesystem is unmounted on GUI node
- try volume creation when remoteFs is unmounted on GUI node of remote cluster

## Documentation Updates
NA

## Upgrade Considerations
NA 
## Linked Issues
fixes #140 
