### PR TITLE
NodePublish fix for handling mount dir behaviour change in k8s 1.20

### DIFF
--- a/driver/csiplugin/nodeserver.go
+++ b/driver/csiplugin/nodeserver.go
@@ -76,13 +76,11 @@ func (ns *ScaleNodeServer) NodePublishVolume(ctx context.Context, req *csi.NodeP
 	}
 
 	glog.Infof("Target SpectrumScale Symlink Path : %v\n", targetSlnkPath[1])
-
-	if _, err := os.Stat(targetPath); err == nil {
-		args := []string{targetPath}
-		outputBytes, err := executeCmd("rmdir", args)
-		glog.Infof("Cmd rmdir args: %v Output: %v", args, outputBytes)
+	if _, err := os.Lstat(targetPath); !os.IsNotExist(err) {
+		glog.V(4).Infof("NodePublishVolume - deleting the targetPath %#v", targetPath)
+		err := os.Remove(targetPath)
 		if err != nil {
-			return nil, err
+			return nil, status.Error(codes.Internal, err.Error())
 		}
 	}
 
@@ -90,7 +88,7 @@ func (ns *ScaleNodeServer) NodePublishVolume(ctx context.Context, req *csi.NodeP
 	outputBytes, err := executeCmd("/bin/ln", args)
 	glog.Infof("Cmd /bin/ln args: %v Output: %v", args, outputBytes)
 	if err != nil {
-		return nil, err
+		return nil, status.Error(codes.Internal, err.Error())
 	}
 
 	glog.V(4).Infof("Successfully mounted %s", targetPath)


### PR DESCRIPTION
k8s stopped creating the mount dir starting k8s 1.20. 
Driver was failing to mount due to error in removing the non-existent directory
**Change :** 
- Delete the Dir/Symlink on NodePublish call
- Replaced rmdir with go native remove
- replaced ln with go native function
- use Remove instead of RemoveAll in NodeUnpublish

Test suggestion : 
- try on k8s 1.20 and 1.19
- try creating application pod with pvc
- try rebooting the node where app pod is running
- try rebooting the GUI node of CNSA where app pod is also running

closes #384 