### PR TITLE
Check Scale cluster supports for snapshotCopy operation

### DIFF
--- a/driver/csiplugin/connectors/connectors.go
+++ b/driver/csiplugin/connectors/connectors.go
@@ -59,7 +59,9 @@ type SpectrumScaleConnector interface {
 	GetFileSetNameFromId(filesystemName string, Id string) (string, error)
 	DeleteSymLnk(filesystemName string, LnkName string) error
 	GetFileSetResponseFromId(filesystemName string, Id string) (Fileset_v2, error)
+
 	IsValidNodeclass(nodeclass string) (bool, error)
+	IsSnapshotSupported() (bool, error)
 
 	//Snapshot operations
 	CreateSnapshot(filesystemName string, filesetName string, snapshotName string) error

--- a/driver/csiplugin/connectors/resources.go
+++ b/driver/csiplugin/connectors/resources.go
@@ -417,6 +417,20 @@ type GetNodesResponse_v2 struct {
 	Paging Pages     `json:"paging,omitempty"`
 }
 
+type GetInfoResponse_v2 struct {
+	Status Status `json:"status,omitempty"`
+	Info   Info   `json:"info,omitempty"`
+}
+
+type Info struct {
+	ServerVersion string `json:"serverVersion,omitempty"`
+	Paths         Path   `json:"paths,omitempty"`
+}
+
+type Path struct {
+	SnapCopyOp []string `json:"/filesystems/{filesystemName}/filesets/{filesetName}/snapshotCopy/{snapshotName},omitempty"`
+}
+
 type NodeConfig struct {
 	AdminLoginName    string `json:"adminLoginName,omitempty"`
 	DesignatedLicense string `json:"designatedLicense,omitempty"`

--- a/driver/csiplugin/connectors/rest_v2.go
+++ b/driver/csiplugin/connectors/rest_v2.go
@@ -659,6 +659,25 @@ func (s *spectrumRestV2) IsValidNodeclass(nodeclass string) (bool, error) {
 	return true, nil
 }
 
+func (s *spectrumRestV2) IsSnapshotSupported() (bool, error) {
+	glog.V(4).Infof("rest_v2 IsSnapshotSupported")
+
+	getVersionURL := utils.FormatURL(s.endpoint, "scalemgmt/v2/info")
+	getVersionResponse := GetInfoResponse_v2{}
+
+	err := s.doHTTP(getVersionURL, "GET", &getVersionResponse, nil)
+	if err != nil {
+		glog.Errorf("Unable to get cluster information: [%v]", err)
+		return false, err
+	}
+
+	if len(getVersionResponse.Info.Paths.SnapCopyOp) == 0 {
+		return false, nil
+	}
+
+	return true, nil
+}
+
 func (s *spectrumRestV2) GetFilesetQuotaDetails(filesystemName string, filesetName string) (Quota_v2, error) {
 	glog.V(4).Infof("rest_v2 GetFilesetQuotaDetails. filesystem: %s, fileset: %s", filesystemName, filesetName)
 


### PR DESCRIPTION
Added check if the Spectrum Scale cluster supports snapshotCopy operations. These operations are supported in Scale version 5.0.5.2 or later.

For this check, we query the REST info endpoint which returns GUI server information like Spectrum Scale version and also lists all the endpoints supported by that version.
