### PR TITLE
Operator Framework labelling

### DIFF
--- a/operator/deploy/olm-catalog/ibm-spectrum-scale-csi-operator/2.0.1/ibm-spectrum-scale-csi-operator.v2.0.1.clusterserviceversion.yaml
+++ b/operator/deploy/olm-catalog/ibm-spectrum-scale-csi-operator/2.0.1/ibm-spectrum-scale-csi-operator.v2.0.1.clusterserviceversion.yaml
@@ -18,6 +18,9 @@ metadata:
     app.kubernetes.io/instance: ibm-spectrum-scale-csi-operator
     app.kubernetes.io/managed-by: ibm-spectrum-scale-csi-operator
     app.kubernetes.io/name: ibm-spectrum-scale-csi-operator
+    operatorframework.io/arch.amd64: supported
+    operatorframework.io/arch.s390x: supported
+    operatorframework.io/arch.ppc64le: supported
     release: ibm-spectrum-scale-csi-operator
   name: ibm-spectrum-scale-csi-operator.v2.0.1
   namespace: placeholder


### PR DESCRIPTION
Added the following CSV labels:

```
operatorframework.io/arch.ppc64le: supported 
operatorframework.io/arch.s390x: supported
operatorframework.io/arch.ppc64le: supported
```