### PR TITLE
Add compression/replication/tiering support for storageclass

### DIFF
--- a/driver/csiplugin/connectors/connectors.go
+++ b/driver/csiplugin/connectors/connectors.go
@@ -67,7 +67,7 @@ type SpectrumScaleConnector interface {
 	GetFileSetResponseFromId(filesystemName string, Id string) (Fileset_v2, error)
 	GetFileSetResponseFromName(filesystemName string, filesetName string) (Fileset_v2, error)
 	SetFilesystemPolicy(policy *Policy, filesystemName string) error
-	GetPoolInfoFromName(storagePoolName string, filesystemName string) error
+	GetTierInfoFromName(tierName string, filesystemName string) error
 	IsValidNodeclass(nodeclass string) (bool, error)
 	IsSnapshotSupported() (bool, error)
 
@@ -86,22 +86,18 @@ type SpectrumScaleConnector interface {
 }
 
 const (
-	UserSpecifiedFilesetType    string = "filesetType"
-	UserSpecifiedFilesetTypeDep string = "fileset-type"
-	UserSpecifiedInodeLimit     string = "inodeLimit"
-	UserSpecifiedInodeLimitDep  string = "inode-limit"
-	UserSpecifiedUid            string = "uid"
-	UserSpecifiedGid            string = "gid"
-	UserSpecifiedClusterId      string = "clusterId"
-	UserSpecifiedParentFset     string = "parentFileset"
-	UserSpecifiedVolBackendFs   string = "volBackendFs"
-	UserSpecifiedVolDirPath     string = "volDirBasePath"
-	UserSpecifiedNodeClass      string = "nodeClass"
-	UserSpecifiedPermissions    string = "permissions"
-	UserSpecifiedCompression    string = "compression"
-	UserSpecifiedReplication    string = "replication"
-	UserSpecifiedStoragePool    string = "storagePool"
-
+	UserSpecifiedFilesetType      string = "filesetType"
+	UserSpecifiedFilesetTypeDep   string = "fileset-type"
+	UserSpecifiedInodeLimit       string = "inodeLimit"
+	UserSpecifiedInodeLimitDep    string = "inode-limit"
+	UserSpecifiedUid              string = "uid"
+	UserSpecifiedGid              string = "gid"
+	UserSpecifiedClusterId        string = "clusterId"
+	UserSpecifiedParentFset       string = "parentFileset"
+	UserSpecifiedVolBackendFs     string = "volBackendFs"
+	UserSpecifiedVolDirPath       string = "volDirBasePath"
+	UserSpecifiedNodeClass        string = "nodeClass"
+	UserSpecifiedPermissions      string = "permissions"
 	UserSpecifiedStorageClassType string = "type"
 	UserSpecifiedCompression      string = "compression"
 	UserSpecifiedTier             string = "tier"

--- a/driver/csiplugin/connectors/connectors.go
+++ b/driver/csiplugin/connectors/connectors.go
@@ -70,6 +70,7 @@ type SpectrumScaleConnector interface {
 	GetTierInfoFromName(tierName string, filesystemName string) error
 	IsValidNodeclass(nodeclass string) (bool, error)
 	IsSnapshotSupported() (bool, error)
+	CheckIfDefaultPolicyPartitionExists(partitionName string, filesystemName string) bool
 
 	//Snapshot operations
 	WaitForJobCompletion(statusCode int, jobID uint64) error

--- a/driver/csiplugin/connectors/connectors.go
+++ b/driver/csiplugin/connectors/connectors.go
@@ -67,6 +67,7 @@ type SpectrumScaleConnector interface {
 	GetFileSetResponseFromId(filesystemName string, Id string) (Fileset_v2, error)
 	GetFileSetResponseFromName(filesystemName string, filesetName string) (Fileset_v2, error)
 	SetFilesystemPolicy(policy *Policy, filesystemName string) error
+	GetPoolInfoFromName(storagePoolName string, filesystemName string) error
 	IsValidNodeclass(nodeclass string) (bool, error)
 	IsSnapshotSupported() (bool, error)
 

--- a/driver/csiplugin/connectors/connectors.go
+++ b/driver/csiplugin/connectors/connectors.go
@@ -99,7 +99,7 @@ const (
 	UserSpecifiedPermissions    string = "permissions"
 	UserSpecifiedCompression    string = "compression"
 	UserSpecifiedReplication    string = "replication"
-	UserSpecifiedTier           string = "tier"
+	UserSpecifiedStoragePool    string = "storagePool"
 
 	UserSpecifiedStorageClassType string = "type"
 	UserSpecifiedCompression      string = "compression"

--- a/driver/csiplugin/connectors/connectors.go
+++ b/driver/csiplugin/connectors/connectors.go
@@ -66,7 +66,7 @@ type SpectrumScaleConnector interface {
 	DeleteSymLnk(filesystemName string, LnkName string) error
 	GetFileSetResponseFromId(filesystemName string, Id string) (Fileset_v2, error)
 	GetFileSetResponseFromName(filesystemName string, filesetName string) (Fileset_v2, error)
-
+	SetFilesystemPolicy(policy *Policy, filesystemName string) error
 	IsValidNodeclass(nodeclass string) (bool, error)
 	IsSnapshotSupported() (bool, error)
 
@@ -97,6 +97,9 @@ const (
 	UserSpecifiedVolDirPath     string = "volDirBasePath"
 	UserSpecifiedNodeClass      string = "nodeClass"
 	UserSpecifiedPermissions    string = "permissions"
+	UserSpecifiedCompression    string = "compression"
+	UserSpecifiedReplication    string = "replication"
+	UserSpecifiedTier           string = "tier"
 
 	UserSpecifiedStorageClassType string = "type"
 	UserSpecifiedCompression      string = "compression"

--- a/driver/csiplugin/connectors/resources.go
+++ b/driver/csiplugin/connectors/resources.go
@@ -659,6 +659,11 @@ type UnmountFilesystemRequest struct {
 	Force bool     `json:"force,omitempty"`
 }
 
+type Policy struct {
+	Policy    string `json:"policy,omitempty"`
+	Partition string `json:"partition,omitempty"`
+}
+
 const (
 	UserSpecifiedUID string = "uid"
 	UserSpecifiedGID string = "gid"

--- a/driver/csiplugin/connectors/resources.go
+++ b/driver/csiplugin/connectors/resources.go
@@ -662,6 +662,7 @@ type UnmountFilesystemRequest struct {
 type Policy struct {
 	Policy    string `json:"policy,omitempty"`
 	Partition string `json:"partition,omitempty"`
+	Priority  int    `json:"priority,omitempty"`
 }
 
 const (

--- a/driver/csiplugin/connectors/rest_v2.go
+++ b/driver/csiplugin/connectors/rest_v2.go
@@ -1387,3 +1387,18 @@ func (s *spectrumRestV2) GetTierInfoFromName(tierName string, filesystemName str
 
 	return nil
 }
+
+func (s *spectrumRestV2) CheckIfDefaultPolicyPartitionExists(partitionName string, filesystemName string) bool {
+	glog.V(4).Infof("rest_v2 CheckPolicyPartitionExists. name %s, filesystem %s", partitionName, filesystemName)
+
+	partitionURL := utils.FormatURL(s.endpoint, fmt.Sprintf("scalemgmt/v2/filesystems/%s/partition/%s", filesystemName, partitionName))
+	getPartitionResponse := GenericResponse{}
+
+	// If it does or doesn't exist and we get an error we will default to just setting it again as an override
+	err := s.doHTTP(partitionURL, "GET", &getPartitionResponse, nil)
+	if err != nil {
+		return false
+	}
+
+	return true
+}

--- a/driver/csiplugin/connectors/rest_v2.go
+++ b/driver/csiplugin/connectors/rest_v2.go
@@ -1349,3 +1349,18 @@ func (s *spectrumRestV2) IsNodeComponentHealthy(nodeName string, component strin
 
 	return true, nil
 }
+
+func (s *spectrumRestV2) SetFilesystemPolicy(policy *Policy, filesystemName string) error {
+	glog.V(4).Infof("rest_v2 setFilesystemPolicy for filesystem %s", filesystemName)
+
+	setPolicyURL := utils.FormatURL(s.endpoint, fmt.Sprintf("scalemgmt/v2/filesystems/%s/policies", filesystemName))
+	status := Status{}
+
+	err := s.doHTTP(setPolicyURL, "PUT", &status, policy)
+	if err != nil {
+		glog.Errorf("Unable to set filesystem policy: %v", status.Message)
+		return err
+	}
+
+	return nil
+}

--- a/driver/csiplugin/connectors/rest_v2.go
+++ b/driver/csiplugin/connectors/rest_v2.go
@@ -667,7 +667,6 @@ func (s *spectrumRestV2) GetFilesetsInodeSpace(filesystemName string, inodeSpace
 	return getFilesetsResponse.Filesets, nil
 }
 
-
 func (s *spectrumRestV2) IsFilesetLinked(filesystemName string, filesetName string) (bool, error) {
 	glog.V(4).Infof("rest_v2 IsFilesetLinked. filesystem: %s, fileset: %s", filesystemName, filesetName)
 
@@ -1371,17 +1370,17 @@ func (s *spectrumRestV2) SetFilesystemPolicy(policy *Policy, filesystemName stri
 	return nil
 }
 
-func (s *spectrumRestV2) GetPoolInfoFromName(storagePoolName string, filesystemName string) error {
-	glog.V(4).Infof("rest_v2 GetPoolInfoFromName. name %s, filesystem %s", storagePoolName, filesystemName)
+func (s *spectrumRestV2) GetTierInfoFromName(tierName string, filesystemName string) error {
+	glog.V(4).Infof("rest_v2 GetTierInfoFromName. name %s, filesystem %s", tierName, filesystemName)
 
-	poolURL := utils.FormatURL(s.endpoint, fmt.Sprintf("scalemgmt/v2/filesystems/%s/pools/%s", filesystemName, storagePoolName))
+	poolURL := utils.FormatURL(s.endpoint, fmt.Sprintf("scalemgmt/v2/filesystems/%s/pools/%s", filesystemName, tierName))
 	getPoolResponse := GenericResponse{}
 
 	err := s.doHTTP(poolURL, "GET", &getPoolResponse, nil)
 	if err != nil {
-		glog.Errorf("Unable to get pool: %s info %v", storagePoolName, getPoolResponse.Status.Message)
-		if strings.Contains(getPoolResponse.Status.Message, "Invalid value in 'storagePool'") {
-			return fmt.Errorf("invalid storagePool '%s' specified for filesystem %s", storagePoolName, filesystemName)
+		glog.Errorf("Unable to get tier: %s info %v", tierName, getPoolResponse.Status.Message)
+		if strings.Contains(getPoolResponse.Status.Message, "Invalid value in 'tier'") {
+			return fmt.Errorf("invalid tier '%s' specified for filesystem %s", tierName, filesystemName)
 		}
 		return err
 	}

--- a/driver/csiplugin/controllerserver.go
+++ b/driver/csiplugin/controllerserver.go
@@ -642,6 +642,11 @@ func (cs *ScaleControllerServer) CreateVolume(ctx context.Context, req *csi.Crea
 	}
 
 	if scaleVol.IsFilesetBased && scaleVol.StoragePool != "" {
+
+		if err := scaleVol.Connector.GetPoolInfoFromName(scaleVol.StoragePool, scaleVol.VolBackendFs); err != nil {
+			return nil, err
+		}
+
 		rule := "RULE 'P%sR%d' SET POOL '%s' REPLICATE(%d) WHERE FILESET_NAME LIKE 'pvc-%%-P%s-R%d%%'"
 		policy := connectors.Policy{}
 

--- a/driver/csiplugin/controllerserver.go
+++ b/driver/csiplugin/controllerserver.go
@@ -637,24 +637,43 @@ func (cs *ScaleControllerServer) CreateVolume(ctx context.Context, req *csi.Crea
 
 	if scaleVol.IsFilesetBased && scaleVol.Compression != "" {
 		glog.Infof("createvolume: compression is enabled: changing volume name")
-		scaleVol.VolName = fmt.Sprintf("%s-COMPRESS%s", scaleVol.VolName, strings.ToUpper(scaleVol.Compression))
+		scaleVol.VolName = fmt.Sprintf("%s-COMPRESS%scsi", scaleVol.VolName, strings.ToUpper(scaleVol.Compression))
 	}
 
 	if scaleVol.IsFilesetBased && scaleVol.Tier != "" {
+		if err := cs.checkVolTierSupport(volFsInfo.Version); err != nil {
+			return nil, err
+		}
 
 		if err := scaleVol.Connector.GetTierInfoFromName(scaleVol.Tier, scaleVol.VolBackendFs); err != nil {
 			return nil, err
 		}
 
-		rule := "RULE 'csi-T%s' SET POOL '%s' WHERE FILESET_NAME LIKE 'pvc-%%-T%s%%'"
+		rule := "RULE 'csi-T%s' SET POOL '%s' WHERE FILESET_NAME LIKE 'pvc-%%-T%scsi%%'"
 		policy := connectors.Policy{}
 
 		policy.Policy = fmt.Sprintf(rule, scaleVol.Tier, scaleVol.Tier, scaleVol.Tier)
-
+		policy.Priority = -5
 		policy.Partition = fmt.Sprintf("csi-T%s", scaleVol.Tier)
 
-		scaleVol.VolName = fmt.Sprintf("%s-T%s", scaleVol.VolName, scaleVol.Tier)
+		scaleVol.VolName = fmt.Sprintf("%s-T%scsi", scaleVol.VolName, scaleVol.Tier)
 		scaleVol.Connector.SetFilesystemPolicy(&policy, scaleVol.VolBackendFs)
+
+		// Since we are using a SET POOL rule, if there is not already a default rule in place in the policy partition
+		// then all files that do not match our rules will have no defined place to go. This sets a default rule with
+		// "lower" priority than the main policy as a catch all. If there is already a default rule in the main policy
+		// file then that will take precedence
+		// TODO: get pool info and find first non-system data pool and use that if possible, otherwise system
+		defaultPartitionName := "csi-defaultRule"
+		if !scaleVol.Connector.CheckIfDefaultPolicyPartitionExists(defaultPartitionName, scaleVol.VolBackendFs) {
+			glog.Infof("createvolume: setting default policy partition rule")
+
+			defaultPolicy := connectors.Policy{}
+			defaultPolicy.Policy = "RULE 'csi-defaultRule' SET POOL 'system'"
+			defaultPolicy.Priority = 5
+			defaultPolicy.Partition = defaultPartitionName
+			scaleVol.Connector.SetFilesystemPolicy(&defaultPolicy, scaleVol.VolBackendFs)
+		}
 	}
 
 	volReqInProcess, err := cs.IfSameVolReqInProcess(scaleVol)
@@ -939,6 +958,17 @@ func (cs *ScaleControllerServer) checkMinScaleVersion(conn connectors.SpectrumSc
 	return true, nil
 }
 
+func (cs *ScaleControllerServer) checkMinFsVersion(fsVersion string, version string) bool {
+	/* Assuming Filesystem version (fsVersion) in a format like 27.00 and version as 2700 */
+	assembledFsVer := strings.ReplaceAll(fsVersion, ".", "")
+
+	glog.Infof("fs version (%s) vs min required version (%s)", assembledFsVer, version)
+	if assembledFsVer < version {
+		return false
+	}
+	return true
+}
+
 func (cs *ScaleControllerServer) checkSnapshotSupport(conn connectors.SpectrumScaleConnector) error {
 	/* Verify Spectrum Scale Version is not below 5.1.1-0 */
 	versionCheck, err := cs.checkMinScaleVersion(conn, "5110")
@@ -961,6 +991,17 @@ func (cs *ScaleControllerServer) checkVolCloneSupport(conn connectors.SpectrumSc
 
 	if !versionCheck {
 		return status.Error(codes.FailedPrecondition, "the minimum required Spectrum Scale version for volume cloning support with CSI is 5.1.2-1")
+	}
+	return nil
+}
+
+func (cs *ScaleControllerServer) checkVolTierSupport(version string) error {
+	/* Verify Spectrum Scale Filesystem Version is not below 5.1.3-0 (27.00) */
+
+	versionCheck := cs.checkMinFsVersion(version, "2700")
+
+	if !versionCheck {
+		return status.Error(codes.FailedPrecondition, "the minimum required Spectrum Scale Filesystem version for tiering support with CSI is 5.1.3-0")
 	}
 	return nil
 }

--- a/driver/csiplugin/gpfs_util.go
+++ b/driver/csiplugin/gpfs_util.go
@@ -64,7 +64,7 @@ type scaleVolume struct {
 	ConsistencyGroup   string                            `json:"consistencyGroup"`
 	Compression        string                            `json:"compression"`
 	Replication        int                               `json:"replication"`
-	Tier               string                            `json:"tier"`
+	StoragePool        string                            `json:"storagePool"`
 }
 
 type scaleVolId struct {
@@ -143,7 +143,7 @@ func getScaleVolumeOptions(volOptions map[string]string) (*scaleVolume, error) {
 	permissions, isPermissionsSpecified := volOptions[connectors.UserSpecifiedPermissions]
 	compression, isCompressionSpecified := volOptions[connectors.UserSpecifiedCompression]
 	replication, isReplicationSpecified := volOptions[connectors.UserSpecifiedReplication]
-	tier, isTierSpecified := volOptions[connectors.UserSpecifiedTier]
+	storagePool, isStoragePoolSpecified := volOptions[connectors.UserSpecifiedStoragePool]
 
 	storageClassType, isSCTypeSpecified := volOptions[connectors.UserSpecifiedStorageClassType]
 	compression, isCompressionSpecified := volOptions[connectors.UserSpecifiedCompression]
@@ -352,9 +352,9 @@ func getScaleVolumeOptions(volOptions map[string]string) (*scaleVolume, error) {
 		glog.V(5).Infof("gpfs_util replication was set: %d", val)
 	}
 
-	if isTierSpecified && tier != "" {
-		scaleVol.Tier = tier
-		glog.V(5).Infof("gpfs_util tier was set: %s", tier)
+	if isStoragePoolSpecified && storagePool != "" {
+		scaleVol.StoragePool = storagePool
+		glog.V(5).Infof("gpfs_util storagePool was set: %s", storagePool)
 	}
 
 	return scaleVol, nil

--- a/driver/csiplugin/gpfs_util.go
+++ b/driver/csiplugin/gpfs_util.go
@@ -325,6 +325,12 @@ func getScaleVolumeOptions(volOptions map[string]string) (*scaleVolume, error) {
 	scaleVol.ConsistencyGroup = volOptions["csi.storage.k8s.io/pvc/namespace"]
 
 	if isCompressionSpecified {
+		// Default compression will be Z if set but not specified
+		if strings.ToLower(compression) == "true" {
+			glog.V(5).Infof("gpfs_util compression was set to true. Defaulting to Z")
+			compression = "z"
+		}
+
 		if !IsValidCompressionAlgorithm(compression) {
 			glog.V(5).Infof("gpfs_util invalid compression algorithm specified: %s",
 				compression)

--- a/driver/csiplugin/gpfs_util.go
+++ b/driver/csiplugin/gpfs_util.go
@@ -63,8 +63,7 @@ type scaleVolume struct {
 	StorageClassType   string                            `json:"storageClassType"`
 	ConsistencyGroup   string                            `json:"consistencyGroup"`
 	Compression        string                            `json:"compression"`
-	Replication        int                               `json:"replication"`
-	StoragePool        string                            `json:"storagePool"`
+	Tier               string                            `json:"tier"`
 }
 
 type scaleVolId struct {
@@ -141,10 +140,6 @@ func getScaleVolumeOptions(volOptions map[string]string) (*scaleVolume, error) {
 	parentFileset, isparentFilesetSpecified := volOptions[connectors.UserSpecifiedParentFset]
 	nodeClass, isNodeClassSpecified := volOptions[connectors.UserSpecifiedNodeClass]
 	permissions, isPermissionsSpecified := volOptions[connectors.UserSpecifiedPermissions]
-	compression, isCompressionSpecified := volOptions[connectors.UserSpecifiedCompression]
-	replication, isReplicationSpecified := volOptions[connectors.UserSpecifiedReplication]
-	storagePool, isStoragePoolSpecified := volOptions[connectors.UserSpecifiedStoragePool]
-
 	storageClassType, isSCTypeSpecified := volOptions[connectors.UserSpecifiedStorageClassType]
 	compression, isCompressionSpecified := volOptions[connectors.UserSpecifiedCompression]
 	tier, isTierSpecified := volOptions[connectors.UserSpecifiedTier]
@@ -340,21 +335,9 @@ func getScaleVolumeOptions(volOptions map[string]string) (*scaleVolume, error) {
 		glog.V(5).Infof("gpfs_util compression was set to %s", compression)
 	}
 
-	if isReplicationSpecified && replication != "" {
-		val, err := strconv.Atoi(replication)
-		if err != nil || val < 1 || val > 3 {
-			glog.V(5).Infof("gpfs_util invalid replication value specified: %s",
-				replication)
-			return &scaleVolume{}, status.Errorf(codes.InvalidArgument,
-				"invalid replication value specified: %s", replication)
-		}
-		scaleVol.Replication = val
-		glog.V(5).Infof("gpfs_util replication was set: %d", val)
-	}
-
-	if isStoragePoolSpecified && storagePool != "" {
-		scaleVol.StoragePool = storagePool
-		glog.V(5).Infof("gpfs_util storagePool was set: %s", storagePool)
+	if isTierSpecified && tier != "" {
+		scaleVol.Tier = tier
+		glog.V(5).Infof("gpfs_util tier was set: %s", tier)
 	}
 
 	return scaleVol, nil


### PR DESCRIPTION
Compression will support the algos specified in 'File compression' in https://www.ibm.com/docs/en/spectrum-scale
Add replication/tiering support with defaulted replication values

## Pull request checklist

<!-- Add your one liner release notes here -->
<!-- eg... -->
<!--   - Major functionality adds -->
<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->
<!--   - are you changing our ScaleCluster CR file? -->
```release-notes
Added support for compression/tiering/replication within a storageclass
```

## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [ ] Bugfix
- [x] Feature Enhancement
- [ ] Test Automation 
- [ ] Code Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Community Operator listing 
- [ ] Other (please describe): 


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying -->
- N/A

## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->
- With this change, a compression, tier, and replication values can be supplied in the storageclass spec.
Once a pvc is created, some validation checks will be done such as making sure a valid compression algorithm was specified or a valid range for replication was set. For tiering and replication, a new rule will be set in the filesystem policy so any new files will be placed/replicated accordingly.


## How risky is this change?
- [ ] Small, isolated change
- [x] Medium, requires regression testing
- [ ] Large, requires functional and regression testing 

