### PR TITLE
Add `ibm-entitlement-key` as default image pull secret

### DIFF
--- a/driver/csiplugin/controllerserver.go
+++ b/driver/csiplugin/controllerserver.go
@@ -1202,25 +1202,16 @@ func (cs *ScaleControllerServer) validateSnapId(sId *scaleSnapId, scVol *scaleVo
 		}
 	}
 
-	isFsetLinked, err := conn.IsFilesetLinked(sId.FsName, sId.FsetName)
-	if err != nil {
-		return status.Error(codes.Internal, fmt.Sprintf("unable to get fileset link information for [%v]", sId.FsetName))
-	}
-	if !isFsetLinked {
-		return status.Error(codes.Internal, fmt.Sprintf("fileset [%v] of source snapshot is not linked", sId.FsetName))
-	}
-
 	filesetToCheck := sId.FsetName
 	if sId.StorageClassType == STORAGECLASS_ADVANCED {
-		// check if independent fileset is linked
 		filesetToCheck = sId.ConsistencyGroup
-		isFsetLinked, err := conn.IsFilesetLinked(sId.FsName, filesetToCheck)
-		if err != nil {
-			return status.Error(codes.Internal, fmt.Sprintf("unable to get fileset link information for [%v]", filesetToCheck))
-		}
-		if !isFsetLinked {
-			return status.Error(codes.Internal, fmt.Sprintf("fileset [%v] of source snapshot is not linked", filesetToCheck))
-		}
+	}
+	isFsetLinked, err := conn.IsFilesetLinked(sId.FsName, filesetToCheck)
+	if err != nil {
+		return status.Error(codes.Internal, fmt.Sprintf("unable to get fileset link information for [%v]", filesetToCheck))
+	}
+	if !isFsetLinked {
+		return status.Error(codes.Internal, fmt.Sprintf("fileset [%v] of source snapshot is not linked", filesetToCheck))
 	}
 
 	isSnapExist, err := conn.CheckIfSnapshotExist(sId.FsName, filesetToCheck, sId.SnapName)
@@ -1353,7 +1344,7 @@ func (cs *ScaleControllerServer) DeleteFilesetVol(FilesystemName string, Fileset
 	}
 
 	if len(snapshotList) > 0 {
-		return false, status.Error(codes.InvalidArgument, fmt.Sprintf("volume fileset [%v] contains one or more snapshot, delete snapshot/volumesnapshot", FilesetName))
+		return false, status.Error(codes.Internal, fmt.Sprintf("volume fileset [%v] contains one or more snapshot, delete snapshot/volumesnapshot", FilesetName))
 	}
 	glog.V(4).Infof("there is no snapshot present in the fileset [%v], continue DeleteFilesetVol", FilesetName)
 
@@ -1370,19 +1361,9 @@ func (cs *ScaleControllerServer) DeleteFilesetVol(FilesystemName string, Fileset
 }
 
 // This function deletes fileset for Consitency Group
-func (cs *ScaleControllerServer) DeleteCGFileset(FilesystemName string, inodeSpace int, volumeIdMembers scaleVolId, conn connectors.SpectrumScaleConnector) error {
+func (cs *ScaleControllerServer) DeleteCGFileset(FilesystemName string, volumeIdMembers scaleVolId, conn connectors.SpectrumScaleConnector) error {
 	glog.V(4).Infof("trying to delete independent fileset for consistency group [%v]", volumeIdMembers.ConsistencyGroup)
-	filesets, err := conn.GetFilesetsInodeSpace(FilesystemName, inodeSpace)
-	if err != nil {
-		return status.Error(codes.Internal, fmt.Sprintf("listing of filesets for filesystem: [%v] failed. Error: [%v]", FilesystemName, err))
-	}
 
-	if len(filesets) > 1 {
-		glog.V(4).Infof("found atleast one dependent fileset for consistency group: [%v]", volumeIdMembers.ConsistencyGroup)
-		return nil
-	}
-
-	// Check if fileset was created by IBM Spectrum Scale CSI Driver
 	filesetDetails, err := conn.ListFileset(FilesystemName, volumeIdMembers.ConsistencyGroup)
 	if err != nil {
 		if strings.Contains(err.Error(), "EFSSG0072C") ||
@@ -1393,9 +1374,24 @@ func (cs *ScaleControllerServer) DeleteCGFileset(FilesystemName string, inodeSpa
 		return status.Error(codes.Internal, fmt.Sprintf("unable to list fileset [%v]. Error: [%v]", volumeIdMembers.ConsistencyGroup, err))
 	}
 
+	// Check if fileset was created by IBM Spectrum Scale CSI Driver
 	if filesetDetails.Config.Comment == connectors.FilesetComment {
+		// before deletion of fileset get its inodeSpace.
+		// this will help to identify if there are one or more dependent filesets for same inodeSpace
+		// which is shared with independent fileset
+		inodeSpace := filesetDetails.Config.InodeSpace
+		filesets, err := conn.GetFilesetsInodeSpace(FilesystemName, inodeSpace)
+		if err != nil {
+			return status.Error(codes.Internal, fmt.Sprintf("listing of filesets for filesystem: [%v] failed. Error: [%v]", FilesystemName, err))
+		}
+
+		if len(filesets) > 1 {
+			glog.V(4).Infof("found atleast one dependent fileset for consistency group: [%v]", volumeIdMembers.ConsistencyGroup)
+			return nil
+		}
+
 		// Delete independent fileset for consistency group
-		_, err := cs.DeleteFilesetVol(FilesystemName, volumeIdMembers.ConsistencyGroup, volumeIdMembers, conn)
+		_, err = cs.DeleteFilesetVol(FilesystemName, volumeIdMembers.ConsistencyGroup, volumeIdMembers, conn)
 		if err != nil {
 			return err
 		}
@@ -1479,25 +1475,6 @@ func (cs *ScaleControllerServer) DeleteVolume(ctx context.Context, req *csi.Dele
 			/* Confirm it is same fileset which was created for this PV */
 			pvName := filepath.Base(relPath)
 			if pvName == FilesetName {
-				// before deletion of fileset get its inodeSpace if storageClassType=STORAGECLASS_ADVANCED
-				// this will help to identify if there are one or more dependent filesets for same inodeSpace
-				// which is shared with independent fileset
-				inodeSpace := 0
-				if volumeIdMembers.StorageClassType == STORAGECLASS_ADVANCED {
-					// Save inodeSpace information
-					filesetDetails, err := conn.ListFileset(FilesystemName, FilesetName)
-					if err != nil {
-						if strings.Contains(err.Error(), "EFSSG0072C") ||
-							strings.Contains(err.Error(), "400 Invalid value in 'filesetName'") { // fileset is already deleted
-
-							glog.V(4).Infof("fileset seems already deleted - %v", err)
-							return &csi.DeleteVolumeResponse{}, nil
-						}
-						return nil, status.Error(codes.Internal, fmt.Sprintf("unable to get the fileset details. Error [%v]", err))
-					}
-					inodeSpace = filesetDetails.Config.InodeSpace
-				}
-
 				isFilesetAlreadyDel, err := cs.DeleteFilesetVol(FilesystemName, FilesetName, volumeIdMembers, conn)
 				if err != nil {
 					return nil, err
@@ -1512,7 +1489,7 @@ func (cs *ScaleControllerServer) DeleteVolume(ctx context.Context, req *csi.Dele
 				}
 
 				if volumeIdMembers.StorageClassType == STORAGECLASS_ADVANCED {
-					err := cs.DeleteCGFileset(FilesystemName, inodeSpace, volumeIdMembers, conn)
+					err := cs.DeleteCGFileset(FilesystemName, volumeIdMembers, conn)
 					if err != nil {
 						return nil, err
 					}

--- a/generated/installer/ibm-spectrum-scale-csi-operator-dev.yaml
+++ b/generated/installer/ibm-spectrum-scale-csi-operator-dev.yaml
@@ -200,6 +200,7 @@ metadata:
     release: ibm-spectrum-scale-csi-operator
 imagePullSecrets:
 - name: ibm-spectrum-scale-csi-registrykey
+- name: ibm-entitlement-key
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition

--- a/generated/installer/ibm-spectrum-scale-csi-operator.yaml
+++ b/generated/installer/ibm-spectrum-scale-csi-operator.yaml
@@ -200,6 +200,7 @@ metadata:
     release: ibm-spectrum-scale-csi-operator
 imagePullSecrets:
 - name: ibm-spectrum-scale-csi-registrykey
+- name: ibm-entitlement-key
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition

--- a/operator/config/rbac/service_account.yaml
+++ b/operator/config/rbac/service_account.yaml
@@ -12,3 +12,4 @@ metadata:
   namespace: ibm-spectrum-scale-csi-driver
 imagePullSecrets:
   - name: ibm-spectrum-scale-csi-registrykey
+  - name: ibm-entitlement-key

--- a/operator/controllers/config/constants.go
+++ b/operator/controllers/config/constants.go
@@ -69,11 +69,11 @@ const (
 	OperatorVersion = "2.5.0"
 
 	// Number of replica pods for CSI Sidecar deployment
-	ReplicaCount       = int32(2)
+	ReplicaCount = int32(2)
 	// Tolerations seconds for the CSI Sidecar deployment
 	TolerationsSeconds = int64(60)
 	// ContainerPort for /healthz/leader-election endpoint
-	AttacherLeaderLivenessPort    = int32(8080)
+	AttacherLeaderLivenessPort = int32(8080)
 
 	//  Default images for containers
 	CSIDriverPluginImage        = "quay.io/ibm-spectrum-scale/ibm-spectrum-scale-csi-driver:v2.5.0"
@@ -113,9 +113,11 @@ const (
 	ConfigMapPath             = "/var/lib/ibm/config"
 	CAcertMountPath           = "/var/lib/ibm/ssl/public/"
 	CSIFinalizer              = "finalizer.csiscaleoperators.csi.ibm.com"
+	DefaultLogLevel           = "DEBUG"
 
-	DefaultImagePullSecret = "ibm-spectrum-scale-csi-registrykey" // #nosec G101 false positive
-	DefaultLogLevel        = "DEBUG"
+	//Default imagePullSecrets
+	ImagePullSecretRegistryKey    = "ibm-spectrum-scale-csi-registrykey" // #nosec G101 false positive
+	ImagePullSecretEntitlementKey = "ibm-entitlement-key"                // #nosec G101 false positive
 )
 
 const (

--- a/operator/controllers/syncer/csi_node.go
+++ b/operator/controllers/syncer/csi_node.go
@@ -103,8 +103,9 @@ func (s *csiNodeSyncer) SyncCSIDaemonsetFn(daemonSetRestartedKey string, daemonS
 			secrets = append(secrets, corev1.LocalObjectReference{Name: s})
 		}
 	} else {
-		// Use default imagePullSecret
-		secrets = append(secrets, corev1.LocalObjectReference{Name: config.DefaultImagePullSecret})
+		// Use default imagePullSecrets
+		secrets = append(secrets, corev1.LocalObjectReference{Name: config.ImagePullSecretRegistryKey},
+			corev1.LocalObjectReference{Name: config.ImagePullSecretEntitlementKey})
 	}
 
 	annotations := s.driver.GetAnnotations(daemonSetRestartedKey, daemonSetRestartedValue)

--- a/operator/controllers/syncer/csi_syncer.go
+++ b/operator/controllers/syncer/csi_syncer.go
@@ -227,18 +227,13 @@ func (s *csiControllerSyncer) SyncAttacherFn() error {
 			logger.Info("SyncAttacherFn: Got ", "ImagePullSecret:", s)
 			secrets = append(secrets, corev1.LocalObjectReference{Name: s})
 		}
-	} else {
-		// Use default imagePullSecrets
-		secrets = append(secrets, corev1.LocalObjectReference{Name: config.ImagePullSecretRegistryKey},
-			corev1.LocalObjectReference{Name: config.ImagePullSecretEntitlementKey})
 	}
+	secrets = append(secrets, corev1.LocalObjectReference{Name: config.ImagePullSecretRegistryKey},
+		corev1.LocalObjectReference{Name: config.ImagePullSecretEntitlementKey})
 
 	// ensure template
 	out.Spec.Template.ObjectMeta.Labels = s.driver.GetCSIControllerPodLabels(config.GetNameForResource(config.CSIControllerAttacher, s.driver.Name))
 	out.Spec.Template.ObjectMeta.Annotations = s.driver.GetAnnotations("", "")
-	if len(secrets) != 0 {
-		out.Spec.Template.Spec.ImagePullSecrets = secrets
-	}
 	out.Spec.Template.Spec.NodeSelector = s.driver.GetNodeSelectors(s.driver.Spec.AttacherNodeSelector)
 	//out.Spec.Template.ObjectMeta.Annotations = s.driver.GetAnnotations()
 
@@ -267,18 +262,13 @@ func (s *csiControllerSyncer) SyncProvisionerFn() error {
 			logger.Info("SyncProvisionerFn: Got ", "ImagePullSecret:", s)
 			secrets = append(secrets, corev1.LocalObjectReference{Name: s})
 		}
-	} else {
-		// Use default imagePullSecrets
-		secrets = append(secrets, corev1.LocalObjectReference{Name: config.ImagePullSecretRegistryKey},
-			corev1.LocalObjectReference{Name: config.ImagePullSecretEntitlementKey})
 	}
+	secrets = append(secrets, corev1.LocalObjectReference{Name: config.ImagePullSecretRegistryKey},
+		corev1.LocalObjectReference{Name: config.ImagePullSecretEntitlementKey})
 
 	// ensure template
 	out.Spec.Template.ObjectMeta.Labels = s.driver.GetCSIControllerPodLabels(config.GetNameForResource(config.CSIControllerProvisioner, s.driver.Name))
 	out.Spec.Template.ObjectMeta.Annotations = s.driver.GetAnnotations("", "")
-	if len(secrets) != 0 {
-		out.Spec.Template.Spec.ImagePullSecrets = secrets
-	}
 	out.Spec.Template.Spec.NodeSelector = s.driver.GetNodeSelectors(s.driver.Spec.ProvisionerNodeSelector)
 	//out.Spec.Template.ObjectMeta.Annotations = s.driver.GetAnnotations()
 
@@ -307,18 +297,13 @@ func (s *csiControllerSyncer) SyncSnapshotterFn() error {
 			logger.Info("SyncSnapshotterFn: Got ", "ImagePullSecret:", s)
 			secrets = append(secrets, corev1.LocalObjectReference{Name: s})
 		}
-	} else {
-		// Use default imagePullSecrets
-		secrets = append(secrets, corev1.LocalObjectReference{Name: config.ImagePullSecretRegistryKey},
-			corev1.LocalObjectReference{Name: config.ImagePullSecretEntitlementKey})
 	}
+	secrets = append(secrets, corev1.LocalObjectReference{Name: config.ImagePullSecretRegistryKey},
+		corev1.LocalObjectReference{Name: config.ImagePullSecretEntitlementKey})
 
 	// ensure template
 	out.Spec.Template.ObjectMeta.Labels = s.driver.GetCSIControllerPodLabels(config.GetNameForResource(config.CSIControllerSnapshotter, s.driver.Name))
 	out.Spec.Template.ObjectMeta.Annotations = s.driver.GetAnnotations("", "")
-	if len(secrets) != 0 {
-		out.Spec.Template.Spec.ImagePullSecrets = secrets
-	}
 	out.Spec.Template.Spec.NodeSelector = s.driver.GetNodeSelectors(s.driver.Spec.SnapshotterNodeSelector)
 	//out.Spec.Template.ObjectMeta.Annotations = s.driver.GetAnnotations()
 
@@ -347,18 +332,13 @@ func (s *csiControllerSyncer) SyncResizerFn() error {
 			logger.Info("SyncResizerFn: Got ", "ImagePullSecret:", s)
 			secrets = append(secrets, corev1.LocalObjectReference{Name: s})
 		}
-	} else {
-		// Use default imagePullSecrets
-		secrets = append(secrets, corev1.LocalObjectReference{Name: config.ImagePullSecretRegistryKey},
-			corev1.LocalObjectReference{Name: config.ImagePullSecretEntitlementKey})
 	}
+	secrets = append(secrets, corev1.LocalObjectReference{Name: config.ImagePullSecretRegistryKey},
+		corev1.LocalObjectReference{Name: config.ImagePullSecretEntitlementKey})
 
 	// ensure template
 	out.Spec.Template.ObjectMeta.Labels = s.driver.GetCSIControllerPodLabels(config.GetNameForResource(config.CSIControllerResizer, s.driver.Name))
 	out.Spec.Template.ObjectMeta.Annotations = s.driver.GetAnnotations("", "")
-	if len(secrets) != 0 {
-		out.Spec.Template.Spec.ImagePullSecrets = secrets
-	}
 	out.Spec.Template.Spec.NodeSelector = s.driver.GetNodeSelectors(s.driver.Spec.ResizerNodeSelector)
 	//out.Spec.Template.ObjectMeta.Annotations = s.driver.GetAnnotations()
 
@@ -426,6 +406,7 @@ func (s *csiControllerSyncer) ensureAttacherPodSpec(secrets []corev1.LocalObject
 		Affinity:           s.driver.Spec.Affinity,
 		Tolerations:        s.driver.Spec.Tolerations,
 		ServiceAccountName: config.GetNameForResource(config.CSIAttacherServiceAccount, s.driver.Name),
+		ImagePullSecrets:   secrets,
 	}
 
 	if pod.Affinity != nil {
@@ -438,10 +419,6 @@ func (s *csiControllerSyncer) ensureAttacherPodSpec(secrets []corev1.LocalObject
 	}
 
 	pod.Tolerations = append(pod.Tolerations, s.driver.GetNodeTolerations()...)
-
-	if len(secrets) != 0 {
-		pod.ImagePullSecrets = secrets
-	}
 	return pod
 }
 
@@ -463,9 +440,7 @@ func (s *csiControllerSyncer) ensureProvisionerPodSpec(secrets []corev1.LocalObj
 		Affinity:           s.driver.Spec.Affinity,
 		Tolerations:        s.driver.Spec.Tolerations,
 		ServiceAccountName: config.GetNameForResource(config.CSIProvisionerServiceAccount, s.driver.Name),
-	}
-	if len(secrets) != 0 {
-		pod.ImagePullSecrets = secrets
+		ImagePullSecrets:   secrets,
 	}
 	return pod
 }
@@ -488,9 +463,7 @@ func (s *csiControllerSyncer) ensureSnapshotterPodSpec(secrets []corev1.LocalObj
 		Affinity:           s.driver.Spec.Affinity,
 		Tolerations:        s.driver.Spec.Tolerations,
 		ServiceAccountName: config.GetNameForResource(config.CSISnapshotterServiceAccount, s.driver.Name),
-	}
-	if len(secrets) != 0 {
-		pod.ImagePullSecrets = secrets
+		ImagePullSecrets:   secrets,
 	}
 	return pod
 }
@@ -513,9 +486,7 @@ func (s *csiControllerSyncer) ensureResizerPodSpec(secrets []corev1.LocalObjectR
 		Affinity:           s.driver.Spec.Affinity,
 		Tolerations:        s.driver.Spec.Tolerations,
 		ServiceAccountName: config.GetNameForResource(config.CSIResizerServiceAccount, s.driver.Name),
-	}
-	if len(secrets) != 0 {
-		pod.ImagePullSecrets = secrets
+		ImagePullSecrets:   secrets,
 	}
 	return pod
 }

--- a/operator/controllers/syncer/csi_syncer.go
+++ b/operator/controllers/syncer/csi_syncer.go
@@ -228,8 +228,9 @@ func (s *csiControllerSyncer) SyncAttacherFn() error {
 			secrets = append(secrets, corev1.LocalObjectReference{Name: s})
 		}
 	} else {
-		// Use default imagePullSecret
-		secrets = append(secrets, corev1.LocalObjectReference{Name: config.DefaultImagePullSecret})
+		// Use default imagePullSecrets
+		secrets = append(secrets, corev1.LocalObjectReference{Name: config.ImagePullSecretRegistryKey},
+			corev1.LocalObjectReference{Name: config.ImagePullSecretEntitlementKey})
 	}
 
 	// ensure template
@@ -267,8 +268,9 @@ func (s *csiControllerSyncer) SyncProvisionerFn() error {
 			secrets = append(secrets, corev1.LocalObjectReference{Name: s})
 		}
 	} else {
-		// Use default imagePullSecret
-		secrets = append(secrets, corev1.LocalObjectReference{Name: config.DefaultImagePullSecret})
+		// Use default imagePullSecrets
+		secrets = append(secrets, corev1.LocalObjectReference{Name: config.ImagePullSecretRegistryKey},
+			corev1.LocalObjectReference{Name: config.ImagePullSecretEntitlementKey})
 	}
 
 	// ensure template
@@ -306,8 +308,9 @@ func (s *csiControllerSyncer) SyncSnapshotterFn() error {
 			secrets = append(secrets, corev1.LocalObjectReference{Name: s})
 		}
 	} else {
-		// Use default imagePullSecret
-		secrets = append(secrets, corev1.LocalObjectReference{Name: config.DefaultImagePullSecret})
+		// Use default imagePullSecrets
+		secrets = append(secrets, corev1.LocalObjectReference{Name: config.ImagePullSecretRegistryKey},
+			corev1.LocalObjectReference{Name: config.ImagePullSecretEntitlementKey})
 	}
 
 	// ensure template
@@ -345,8 +348,9 @@ func (s *csiControllerSyncer) SyncResizerFn() error {
 			secrets = append(secrets, corev1.LocalObjectReference{Name: s})
 		}
 	} else {
-		// Use default imagePullSecret
-		secrets = append(secrets, corev1.LocalObjectReference{Name: config.DefaultImagePullSecret})
+		// Use default imagePullSecrets
+		secrets = append(secrets, corev1.LocalObjectReference{Name: config.ImagePullSecretRegistryKey},
+			corev1.LocalObjectReference{Name: config.ImagePullSecretEntitlementKey})
 	}
 
 	// ensure template


### PR DESCRIPTION
- Code changes for part 1 of https://github.com/IBM/ibm-spectrum-scale-csi/issues/632
	 * Add ibm-entitlement-key as another default image pull secret
	 * Keep default pull secrets even when user specifies the pull secrets
	 * Removed duplicate setting of pull secrets 

- Part 2 (check for pull failures and include a message to the user for debug) is WIP - The state of pods changes from ImagePullBackOff to CrashLoopBackOff to ImagePullErr - so the pull error is logged only sometimes currently - will create a separate PR for this.

## Pull request checklist

<!-- Add your one liner release notes here -->
<!-- eg... -->
<!--   - Major functionality adds -->
<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->
<!--   - are you changing our ScaleCluster CR file? -->
```release-notes

```

## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [ ] Bugfix
- [ ] Feature Enhancement
- [ ] Test Automation 
- [ ] Code Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Community Operator listing 
- [ ] Other (please describe): 


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying -->
-

## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->
-

## How risky is this change?
- [ ] Small, isolated change
- [ ] Medium, requires regression testing
- [ ] Large, requires functional and regression testing 

