### PR TITLE
setting inodeLimit to 1M for consistencyGroup

### DIFF
--- a/driver/csiplugin/controllerserver.go
+++ b/driver/csiplugin/controllerserver.go
@@ -115,7 +115,7 @@ func (cs *ScaleControllerServer) generateVolID(scVol *scaleVolume, uid string, i
 	consistencyGroup := ""
 	path := ""
 
-	if isNewVolumeType { 
+	if isNewVolumeType {
 		primaryConn, isprimaryConnPresent := cs.Driver.connmap["primary"]
 		if !isprimaryConnPresent {
 			glog.Errorf("unable to get connector for primary cluster")
@@ -322,6 +322,12 @@ func (cs *ScaleControllerServer) createFilesetBasedVol(scVol *scaleVolume, isNew
 		//Set uid and gid as 0 for CG independent fileset
 		opt[connectors.UserSpecifiedUid] = "0"
 		opt[connectors.UserSpecifiedGid] = "0"
+		if scVol.InodeLimit != "" {
+			opt[connectors.UserSpecifiedInodeLimit] = scVol.InodeLimit
+		} else {
+			opt[connectors.UserSpecifiedInodeLimit] = "1M"
+			// Assumption: On an avertage a consistancy group contains 10 volumes
+		}
 		scVol.ParentFileset = ""
 		createDataDir := false
 		filesetPath, err := cs.createFilesetVol(scVol, indepFilesetName, fsDetails, opt, createDataDir, true, isNewVolumeType)

--- a/driver/csiplugin/controllerserver.go
+++ b/driver/csiplugin/controllerserver.go
@@ -326,7 +326,7 @@ func (cs *ScaleControllerServer) createFilesetBasedVol(scVol *scaleVolume, isNew
 			opt[connectors.UserSpecifiedInodeLimit] = scVol.InodeLimit
 		} else {
 			opt[connectors.UserSpecifiedInodeLimit] = "1M"
-			// Assumption: On an avertage a consistancy group contains 10 volumes
+			// Assumption: On an average a consistency group contains 10 volumes
 		}
 		scVol.ParentFileset = ""
 		createDataDir := false

--- a/driver/csiplugin/gpfs_util.go
+++ b/driver/csiplugin/gpfs_util.go
@@ -73,7 +73,7 @@ type scaleVolId struct {
 	FsetId           string
 	FsetName         string
 	DirPath          string
-	Path		 string
+	Path             string
 	IsFilesetBased   bool
 	StorageClassType string
 	ConsistencyGroup string
@@ -269,12 +269,12 @@ func getScaleVolumeOptions(volOptions map[string]string) (*scaleVolume, error) {
 	if fsTypeSpecified && volDirPathSpecified {
 		return &scaleVolume{}, status.Error(codes.InvalidArgument, "The parameters \"type\" and \"volDirBasePath\" are mutually exclusive")
 	}
- 
+
 	if fsTypeSpecified || isSCTypeSpecified {
 		scaleVol.IsFilesetBased = true
 	}
 
-	if isCompressionSpecified && compression == "" {
+	if isCompressionSpecified && (compression == "" || compression == "false") {
 		isCompressionSpecified = false
 	}
 	if isTierSpecified && tier == "" {


### PR DESCRIPTION
## Pull request checklist

<!-- Add your one liner release notes here -->
setting inodeLimit to 1M for consistencyGroup is user has not specified the inodeLimit in storageClass
adding validation for compression=false
<!-- eg... -->
<!--   - Major functionality adds -->
<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->
<!--   - are you changing our ScaleCluster CR file? -->
```release-notes

```
fixes #596 
fixes #591 
## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [x] Bugfix
- [ ] Feature Enhancement
- [ ] Test Automation 
- [ ] Code Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Community Operator listing 
- [ ] Other (please describe): 


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying -->
-

## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->
-

## How risky is this change?
- [ ] Small, isolated change
- [ ] Medium, requires regression testing
- [ ] Large, requires functional and regression testing 

