### PR TITLE
Changes in snap.sh and olm upgrade automation 

### DIFF
--- a/tools/ansible/k8s-olm-test-playbook.yaml
+++ b/tools/ansible/k8s-olm-test-playbook.yaml
@@ -12,6 +12,7 @@
       - 1.1.0
       - 2.0.0
       - 2.1.0
+      - 2.2.0
 
     QUAY_USERNAME: "QUAY_USERNAME"
     QUAY_PASSWORD: "QUAY_PASSWORD"
@@ -21,10 +22,10 @@
 
     # Contains the CSV directories for all of the versions to be tested.
     # This  can  be a  copy of https://github.com/operator-framework/community-operators/tree/master/community-operators/ibm-spectrum-scale-csi-operator
-    # To  add dev version just copy the version directory from operator/deploy/olm-catalog/ibm-spectrum-scale-csi-operator/
+    # To  add dev version just copy the version directory from operator/config/olm-catalog/ibm-spectrum-scale-csi-operator/
     # Must be full directory name
 
-    OPERATOR_DIR:  /root/ibm-spectrum-scale-csi/operator/deploy/olm-catalog/ibm-spectrum-scale-csi-operator
+    OPERATOR_DIR:  /root/ibm-spectrum-scale-csi/operator/config/olm-catalog/ibm-spectrum-scale-csi-operator
     #It can also be /root/demo/community-operators/community-operators/ibm-spectrum-scale-csi-operator
 
     # Do not change following variables

--- a/tools/ansible/oc-olm-test-playbook.yaml
+++ b/tools/ansible/oc-olm-test-playbook.yaml
@@ -12,6 +12,7 @@
       - 1.1.0
       - 2.0.0
       - 2.1.0
+      - 2.2.0
 
     QUAY_USERNAME: "QUAY_USERNAME"
     QUAY_PASSWORD: "QUAY_PASSWORD"
@@ -21,7 +22,7 @@
 
     # Contains the CSV directories for all of the versions to be tested.
     # This  can  be a  copy of https://github.com/operator-framework/community-operators/tree/master/community-operators/ibm-spectrum-scale-csi-operator
-    # To  add dev version just copy the version directory from operator/deploy/olm-catalog/ibm-spectrum-scale-csi-operator/
+    # To  add dev version just copy the version directory from operator/config/olm-catalog/ibm-spectrum-scale-csi-operator/
     # Must be full directory name
 
     OPERATOR_DIR:  /root/ibm-spectrum-scale-csi/operator/config/olm-catalog/ibm-spectrum-scale-csi-operator

--- a/tools/ansible/olmupgrade.md
+++ b/tools/ansible/olmupgrade.md
@@ -44,13 +44,14 @@ OPERATOR_VERSIONS:
   - 1.1.0
   - 2.0.0
   - 2.1.0
+  - 2.2.0
 
 # Quay username with write access to the application and Quay Password
 QUAY_USERNAME: "QUAY_USERNAME"
 QUAY_PASSWORD: "QUAY_PASSWORD"
 
 # Check OPERATOR_DIR location is correct
-OPERATOR_DIR:  /root/ibm-spectrum-scale-csi/operator/deploy/olm-catalog/ibm-spectrum-scale-csi-operator
+OPERATOR_DIR:  /root/ibm-spectrum-scale-csi/operator/config/olm-catalog/ibm-spectrum-scale-csi-operator
 ```
 3. Run OLM upgrade playbook using following command
 ```
@@ -125,9 +126,10 @@ OPERATOR_VERSIONS:
   - 1.1.0
   - 2.0.0
   - 2.1.0
+  - 2.2.0
 
 # Check OPERATOR_DIR location is correct
-OPERATOR_DIR:  /root/ibm-spectrum-scale-csi/operator/deploy/olm-catalog/ibm-spectrum-scale-csi-operator
+OPERATOR_DIR:  /root/ibm-spectrum-scale-csi/operator/config/olm-catalog/ibm-spectrum-scale-csi-operator
 ```
 6. Run following command
 ```

--- a/tools/spectrum-scale-driver-snap.sh
+++ b/tools/spectrum-scale-driver-snap.sh
@@ -110,15 +110,11 @@ for opPodName in $($cmd get pods --no-headers --namespace "$ns" -l app.kubernete
   $klog pod/"${opPodName}" --all-containers  --previous > "${logdir}"/"${opPodName}"-previous.log 2>&1 || :
 done
 
-describe_label_cmd="$cmd describe all,cm,secret,storageclass,pvc,ds,serviceaccount -l product=${CSI_SPECTRUM_SCALE_LABEL} --namespace $ns"
+describe_label_cmd="$cmd describe all,cm,secret,storageclass,pvc,ds,serviceaccount,clusterroles,clusterrolebindings -l product=${CSI_SPECTRUM_SCALE_LABEL} --namespace $ns"
 echo "$describe_label_cmd"
 $describe_label_cmd > "$describe_all_per_label" 2>&1 || :
 
-describe_clusterroles="$cmd describe clusterroles/external-provisioner-runner clusterrolebindings/csi-provisioner-role clusterroles/external-attacher-runner clusterrolebindings/csi-provisioner-role clusterroles/csi-nodeplugin clusterrolebindings/csi-nodeplugin clusterroles/ibm-spectrum-scale-csi-snapshotter clusterrolebindings/ibm-spectrum-scale-csi-snapshotter clusterroles/snapshot-controller-runner clusterrolebindings/snapshot-controller-role --namespace $ns"
-echo "$describe_clusterroles"
-$describe_clusterroles >> "$describe_all_per_label" 2>&1 || :
-
-get_label_cmd="$cmd get all,cm,secret,storageclass,pvc,ds,serviceaccount --namespace $ns -l product=${CSI_SPECTRUM_SCALE_LABEL}"
+get_label_cmd="$cmd get all,cm,secret,storageclass,pvc,serviceaccount,clusterroles,clusterrolebindings --namespace $ns -l product=${CSI_SPECTRUM_SCALE_LABEL}"
 echo "$get_label_cmd"
 $get_label_cmd > "$get_all_per_label" 2>&1 || :
 


### PR DESCRIPTION
1. Fix for clusterroles and clusterrolebindings
2. added support for 2.2.0 in olm upgrade automation and olm-catalog path