### PR TITLE
Fix snapshot creation timestamp

### DIFF
--- a/driver/csiplugin/connectors/connectors.go
+++ b/driver/csiplugin/connectors/connectors.go
@@ -25,6 +25,7 @@ import (
 type SpectrumScaleConnector interface {
 	//Cluster operations
 	GetClusterId() (string, error)
+	GetTimeZoneOffset() (string, error)
 	//Filesystem operations
 	GetFilesystemMountDetails(filesystemName string) (MountInfo, error)
 	IsFilesystemMountedOnGUINode(filesystemName string) (bool, error)

--- a/driver/csiplugin/connectors/resources.go
+++ b/driver/csiplugin/connectors/resources.go
@@ -28,6 +28,22 @@ type Cluster struct {
 	Nodes          []ClusterNode     `json:"nodes,omitempty"`
 }
 
+type GetConfigResponse struct {
+	Config Config `json:"config,omitempty"`
+	Status Status `json:"status,omitempty"`
+}
+
+type Config struct {
+	ClusterConfig ClusterConfig `json:"clusterConfig,omitempty"`
+}
+
+type ClusterConfig struct {
+	ClusterID       string `json:"clusterId,omitempty"`
+	ClusterName     string `json:"clusterName,omitempty"`
+	MinReleaseLevel string `json:"minReleaseLevel,omitempty"`
+	TimeZoneOffset  string `json:"timeZoneOffset,omitempty"`
+}
+
 type CesSummary struct {
 	EnabledServices string `json:"enabledServices"`
 	AddressPolicy   string `json:"addressPolicy,omitempty"`

--- a/driver/csiplugin/connectors/rest_v2.go
+++ b/driver/csiplugin/connectors/rest_v2.go
@@ -164,6 +164,21 @@ func (s *spectrumRestV2) GetClusterId() (string, error) {
 	return cid_str, nil
 }
 
+func (s *spectrumRestV2) GetTimeZoneOffset() (string, error) {
+	glog.V(4).Infof("rest_v2 GetTimeZoneOffset")
+
+	getConfigURL := utils.FormatURL(s.endpoint, "scalemgmt/v2/config")
+	getConfigResponse := GetConfigResponse{}
+
+	err := s.doHTTP(getConfigURL, "GET", &getConfigResponse, nil)
+	if err != nil {
+		glog.Errorf("Unable to get cluster configuration: %v", err)
+		return "", err
+	}
+	timezone := fmt.Sprintf("%v", getConfigResponse.Config.ClusterConfig.TimeZoneOffset)
+	return timezone, nil
+}
+
 func (s *spectrumRestV2) GetFilesystemMountDetails(filesystemName string) (MountInfo, error) {
 	glog.V(4).Infof("rest_v2 GetFilesystemMountDetails. filesystemName: %s", filesystemName)
 


### PR DESCRIPTION
The snapshot creation timestamp returned by Spectrum Scale REST API does not contain timezone info. Enhanced the code to get timezone offset from cluster config REST API to construct the correct creation timestamp.