### PR TITLE
Don't create directory for CG independent fileset

### DIFF
--- a/driver/csiplugin/controllerserver.go
+++ b/driver/csiplugin/controllerserver.go
@@ -303,7 +303,7 @@ func (cs *ScaleControllerServer) createFilesetBasedVol(scVol *scaleVolume, isNew
 		opt[connectors.UserSpecifiedParentFset] = ""
 		scVol.ParentFileset = ""
 		createDataDir := false
-		filesetPath, err := cs.createFilesetVol(scVol, indepFilesetName, fsDetails, opt, createDataDir, false)
+		filesetPath, err := cs.createFilesetVol(scVol, indepFilesetName, fsDetails, opt, createDataDir, true)
 		if err != nil {
 			glog.Errorf("volume:[%v] - failed to create independent fileset [%v] in filesystem [%v]. Error: %v", indepFilesetName, indepFilesetName, scVol.VolBackendFs, err)
 			return "", err
@@ -316,7 +316,7 @@ func (cs *ScaleControllerServer) createFilesetBasedVol(scVol *scaleVolume, isNew
 		opt[connectors.UserSpecifiedParentFset] = indepFilesetName
 		scVol.ParentFileset = indepFilesetName
 		createDataDir = true
-		filesetPath, err = cs.createFilesetVol(scVol, scVol.VolName, fsDetails, opt, createDataDir, true)
+		filesetPath, err = cs.createFilesetVol(scVol, scVol.VolName, fsDetails, opt, createDataDir, false)
 		if err != nil {
 			glog.Errorf("volume:[%v] - failed to create dependent fileset [%v] in filesystem [%v]. Error: %v", scVol.VolName, scVol.VolName, scVol.VolBackendFs, err)
 			return "", err
@@ -336,7 +336,7 @@ func (cs *ScaleControllerServer) createFilesetBasedVol(scVol *scaleVolume, isNew
 		// Create fileset
 		glog.V(4).Infof("creating fileset for classic storageClass with fileset name: [%v]", scVol.VolName)
 		createDataDir := true
-		filesetPath, err := cs.createFilesetVol(scVol, scVol.VolName, fsDetails, opt, createDataDir, true)
+		filesetPath, err := cs.createFilesetVol(scVol, scVol.VolName, fsDetails, opt, createDataDir, false)
 		if err != nil {
 			glog.Errorf("volume:[%v] - failed to create fileset [%v] in filesystem [%v]. Error: %v", scVol.VolName, scVol.VolName, scVol.VolBackendFs, err)
 			return "", err
@@ -346,7 +346,7 @@ func (cs *ScaleControllerServer) createFilesetBasedVol(scVol *scaleVolume, isNew
 	}
 }
 
-func (cs *ScaleControllerServer) createFilesetVol(scVol *scaleVolume, volName string, fsDetails connectors.FileSystem_v2, opt map[string]interface{}, createDataDir bool, setQuota bool) (string, error) { //nolint:gocyclo,funlen
+func (cs *ScaleControllerServer) createFilesetVol(scVol *scaleVolume, volName string, fsDetails connectors.FileSystem_v2, opt map[string]interface{}, createDataDir bool, isCGIndependentFset bool) (string, error) { //nolint:gocyclo,funlen
 	// Check if fileset exist
 	filesetInfo, err := scVol.Connector.ListFileset(scVol.VolBackendFs, volName)
 	if err != nil {
@@ -372,7 +372,7 @@ func (cs *ScaleControllerServer) createFilesetVol(scVol *scaleVolume, volName st
 		}
 	} else {
 		// fileset is present. Confirm if creator is IBM Spectrum Scale CSI driver and fileset type is correct.
-		if (filesetInfo.Config.Comment != connectors.FilesetComment) {
+		if filesetInfo.Config.Comment != connectors.FilesetComment {
 			glog.Errorf("volume:[%v] - the fileset is not created by IBM Spectrum Scale CSI driver. Cannot use it.", volName)
 			return "", status.Error(codes.Internal, fmt.Sprintf("volume:[%v] - the fileset is not created by IBM Spectrum Scale CSI driver. Cannot use it.", volName))
 		}
@@ -419,24 +419,25 @@ func (cs *ScaleControllerServer) createFilesetVol(scVol *scaleVolume, volName st
 			return "", status.Error(codes.Internal, fmt.Sprintf("unable to list fileset [%v] in filesystem [%v] after linking. Error: %v", volName, scVol.VolBackendFs, err))
 		}
 	}
+	targetBasePath := ""
+	if !isCGIndependentFset {
+		if scVol.VolSize != 0 {
+			err = cs.setQuota(scVol, volName)
+			if err != nil {
+				return "", status.Error(codes.Internal, err.Error())
+			}
+		}
 
-	if scVol.VolSize != 0 && setQuota {
-		err = cs.setQuota(scVol, volName)
+		targetBasePath, err = cs.getTargetPath(filesetInfo.Config.Path, fsDetails.Mount.MountPoint, volName, createDataDir)
+		if err != nil {
+			return "", status.Error(codes.Internal, err.Error())
+		}
+
+		err = cs.createDirectory(scVol, volName, targetBasePath)
 		if err != nil {
 			return "", status.Error(codes.Internal, err.Error())
 		}
 	}
-
-	targetBasePath, err := cs.getTargetPath(filesetInfo.Config.Path, fsDetails.Mount.MountPoint, volName, createDataDir)
-	if err != nil {
-		return "", status.Error(codes.Internal, err.Error())
-	}
-
-	err = cs.createDirectory(scVol, volName, targetBasePath)
-	if err != nil {
-		return "", status.Error(codes.Internal, err.Error())
-	}
-
 	return targetBasePath, nil
 }
 
@@ -494,7 +495,7 @@ func (cs *ScaleControllerServer) CreateVolume(ctx context.Context, req *csi.Crea
 		return nil, err
 	}
 
-        isNewVolumeType := false
+	isNewVolumeType := false
 	if scaleVol.StorageClassType == storageClassAdvanced {
 		isNewVolumeType = true
 	}
@@ -801,7 +802,6 @@ func (cs *ScaleControllerServer) CreateVolume(ctx context.Context, req *csi.Crea
 	if err != nil {
 		return nil, status.Error(codes.Internal, err.Error())
 	}
-
 	volID := cs.generateVolID(scaleVol, volFsInfo.UUID, isNewVolumeType)
 
 	if isVolSource {
@@ -1222,7 +1222,7 @@ func (cs *ScaleControllerServer) DeleteFilesetVol(FilesystemName string, Fileset
 }
 
 // This function deletes fileset for Consitency Group
-func (cs *ScaleControllerServer) DeleteCGFileset(FilesystemName string, inodeSpace int, volumeIdMembers scaleVolId, conn connectors.SpectrumScaleConnector) (error) {
+func (cs *ScaleControllerServer) DeleteCGFileset(FilesystemName string, inodeSpace int, volumeIdMembers scaleVolId, conn connectors.SpectrumScaleConnector) error {
 	glog.V(4).Infof("trying to delete independent fileset for consistency group [%v]", volumeIdMembers.ConsistencyGroup)
 	filesets, err := conn.GetFilesetsInodeSpace(FilesystemName, inodeSpace)
 	if err != nil {

--- a/driver/csiplugin/controllerserver.go
+++ b/driver/csiplugin/controllerserver.go
@@ -301,6 +301,9 @@ func (cs *ScaleControllerServer) createFilesetBasedVol(scVol *scaleVolume, isNew
 		glog.V(4).Infof("creating independent fileset for new storageClass with fileset name: [%v]", indepFilesetName)
 		opt[connectors.UserSpecifiedFilesetType] = independentFileset
 		opt[connectors.UserSpecifiedParentFset] = ""
+		//Set uid and gid as 0 for CG independent fileset
+		opt[connectors.UserSpecifiedUid] = "0"
+		opt[connectors.UserSpecifiedGid] = "0"
 		scVol.ParentFileset = ""
 		createDataDir := false
 		filesetPath, err := cs.createFilesetVol(scVol, indepFilesetName, fsDetails, opt, createDataDir, true)
@@ -314,6 +317,14 @@ func (cs *ScaleControllerServer) createFilesetBasedVol(scVol *scaleVolume, isNew
 		glog.V(4).Infof("creating dependent fileset for new storageClass with fileset name: [%v]", scVol.VolName)
 		opt[connectors.UserSpecifiedFilesetType] = dependentFileset
 		opt[connectors.UserSpecifiedParentFset] = indepFilesetName
+		delete(opt, connectors.UserSpecifiedUid)
+		delete(opt, connectors.UserSpecifiedGid)
+		if scVol.VolUid != "" {
+			opt[connectors.UserSpecifiedUid] = scVol.VolUid
+		}
+		if scVol.VolGid != "" {
+			opt[connectors.UserSpecifiedGid] = scVol.VolGid
+		}
 		scVol.ParentFileset = indepFilesetName
 		createDataDir = true
 		filesetPath, err = cs.createFilesetVol(scVol, scVol.VolName, fsDetails, opt, createDataDir, false)


### PR DESCRIPTION
- Fix for issue https://github.com/IBM/ibm-spectrum-scale-csi/issues/572
- But there can be following issue with the same re-create steps, in some cases:
```
[EFSSG0763C The parent directory "/ibm/gpfs0/ibm-spectrum-scale-csi-driver" of the specified junction path does not exist.]
```
It is due to scale gui db sync issue (in some cases, the result of `mmunlinkfileset` run on scale cluster may not sync immediately on scale gui db), so it is recommended not to unlink any CSI fileset.

- Set uid and gid as 0 for CG independent fileset
## Pull request type

Please check the type of change your PR introduces:
- [ ] Bugfix
- [ ] Feature Enhancement
- [ ] Test Automation 
- [ ] Code Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Community Operator listing 
- [ ] Other (please describe): 


## How risky is this change?
- [ ] Small, isolated change
- [ ] Medium, requires regression testing
- [ ] Large, requires functional and regression testing 

