### PR TITLE
bumping ansible-operator version to v0.19.4

### DIFF
--- a/operator/build/Dockerfile
+++ b/operator/build/Dockerfile
@@ -1,7 +1,7 @@
 # Multi-arch build for IBM Spectrum Scale CSI Operator
 # usage: docker buildx build -f build/Dockerfile --platform=linux/amd64 -t my_image_tag .
 
-FROM quay.io/operator-framework/ansible-operator:v0.19.0
+FROM quay.io/operator-framework/ansible-operator:v0.19.4
 MAINTAINER jdunham@us.ibm.com
 
 ARG CSI_ATTACHER_IMAGE


### PR DESCRIPTION
bumping ansible-operator version to v0.19.4