### PR TITLE
Adding and parsing new StorageClass parameters

### DIFF
--- a/driver/csiplugin/connectors/connectors.go
+++ b/driver/csiplugin/connectors/connectors.go
@@ -97,6 +97,10 @@ const (
 	UserSpecifiedNodeClass      string = "nodeClass"
 	UserSpecifiedPermissions    string = "permissions"
 
+	UserSpecifiedSCType      string = "scType"
+	UserSpecifiedCompression string = "compression"
+	UserSpecifiedTier        string = "tier"
+
 	FilesetComment string = "Fileset created by IBM Container Storage Interface driver"
 )
 


### PR DESCRIPTION
- Added and parsed these 3 new parameters of StorageClass: scType, compression, tier
- Added a place-holder where volume ID change will be required based on parsing new StorageClass
- Some indentation and whitespace auto fixes by vscode go fmt plugin

An example of new StorageClass:
```
apiVersion: storage.k8s.io/v1
kind: StorageClass
metadata:
  name: new-sc
provisioner: spectrumscale.csi.ibm.com
parameters:
  volBackendFs: "fs1"
  scType: "Advanced"
  compression: "true"
  tier: "fast"
reclaimPolicy: Delete

```

## Pull request checklist

<!-- Add your one liner release notes here -->
<!-- eg... -->
<!--   - Major functionality adds -->
<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->
<!--   - are you changing our ScaleCluster CR file? -->
```release-notes

```

## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [ ] Bugfix
- [ ] Feature Enhancement
- [ ] Test Automation 
- [ ] Code Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Community Operator listing 
- [ ] Other (please describe): 


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying -->
-

## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->
-

## How risky is this change?
- [ ] Small, isolated change
- [ ] Medium, requires regression testing
- [ ] Large, requires functional and regression testing 

