### PR TITLE
Upgraded sidecars and using gcr images as defaults

### DIFF
--- a/operator/deploy/crds/csiscaleoperators.csi.ibm.com_cr.yaml
+++ b/operator/deploy/crds/csiscaleoperators.csi.ibm.com_cr.yaml
@@ -50,15 +50,15 @@ spec:
 
 # Attacher image name, in case we do not want to use default image.
 # ==================================================================================
-#  attacher: "quay.io/k8scsi/csi-attacher:v2.1.1"
+#  attacher: "us.gcr.io/k8s-artifacts-prod/sig-storage/csi-attacher:v3.0.0"
 
 # Provisioner image name, in case we do not want to use default image.
 # ==================================================================================
-#  provisioner: "quay.io/k8scsi/csi-provisioner:v1.5.0"
+#  provisioner: "us.gcr.io/k8s-artifacts-prod/sig-storage/csi-provisioner:v2.0.2"
 
 # Driver Registrar image name, in case we do not want to use default image.
 # ==================================================================================
-#  driverRegistrar: "quay.io/k8scsi/csi-node-driver-registrar:v1.2.0"
+#  driverRegistrar: "us.gcr.io/k8s-artifacts-prod/sig-storage/csi-node-driver-registrar:v2.0.1"
 
 # SpectrumScale CSI Plugin image name, in case we do not want to use default image.
 # ==================================================================================

--- a/operator/roles/csi-scale/defaults/main.yml
+++ b/operator/roles/csi-scale/defaults/main.yml
@@ -14,10 +14,10 @@ namespace: '{{ meta.namespace | default("default") }}'
 storage-class: "ibm-spectrum-scale-csi"
 
 # Image defaults
-attacher: "{{ lookup('env', 'CSI_ATTACHER_IMAGE') | default('quay.io/k8scsi/csi-attacher:v2.1.1', true) }}"
-provisioner: "{{ lookup('env', 'CSI_PROVISIONER_IMAGE') | default('quay.io/k8scsi/csi-provisioner:v1.5.0', true) }}"
+attacher: "{{ lookup('env', 'CSI_ATTACHER_IMAGE') | default('us.gcr.io/k8s-artifacts-prod/sig-storage/csi-attacher:v3.0.0', true) }}"
+provisioner: "{{ lookup('env', 'CSI_PROVISIONER_IMAGE') | default('us.gcr.io/k8s-artifacts-prod/sig-storage/csi-provisioner:v2.0.2', true) }}"
 # Due to camelCase these get loaded differently in the operator.
-driverRegistrar: "{{ driver_registrar | default(lookup('env', 'CSI_NODE_REGISTRAR_IMAGE')) | default('quay.io/k8scsi/csi-node-driver-registrar:v1.2.0', true) }}"
+driverRegistrar: "{{ driver_registrar | default(lookup('env', 'CSI_NODE_REGISTRAR_IMAGE')) | default('us.gcr.io/k8s-artifacts-prod/sig-storage/csi-node-driver-registrar:v2.0.1', true) }}"
 spectrumScale: "{{ spectrum_scale | default(lookup('env', 'CSI_DRIVER_IMAGE')) | default('quay.io/ibm-spectrum-scale/ibm-spectrum-scale-csi-driver:v2.0.0', true) }}"
 
 # Set defaults for the secret counter and hostpath.

--- a/operator/roles/csi-scale/templates/cluster-role-attacher.yaml.j2
+++ b/operator/roles/csi-scale/templates/cluster-role-attacher.yaml.j2
@@ -63,3 +63,14 @@ rules:
   - get
   - list
   - watch
+- apiGroups:
+  - storage.k8s.io
+  resources:
+  - volumeattachments/status
+  verbs:
+  - get
+  - list
+  - watch
+  - update
+  - patch
+

--- a/operator/roles/csi-scale/templates/cluster-role-provisioner.yaml.j2
+++ b/operator/roles/csi-scale/templates/cluster-role-provisioner.yaml.j2
@@ -71,3 +71,14 @@ rules:
   - create
   - update
   - patch
+- apiGroups:
+  - storage.k8s.io
+  resources:
+  - volumeattachments
+  verbs:
+  - get
+  - list
+  - watch
+  - update
+  - patch
+


### PR DESCRIPTION
- Upgraded to newer sidecar images
- Added required access to the attacher and provisioner clusterroles
- Used gcr images as defaults
- Updated the CR file to point to gcr images

Documentation impact:
Doc needs to be updated to point to new images