### PR TITLE
fixing the listquota checks

### DIFF
--- a/driver/csiplugin/connectors/rest_v2.go
+++ b/driver/csiplugin/connectors/rest_v2.go
@@ -766,8 +766,8 @@ func (s *spectrumRestV2) ListFilesetQuota(filesystemName string, filesetName str
 		return "", err
 	}
 
-	if (Quota_v2{}) == listQuotaResponse {
-		return "", nil
+	if listQuotaResponse.BlockLimit > 0 {
+		return fmt.Sprintf("%dK", listQuotaResponse.BlockLimit), nil
 	} else {
 		glog.Errorf("No quota information found for fileset %s", filesetName)
 		return "", nil


### PR DESCRIPTION
If set quota is set correctly in last attempt of volume creation then CSI driver must not retry set quota. 

Signed-off-by: Deepak R Ghuge <deeghuge@in.ibm.com>