### PR TITLE
Add a copy of the default Kustomization to the config dir

### DIFF
--- a/kustomization.yaml
+++ b/kustomization.yaml
@@ -1,0 +1,2 @@
+resources:
+  - operator/config/default


### PR DESCRIPTION
In order to copy the manifests via URL, the directories in the Kustomization (manager, rbac and crd) must either be within the same directory as the Kustomization or in a subdirectory. In this PR I'm adding a copy of the kustomization.yaml to the config directory so that this can be used to pull the CSI manifests via URL.