### PR TITLE
do not use hostNetwork for CSI pods

### DIFF
--- a/operator/roles/csi-scale/templates/csi-plugin.yaml.j2
+++ b/operator/roles/csi-scale/templates/csi-plugin.yaml.j2
@@ -35,7 +35,7 @@ spec:
 {% endfor %}
 {% endif %}
       serviceAccount: "{{ productName }}-node"
-      hostNetwork: true
+      hostNetwork: false
       containers:
         - name: driver-registrar
 {% if 'apps.openshift.io' in api_groups %}

--- a/operator/roles/csi-scale/templates/scc.yaml.j2
+++ b/operator/roles/csi-scale/templates/scc.yaml.j2
@@ -28,7 +28,7 @@ volumes:
 - secret
 allowHostDirVolumePlugin: true
 allowHostIPC: false
-allowHostNetwork: true
+allowHostNetwork: false
 allowHostPID: false
 allowHostPorts: false
 allowPrivilegeEscalation: true


### PR DESCRIPTION
Hi, 

I was wondering if hostNetwork is truly need for the CSI plugin pods.  It seems that CSI driver plugin is not listening on hostNetwork and this is not needed.  

If hostNetwork actually is required for some reason that I do not see, then it would be good to use `dnsPolicy: ClusterFirstWithHostNet` so that the CSI pods can properly resolve cluster services.

Thoughts?