### PR TITLE
changes for csi-snapshotter 4.0.0 version

### DIFF
--- a/SNAPSHOTS.md
+++ b/SNAPSHOTS.md
@@ -4,7 +4,7 @@ Min Kubernetes version: 1.20
 Min OpenShift version: 4.7
 
 ## Installing the external snapshotter
-Note: Kubernetes distributions should provide the external snapshotter by default. OpenShift 4.4+ has the snapshot controller installed by default and below steps are not needed. Perform below two steps for Kubernetes cluster.
+Note: Kubernetes distributions should provide the external snapshotter by default. OpenShift 4.7+ has the snapshot controller installed by default and below steps are not needed. Perform below two steps for Kubernetes cluster.
 
 ### Install external snapshotter CRDs
 

--- a/operator/deploy/crds/csiscaleoperators.csi.ibm.com_cr.yaml
+++ b/operator/deploy/crds/csiscaleoperators.csi.ibm.com_cr.yaml
@@ -60,6 +60,10 @@ spec:
 # ==================================================================================
 #  driverRegistrar: "us.gcr.io/k8s-artifacts-prod/sig-storage/csi-node-driver-registrar:v2.0.1"
 
+# Snapshotter image name, in case we do not want to use default image.
+# ==================================================================================
+#  snapshotter: "us.gcr.io/k8s-artifacts-prod/sig-storage/csi-snapshotter:v4.0.0"
+
 # SpectrumScale CSI Plugin image name, in case we do not want to use default image.
 # ==================================================================================
 #  spectrumScale: "quay.io/ibm-spectrum-scale/ibm-spectrum-scale-csi-driver:v2.1.0"

--- a/operator/roles/csi-scale/defaults/main.yml
+++ b/operator/roles/csi-scale/defaults/main.yml
@@ -14,7 +14,7 @@ namespace: '{{ meta.namespace | default("default") }}'
 storage-class: "ibm-spectrum-scale-csi"
 
 # Image defaults
-snapshotter: "{{ lookup('env', 'CSI_SNAPSHOTTER_IMAGE') | default('us.gcr.io/k8s-artifacts-prod/sig-storage/csi-snapshotter:v3.0.0', true) }}"
+snapshotter: "{{ lookup('env', 'CSI_SNAPSHOTTER_IMAGE') | default('us.gcr.io/k8s-artifacts-prod/sig-storage/csi-snapshotter:v4.0.0', true) }}"
 attacher: "{{ lookup('env', 'CSI_ATTACHER_IMAGE') | default('us.gcr.io/k8s-artifacts-prod/sig-storage/csi-attacher:v3.0.0', true) }}"
 provisioner: "{{ lookup('env', 'CSI_PROVISIONER_IMAGE') | default('us.gcr.io/k8s-artifacts-prod/sig-storage/csi-provisioner:v2.0.2', true) }}"
 

--- a/operator/roles/csi-scale/templates/cluster-role-snapshotter.yaml.j2
+++ b/operator/roles/csi-scale/templates/cluster-role-snapshotter.yaml.j2
@@ -13,14 +13,6 @@ rules:
 - apiGroups:
   - ''
   resources:
-  - secrets
-  verbs:
-  - get
-  - list
-
-- apiGroups:
-  - ''
-  resources:
   - events
   verbs:
   - list

--- a/operator/roles/csi-scale/templates/csi-plugin-snapshotter.yaml.j2
+++ b/operator/roles/csi-scale/templates/csi-plugin-snapshotter.yaml.j2
@@ -47,6 +47,7 @@ spec:
           args:
             - "--csi-address=$(ADDRESS)"
             - "--v=5" # Debugging
+            - "--leader-election=false"
           env:
             - name: ADDRESS
               value: /var/lib/kubelet/plugins/spectrumscale.csi.ibm.com/csi.sock

--- a/tools/scripts/ci/install_minikube.sh
+++ b/tools/scripts/ci/install_minikube.sh
@@ -24,7 +24,7 @@ echo $HOME
 
 # Start minikube and chown for minikub.
 sudo chown -R travis: /home/travis/.minikube/
-sudo minikube start --driver=none --kubernetes-version=${KUBE_VERSION} --cpus=2
+sudo minikube start --driver=none --kubernetes-version=${KUBE_VERSION} --extra-config=kubeadm.ignore-preflight-errors=NumCPU --force
 minikube update-context
 eval $(minikube docker-env)
 

--- a/tools/scripts/ci/install_minikube.sh
+++ b/tools/scripts/ci/install_minikube.sh
@@ -24,7 +24,7 @@ echo $HOME
 
 # Start minikube and chown for minikub.
 sudo chown -R travis: /home/travis/.minikube/
-sudo minikube start --driver=none --kubernetes-version=${KUBE_VERSION} --cpu=2
+sudo minikube start --driver=none --kubernetes-version=${KUBE_VERSION} --cpus=2
 minikube update-context
 eval $(minikube docker-env)
 

--- a/tools/scripts/ci/install_minikube.sh
+++ b/tools/scripts/ci/install_minikube.sh
@@ -24,7 +24,7 @@ echo $HOME
 
 # Start minikube and chown for minikub.
 sudo chown -R travis: /home/travis/.minikube/
-sudo minikube start --vm-driver=none --kubernetes-version=${KUBE_VERSION}
+sudo minikube start --driver=none --kubernetes-version=${KUBE_VERSION} --cpu=2
 minikube update-context
 eval $(minikube docker-env)
 


### PR DESCRIPTION
Changes :

1. Change for using csi-snapshotter 4.0.0 version for snapshot sidecar 
2. Changes in snapshots.md for using minimum OCP 4.7 for snapshot use
3. Removed secret permission from snapshot cluster role as it is not required in our CSI driver 
More details here :
https://github.com/kubernetes-csi/external-snapshotter/blob/release-4.0/deploy/kubernetes/csi-snapshotter/rbac-csi-snapshotter.yaml

4. Make changes for travis CI to run (removed CPU requirement from minikube)
5. Made changes in args for csisnapshot sidecar according to https://github.com/kubernetes-csi/external-snapshotter/blob/release-4.0/deploy/kubernetes/csi-snapshotter/setup-csi-snapshotter.yaml#L91 