### PR TITLE
Removed duplicate toleration logic

### DIFF
--- a/operator/controllers/syncer/csi_node.go
+++ b/operator/controllers/syncer/csi_node.go
@@ -118,7 +118,6 @@ func (s *csiNodeSyncer) SyncCSIDaemonsetFn(daemonSetRestartedKey string, daemonS
 	if len(secrets) != 0 {
 		out.Spec.Template.Spec.ImagePullSecrets = secrets
 	}
-	out.Spec.Template.Spec.Tolerations = s.driver.Spec.Tolerations
 	out.Spec.Template.Spec.NodeSelector = s.driver.GetNodeSelectors(s.driver.Spec.PluginNodeSelector)
 
 	err := mergo.Merge(&out.Spec.Template.Spec, s.ensurePodSpec(secrets), mergo.WithTransformers(transformers.PodSpec))

--- a/operator/controllers/syncer/csi_syncer.go
+++ b/operator/controllers/syncer/csi_syncer.go
@@ -238,7 +238,6 @@ func (s *csiControllerSyncer) SyncAttacherFn() error {
 	if len(secrets) != 0 {
 		out.Spec.Template.Spec.ImagePullSecrets = secrets
 	}
-	out.Spec.Template.Spec.Tolerations = s.driver.Spec.Tolerations
 	out.Spec.Template.Spec.NodeSelector = s.driver.GetNodeSelectors(s.driver.Spec.AttacherNodeSelector)
 	//out.Spec.Template.ObjectMeta.Annotations = s.driver.GetAnnotations()
 
@@ -278,7 +277,6 @@ func (s *csiControllerSyncer) SyncProvisionerFn() error {
 	if len(secrets) != 0 {
 		out.Spec.Template.Spec.ImagePullSecrets = secrets
 	}
-	out.Spec.Template.Spec.Tolerations = s.driver.Spec.Tolerations
 	out.Spec.Template.Spec.NodeSelector = s.driver.GetNodeSelectors(s.driver.Spec.ProvisionerNodeSelector)
 	//out.Spec.Template.ObjectMeta.Annotations = s.driver.GetAnnotations()
 
@@ -318,7 +316,6 @@ func (s *csiControllerSyncer) SyncSnapshotterFn() error {
 	if len(secrets) != 0 {
 		out.Spec.Template.Spec.ImagePullSecrets = secrets
 	}
-	out.Spec.Template.Spec.Tolerations = s.driver.Spec.Tolerations
 	out.Spec.Template.Spec.NodeSelector = s.driver.GetNodeSelectors(s.driver.Spec.SnapshotterNodeSelector)
 	//out.Spec.Template.ObjectMeta.Annotations = s.driver.GetAnnotations()
 
@@ -358,7 +355,6 @@ func (s *csiControllerSyncer) SyncResizerFn() error {
 	if len(secrets) != 0 {
 		out.Spec.Template.Spec.ImagePullSecrets = secrets
 	}
-	out.Spec.Template.Spec.Tolerations = s.driver.Spec.Tolerations
 	out.Spec.Template.Spec.NodeSelector = s.driver.GetNodeSelectors(s.driver.Spec.ResizerNodeSelector)
 	//out.Spec.Template.ObjectMeta.Annotations = s.driver.GetAnnotations()
 


### PR DESCRIPTION
## Pull request checklist

- Fixes #625 

<!-- Add your one liner release notes here -->
<!-- eg... -->
<!--   - Major functionality adds -->
<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->
<!--   - are you changing our ScaleCluster CR file? -->

## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [x] Bugfix
- [ ] Feature Enhancement
- [ ] Test Automation 
- [ ] Code Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Community Operator listing 
- [ ] Other (please describe): 


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying -->
- Tolerations are not set correctly in driver and controller pods because of which pods were scheduling only to worker nodes.

## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->
- Removed the duplicate logic of adding tolerations in pod template, duplicate logic was updating tolerations in incorrect format.

## How risky is this change?
- [x] Small, isolated change
- [ ] Medium, requires regression testing
- [ ] Large, requires functional and regression testing 

