### PR TITLE
Fix for volume cloning for consistency group

### DIFF
--- a/driver/csiplugin/controllerserver.go
+++ b/driver/csiplugin/controllerserver.go
@@ -952,7 +952,9 @@ func (cs *ScaleControllerServer) copyVolumeContent(scVol *scaleVolume, vID scale
 	jobDetails := VolCopyJobDetails{VOLCOPY_JOB_NOT_STARTED, volID}
 	if scVol.IsFilesetBased {
 		path := ""
-		if vID.StorageClassType != STORAGECLASS_ADVANCED {
+		if vID.StorageClassType == STORAGECLASS_ADVANCED {
+			path = "/"
+		} else {
 			path = fmt.Sprintf("%s%s", vID.FsetName, "-data")
 		}
 


### PR DESCRIPTION
Signed-off-by: Madhu Thorat <madhu.punjabi@in.ibm.com>

## Pull request checklist

<!-- Add your one liner release notes here -->
<!-- eg... -->
<!--   - Major functionality adds -->
<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->
<!--   - are you changing our ScaleCluster CR file? -->
```release-notes

```

## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [x] Bugfix
- [ ] Feature Enhancement
- [ ] Test Automation 
- [ ] Code Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Community Operator listing 
- [ ] Other (please describe): 


## What is the current behavior?
Volume cloning fails for CG after removing -data directory


## What is the new behavior?
Volume cloning passes for CG after removing -data directory

## How risky is this change?
- [x] Small, isolated change
- [ ] Medium, requires regression testing
- [ ] Large, requires functional and regression testing 

