### PR TITLE
dynamic inode limit calculation

### DIFF
--- a/driver/csiplugin/controllerserver.go
+++ b/driver/csiplugin/controllerserver.go
@@ -254,6 +254,14 @@ func (cs *ScaleControllerServer) createFilesetBasedVol(scVol *scaleVolume) (stri
 	}
 	if scVol.InodeLimit != "" {
 		opt[connectors.UserSpecifiedInodeLimit] = scVol.InodeLimit
+	} else {
+		blockSize := uint64(fsDetails.Block.BlockSize)
+		var inodeLimit uint64
+		inodeLimit = scVol.VolSize / blockSize
+		if inodeLimit < 1024 {
+			inodeLimit = 1024
+		}
+		opt[connectors.UserSpecifiedInodeLimit] = strconv.FormatUint(inodeLimit, 10)
 	}
 	if scVol.ParentFileset != "" {
 		opt[connectors.UserSpecifiedParentFset] = scVol.ParentFileset


### PR DESCRIPTION
If inodeLimit is not specified in StorageClasss then use following formula to calculate the inodeLimit instead of using default 1million. 
inodeLimit = PV size / Filesystem Block size
Fixes #321 