### PR TITLE
Fix for issue #620 and added fix for snapshot restore of a PVC after PVC got deleted 

### DIFF
--- a/driver/csiplugin/controllerserver.go
+++ b/driver/csiplugin/controllerserver.go
@@ -941,12 +941,7 @@ func (cs *ScaleControllerServer) copySnapContent(scVol *scaleVolume, snapId scal
 		return err
 	}
 
-	primaryConn, isprimaryConnPresent := cs.Driver.connmap["primary"]
-	if !isprimaryConnPresent {
-		glog.Errorf("unable to get connector for primary cluster")
-		return status.Error(codes.Internal, "unable to find primary cluster details in custom resource")
-	}
-	targetFsDetails, err := primaryConn.GetFilesystemDetails(targetFsName)
+	targetFsDetails, err := conn.GetFilesystemDetails(targetFsName)
 	if err != nil {
 		return err
 	}

--- a/driver/csiplugin/controllerserver.go
+++ b/driver/csiplugin/controllerserver.go
@@ -1202,25 +1202,16 @@ func (cs *ScaleControllerServer) validateSnapId(sId *scaleSnapId, scVol *scaleVo
 		}
 	}
 
-	isFsetLinked, err := conn.IsFilesetLinked(sId.FsName, sId.FsetName)
-	if err != nil {
-		return status.Error(codes.Internal, fmt.Sprintf("unable to get fileset link information for [%v]", sId.FsetName))
-	}
-	if !isFsetLinked {
-		return status.Error(codes.Internal, fmt.Sprintf("fileset [%v] of source snapshot is not linked", sId.FsetName))
-	}
-
 	filesetToCheck := sId.FsetName
 	if sId.StorageClassType == STORAGECLASS_ADVANCED {
-		// check if independent fileset is linked
 		filesetToCheck = sId.ConsistencyGroup
-		isFsetLinked, err := conn.IsFilesetLinked(sId.FsName, filesetToCheck)
-		if err != nil {
-			return status.Error(codes.Internal, fmt.Sprintf("unable to get fileset link information for [%v]", filesetToCheck))
-		}
-		if !isFsetLinked {
-			return status.Error(codes.Internal, fmt.Sprintf("fileset [%v] of source snapshot is not linked", filesetToCheck))
-		}
+	}
+	isFsetLinked, err := conn.IsFilesetLinked(sId.FsName, filesetToCheck)
+	if err != nil {
+		return status.Error(codes.Internal, fmt.Sprintf("unable to get fileset link information for [%v]", filesetToCheck))
+	}
+	if !isFsetLinked {
+		return status.Error(codes.Internal, fmt.Sprintf("fileset [%v] of source snapshot is not linked", filesetToCheck))
 	}
 
 	isSnapExist, err := conn.CheckIfSnapshotExist(sId.FsName, filesetToCheck, sId.SnapName)

--- a/driver/csiplugin/controllerserver.go
+++ b/driver/csiplugin/controllerserver.go
@@ -1353,7 +1353,7 @@ func (cs *ScaleControllerServer) DeleteFilesetVol(FilesystemName string, Fileset
 	}
 
 	if len(snapshotList) > 0 {
-		return false, status.Error(codes.InvalidArgument, fmt.Sprintf("volume fileset [%v] contains one or more snapshot, delete snapshot/volumesnapshot", FilesetName))
+		return false, status.Error(codes.Internal, fmt.Sprintf("volume fileset [%v] contains one or more snapshot, delete snapshot/volumesnapshot", FilesetName))
 	}
 	glog.V(4).Infof("there is no snapshot present in the fileset [%v], continue DeleteFilesetVol", FilesetName)
 
@@ -1370,19 +1370,9 @@ func (cs *ScaleControllerServer) DeleteFilesetVol(FilesystemName string, Fileset
 }
 
 // This function deletes fileset for Consitency Group
-func (cs *ScaleControllerServer) DeleteCGFileset(FilesystemName string, inodeSpace int, volumeIdMembers scaleVolId, conn connectors.SpectrumScaleConnector) error {
+func (cs *ScaleControllerServer) DeleteCGFileset(FilesystemName string, volumeIdMembers scaleVolId, conn connectors.SpectrumScaleConnector) error {
 	glog.V(4).Infof("trying to delete independent fileset for consistency group [%v]", volumeIdMembers.ConsistencyGroup)
-	filesets, err := conn.GetFilesetsInodeSpace(FilesystemName, inodeSpace)
-	if err != nil {
-		return status.Error(codes.Internal, fmt.Sprintf("listing of filesets for filesystem: [%v] failed. Error: [%v]", FilesystemName, err))
-	}
 
-	if len(filesets) > 1 {
-		glog.V(4).Infof("found atleast one dependent fileset for consistency group: [%v]", volumeIdMembers.ConsistencyGroup)
-		return nil
-	}
-
-	// Check if fileset was created by IBM Spectrum Scale CSI Driver
 	filesetDetails, err := conn.ListFileset(FilesystemName, volumeIdMembers.ConsistencyGroup)
 	if err != nil {
 		if strings.Contains(err.Error(), "EFSSG0072C") ||
@@ -1393,9 +1383,24 @@ func (cs *ScaleControllerServer) DeleteCGFileset(FilesystemName string, inodeSpa
 		return status.Error(codes.Internal, fmt.Sprintf("unable to list fileset [%v]. Error: [%v]", volumeIdMembers.ConsistencyGroup, err))
 	}
 
+	// Check if fileset was created by IBM Spectrum Scale CSI Driver
 	if filesetDetails.Config.Comment == connectors.FilesetComment {
+		// before deletion of fileset get its inodeSpace.
+		// this will help to identify if there are one or more dependent filesets for same inodeSpace
+		// which is shared with independent fileset
+		inodeSpace := filesetDetails.Config.InodeSpace
+		filesets, err := conn.GetFilesetsInodeSpace(FilesystemName, inodeSpace)
+		if err != nil {
+			return status.Error(codes.Internal, fmt.Sprintf("listing of filesets for filesystem: [%v] failed. Error: [%v]", FilesystemName, err))
+		}
+
+		if len(filesets) > 1 {
+			glog.V(4).Infof("found atleast one dependent fileset for consistency group: [%v]", volumeIdMembers.ConsistencyGroup)
+			return nil
+		}
+
 		// Delete independent fileset for consistency group
-		_, err := cs.DeleteFilesetVol(FilesystemName, volumeIdMembers.ConsistencyGroup, volumeIdMembers, conn)
+		_, err = cs.DeleteFilesetVol(FilesystemName, volumeIdMembers.ConsistencyGroup, volumeIdMembers, conn)
 		if err != nil {
 			return err
 		}
@@ -1479,25 +1484,6 @@ func (cs *ScaleControllerServer) DeleteVolume(ctx context.Context, req *csi.Dele
 			/* Confirm it is same fileset which was created for this PV */
 			pvName := filepath.Base(relPath)
 			if pvName == FilesetName {
-				// before deletion of fileset get its inodeSpace if storageClassType=STORAGECLASS_ADVANCED
-				// this will help to identify if there are one or more dependent filesets for same inodeSpace
-				// which is shared with independent fileset
-				inodeSpace := 0
-				if volumeIdMembers.StorageClassType == STORAGECLASS_ADVANCED {
-					// Save inodeSpace information
-					filesetDetails, err := conn.ListFileset(FilesystemName, FilesetName)
-					if err != nil {
-						if strings.Contains(err.Error(), "EFSSG0072C") ||
-							strings.Contains(err.Error(), "400 Invalid value in 'filesetName'") { // fileset is already deleted
-
-							glog.V(4).Infof("fileset seems already deleted - %v", err)
-							return &csi.DeleteVolumeResponse{}, nil
-						}
-						return nil, status.Error(codes.Internal, fmt.Sprintf("unable to get the fileset details. Error [%v]", err))
-					}
-					inodeSpace = filesetDetails.Config.InodeSpace
-				}
-
 				isFilesetAlreadyDel, err := cs.DeleteFilesetVol(FilesystemName, FilesetName, volumeIdMembers, conn)
 				if err != nil {
 					return nil, err
@@ -1512,7 +1498,7 @@ func (cs *ScaleControllerServer) DeleteVolume(ctx context.Context, req *csi.Dele
 				}
 
 				if volumeIdMembers.StorageClassType == STORAGECLASS_ADVANCED {
-					err := cs.DeleteCGFileset(FilesystemName, inodeSpace, volumeIdMembers, conn)
+					err := cs.DeleteCGFileset(FilesystemName, volumeIdMembers, conn)
 					if err != nil {
 						return nil, err
 					}


### PR DESCRIPTION
## Pull request checklist

<!-- Add your one liner release notes here -->
<!-- eg... -->
<!--   - Major functionality adds -->
<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->
<!--   - are you changing our ScaleCluster CR file? -->
```release-notes

```

## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [x] Bugfix
- [ ] Feature Enhancement
- [ ] Test Automation 
- [ ] Code Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Community Operator listing 
- [ ] Other (please describe): 


## What is the current behavior?
Independent fileset for CG doesn't get deleted if all PVCs are deleted first and then all snapshots are deleted.

## What is the new behavior?
Fix for - Independent fileset for CG doesn't get deleted if all PVCs are deleted first and then all snapshots are deleted.


## How risky is this change?
- [ ] Small, isolated change
- [x] Medium, requires regression testing
- [ ] Large, requires functional and regression testing 

