### PR TITLE
Change `type` SC parameter to `version`

### DIFF
--- a/driver/csiplugin/connectors/connectors.go
+++ b/driver/csiplugin/connectors/connectors.go
@@ -100,7 +100,7 @@ const (
 	UserSpecifiedVolDirPath       string = "volDirBasePath"
 	UserSpecifiedNodeClass        string = "nodeClass"
 	UserSpecifiedPermissions      string = "permissions"
-	UserSpecifiedStorageClassType string = "type"
+	UserSpecifiedStorageClassType string = "version"
 	UserSpecifiedCompression      string = "compression"
 	UserSpecifiedTier             string = "tier"
 

--- a/driver/csiplugin/gpfs_util.go
+++ b/driver/csiplugin/gpfs_util.go
@@ -268,13 +268,13 @@ func getScaleVolumeOptions(volOptions map[string]string) (*scaleVolume, error) {
 	}
 
 	if isSCAdvanced && fsTypeSpecified {
-		return &scaleVolume{}, status.Error(codes.InvalidArgument, "The parameter \"filesetType\" is not allowed with \"version\" value \""+storageClassAdvanced+"\"")
+		return &scaleVolume{}, status.Error(codes.InvalidArgument, "filesetType and version="+storageClassAdvanced+" must not be specified together in storageClass")
 	}
 	if isSCAdvanced && isparentFilesetSpecified {
-		return &scaleVolume{}, status.Error(codes.InvalidArgument, "The parameter \"parentFileset\" is not allowed with \"version\" value \""+storageClassAdvanced+"\"")
+		return &scaleVolume{}, status.Error(codes.InvalidArgument, "parentFileset and version="+storageClassAdvanced+" must not be specified together in storageClass")
 	}
 	if isSCAdvanced && volDirPathSpecified {
-		return &scaleVolume{}, status.Error(codes.InvalidArgument, "The parameter \"volDirBasePath\" is not allowed with \"version\" value \""+storageClassAdvanced+"\"")
+		return &scaleVolume{}, status.Error(codes.InvalidArgument, "volDirBasePath and version="+storageClassAdvanced+" must not be specified together in storageClass")
 	}
 
 	if fsTypeSpecified || isSCAdvanced {

--- a/driver/csiplugin/gpfs_util.go
+++ b/driver/csiplugin/gpfs_util.go
@@ -33,7 +33,8 @@ import (
 const (
 	dependentFileset     = "dependent"
 	independentFileset   = "independent"
-	storageClassAdvanced = "advanced"
+	storageClassClassic  = "1"
+	storageClassAdvanced = "2"
 )
 
 type scaleVolume struct {
@@ -158,12 +159,18 @@ func getScaleVolumeOptions(volOptions map[string]string) (*scaleVolume, error) {
 	if isSCTypeSpecified && storageClassType == "" {
 		isSCTypeSpecified = false
 	}
+	isSCAdvanced := false
 	if isSCTypeSpecified {
-		//This is a new type of StorageClass
-		if storageClassType != storageClassAdvanced {
-			return &scaleVolume{}, status.Error(codes.InvalidArgument, "storageClassType must be \""+storageClassAdvanced+"\" if specified.")
+		if storageClassType != storageClassClassic && storageClassType != storageClassAdvanced {
+			return &scaleVolume{}, status.Error(codes.InvalidArgument, "The parameter \"version\" can have values only "+
+				"\""+storageClassClassic+"\" or \""+storageClassAdvanced+"\"")
 		}
 		scaleVol.StorageClassType = storageClassType
+		if storageClassType == storageClassAdvanced {
+			isSCAdvanced = true
+		}
+	} else {
+		scaleVol.StorageClassType = storageClassClassic
 	}
 
 	if fsSpecified && volBckFs == "" {
@@ -184,7 +191,7 @@ func getScaleVolumeOptions(volOptions map[string]string) (*scaleVolume, error) {
 		volDirPathSpecified = false
 	}
 
-	if !fsTypeSpecified && !volDirPathSpecified && !isSCTypeSpecified {
+	if !fsTypeSpecified && !volDirPathSpecified && !isSCAdvanced {
 		fsTypeSpecified = true
 		fsType = independentFileset
 	}
@@ -260,17 +267,17 @@ func getScaleVolumeOptions(volOptions map[string]string) (*scaleVolume, error) {
 		scaleVol.IsFilesetBased = false
 	}
 
-	if fsTypeSpecified && isSCTypeSpecified {
-		return &scaleVolume{}, status.Error(codes.InvalidArgument, "The parameters \"type\" and \"filesetType\" are mutually exclusive")
+	if isSCAdvanced && fsTypeSpecified {
+		return &scaleVolume{}, status.Error(codes.InvalidArgument, "The parameter \"filesetType\" is not allowed with \"version\" value \""+storageClassAdvanced+"\"")
 	}
-	if fsTypeSpecified && inodeLimSpecified {
-		return &scaleVolume{}, status.Error(codes.InvalidArgument, "The parameters \"type\" and \"inodeLimit\" are mutually exclusive")
+	if isSCAdvanced && isparentFilesetSpecified {
+		return &scaleVolume{}, status.Error(codes.InvalidArgument, "The parameter \"parentFileset\" is not allowed with \"version\" value \""+storageClassAdvanced+"\"")
 	}
-	if fsTypeSpecified && volDirPathSpecified {
-		return &scaleVolume{}, status.Error(codes.InvalidArgument, "The parameters \"type\" and \"volDirBasePath\" are mutually exclusive")
+	if isSCAdvanced && volDirPathSpecified {
+		return &scaleVolume{}, status.Error(codes.InvalidArgument, "The parameter \"volDirBasePath\" is not allowed with \"version\" value \""+storageClassAdvanced+"\"")
 	}
 
-	if fsTypeSpecified || isSCTypeSpecified {
+	if fsTypeSpecified || isSCAdvanced {
 		scaleVol.IsFilesetBased = true
 	}
 


### PR DESCRIPTION
- Change storage class parameter `type` (which had value `advanced`) to `version` which can have values 1 (for old storage class) or 2 (for new storage class)

- Some changes to parameters allowed with storage class with version 2:
	* Allow parameter `inodeLimit`
	* Disallow parameter `parentFileset`

Some code readability enhancements TODO later:
* Use `version` instead of `type` everywhere for CG
* Change volume handle <storageclass_type> value to 1 or 2(which is currently 0 or 1), to be consistent with `version` value

## Pull request checklist

<!-- Add your one liner release notes here -->
<!-- eg... -->
<!--   - Major functionality adds -->
<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->
<!--   - are you changing our ScaleCluster CR file? -->
```release-notes

```

## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [ ] Bugfix
- [ ] Feature Enhancement
- [ ] Test Automation 
- [ ] Code Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Community Operator listing 
- [ ] Other (please describe): 


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying -->
-

## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->
-

## How risky is this change?
- [ ] Small, isolated change
- [ ] Medium, requires regression testing
- [ ] Large, requires functional and regression testing 

