### PR TITLE
Executing fileset refresh task during plugin init 

### DIFF
--- a/driver/csiplugin/connectors/connectors.go
+++ b/driver/csiplugin/connectors/connectors.go
@@ -40,6 +40,7 @@ type SpectrumScaleConnector interface {
 	//ListFilesets(filesystemName string) ([]resources.Volume, error)
 	ListFileset(filesystemName string, filesetName string) (Fileset_v2, error)
 	IsFilesetLinked(filesystemName string, filesetName string) (bool, error)
+	FilesetRefreshTask() error
 	//TODO modify quota from string to Capacity (see kubernetes)
 	ListFilesetQuota(filesystemName string, filesetName string) (string, error)
 	SetFilesetQuota(filesystemName string, filesetName string, quota string) error

--- a/driver/csiplugin/connectors/rest_v2.go
+++ b/driver/csiplugin/connectors/rest_v2.go
@@ -439,6 +439,21 @@ func (s *spectrumRestV2) IsFilesetLinked(filesystemName string, filesetName stri
 	return true, nil
 }
 
+func (s *spectrumRestV2) FilesetRefreshTask() error {
+	glog.V(4).Infof("rest_v2 FilesetRefreshTask")
+
+	filesetRefreshURL := utils.FormatURL(s.endpoint, "scalemgmt/v2/refreshTask/enqueue?taskId=FILESETS&maxDelay=0")
+	filesetRefreshResponse := GenericResponse{}
+
+	err := s.doHTTP(filesetRefreshURL, "POST", &filesetRefreshResponse, nil)
+	if err != nil {
+		glog.Errorf("Error in fileset refresh task: %v", err)
+		return err
+	}
+
+	return nil
+}
+
 func (s *spectrumRestV2) MakeDirectory(filesystemName string, relativePath string, uid string, gid string) error {
 	glog.V(4).Infof("rest_v2 MakeDirectory. filesystem: %s, path: %s, uid: %s, gid: %s", filesystemName, relativePath, uid, gid)
 

--- a/driver/csiplugin/gpfs.go
+++ b/driver/csiplugin/gpfs.go
@@ -280,6 +280,15 @@ func (driver *ScaleDriver) PluginInitialize() (map[string]connectors.SpectrumSca
 		return scaleConnMap, scaleConfig, primaryInfo, err
 	}
 
+	// In case primary FS is remotely mounted, run fileset refresh task on primary cluster
+	if primaryInfo.RemoteCluster != "" {
+		err = scaleConnMap["primary"].FilesetRefreshTask()
+		if err != nil {
+			glog.Errorf("Error in fileset refresh task")
+			return scaleConnMap, scaleConfig, primaryInfo, err
+		}
+	}
+
 	if fsmount != primaryInfo.PrimaryFSMount {
 		fsetlinkpath = strings.Replace(fsetlinkpath, fsmount, primaryInfo.PrimaryFSMount, 1)
 	}

--- a/driver/csiplugin/gpfs.go
+++ b/driver/csiplugin/gpfs.go
@@ -282,10 +282,14 @@ func (driver *ScaleDriver) PluginInitialize() (map[string]connectors.SpectrumSca
 
 	// In case primary FS is remotely mounted, run fileset refresh task on primary cluster
 	if primaryInfo.RemoteCluster != "" {
-		err = scaleConnMap["primary"].FilesetRefreshTask()
+		_, err := scaleConnMap["primary"].ListFileset(primaryInfo.GetPrimaryFs(), primaryInfo.PrimaryFset)
 		if err != nil {
-			glog.Errorf("Error in fileset refresh task")
-			return scaleConnMap, scaleConfig, primaryInfo, err
+			glog.Infof("Primary fileset %v not visible on primary cluster. Running fileset refresh task", primaryInfo.PrimaryFset)
+			err = scaleConnMap["primary"].FilesetRefreshTask()
+			if err != nil {
+				glog.Errorf("Error in fileset refresh task")
+				return scaleConnMap, scaleConfig, primaryInfo, err
+			}
 		}
 	}
 


### PR DESCRIPTION
Executing fileset refresh task during plugin init  if the file system is remotely mounted. This is so that the fileset is visible in local/primary cluster's GUI