### PR TITLE
replace affinity label from beta.kubernetes.io/arch to kubernetes.io/arch

### DIFF
--- a/generated/installer/ibm-spectrum-scale-csi-operator-dev.yaml
+++ b/generated/installer/ibm-spectrum-scale-csi-operator-dev.yaml
@@ -33,7 +33,7 @@ spec:
           requiredDuringSchedulingIgnoredDuringExecution:
             nodeSelectorTerms:
             - matchExpressions:
-              - key: beta.kubernetes.io/arch
+              - key: kubernetes.io/arch
                 operator: Exists
       containers:
       - args:

--- a/generated/installer/ibm-spectrum-scale-csi-operator.yaml
+++ b/generated/installer/ibm-spectrum-scale-csi-operator.yaml
@@ -33,7 +33,7 @@ spec:
           requiredDuringSchedulingIgnoredDuringExecution:
             nodeSelectorTerms:
             - matchExpressions:
-              - key: beta.kubernetes.io/arch
+              - key: kubernetes.io/arch
                 operator: Exists
       containers:
       - args:

--- a/operator/config/manager/manager.yaml
+++ b/operator/config/manager/manager.yaml
@@ -34,7 +34,7 @@ spec:
           requiredDuringSchedulingIgnoredDuringExecution:
             nodeSelectorTerms:
               - matchExpressions:
-                  - key: beta.kubernetes.io/arch
+                  - key: kubernetes.io/arch
                     operator: Exists
       containers:
         - name: operator

--- a/operator/config/manifests/bases/ibm-spectrum-scale-csi-operator.clusterserviceversion.yaml
+++ b/operator/config/manifests/bases/ibm-spectrum-scale-csi-operator.clusterserviceversion.yaml
@@ -366,7 +366,7 @@ spec:
                   requiredDuringSchedulingIgnoredDuringExecution:
                     nodeSelectorTerms:
                     - matchExpressions:
-                      - key: beta.kubernetes.io/arch
+                      - key: kubernetes.io/arch
                         operator: Exists
               containers:
               - name: operator

--- a/operator/config/olm-catalog/ibm-spectrum-scale-csi-operator/2.3.0/ibm-spectrum-scale-csi-operator.v2.3.0.clusterserviceversion.yaml
+++ b/operator/config/olm-catalog/ibm-spectrum-scale-csi-operator/2.3.0/ibm-spectrum-scale-csi-operator.v2.3.0.clusterserviceversion.yaml
@@ -366,7 +366,7 @@ spec:
                   requiredDuringSchedulingIgnoredDuringExecution:
                     nodeSelectorTerms:
                     - matchExpressions:
-                      - key: beta.kubernetes.io/arch
+                      - key: kubernetes.io/arch
                         operator: Exists
               containers:
               - name: operator

--- a/operator/config/olm-catalog/ibm-spectrum-scale-csi-operator/manifests/ibm-spectrum-scale-csi-operator.clusterserviceversion.yaml
+++ b/operator/config/olm-catalog/ibm-spectrum-scale-csi-operator/manifests/ibm-spectrum-scale-csi-operator.clusterserviceversion.yaml
@@ -366,7 +366,7 @@ spec:
                   requiredDuringSchedulingIgnoredDuringExecution:
                     nodeSelectorTerms:
                     - matchExpressions:
-                      - key: beta.kubernetes.io/arch
+                      - key: kubernetes.io/arch
                         operator: Exists
               containers:
               - name: operator


### PR DESCRIPTION
This is a requirement for casebundle linting. And beta.kubernetes.io/arch got deprecated in k8s 1.18 also.

For kubernetes reference : 
https://github.com/kubernetes/kubernetes/pull/89462
beta.kubernetes.io/arch is already deprecated since v1.14, are targeted for removal in v1.18 #89462