### PR TITLE
add CSIScaleOperators to scale category

### DIFF
--- a/operator/deploy/crds/csiscaleoperators.csi.ibm.com.crd.yaml
+++ b/operator/deploy/crds/csiscaleoperators.csi.ibm.com.crd.yaml
@@ -16,6 +16,8 @@ spec:
       type: string
   group: csi.ibm.com
   names:
+    categories:
+    - scale
     kind: CSIScaleOperator
     listKind: CSIScaleOperatorList
     plural: csiscaleoperators


### PR DESCRIPTION
I think it would be user-friendly to have a `scale` category, which all Spectrum Scale related custom resources (CRs) can be under.

This allows users to do `kubectl get scale` and see their resources, akin to doing `kubectl get all`

```bash
oc get scale 
                           
NAME                                                  READY
csiscaleoperator.csi.ibm.com/ibm-spectrum-scale-csi   

NAME                                            CLUSTER NAME
scalecluster.scale.ibm.com/ibm-spectrum-scale
```

Thoughts?