### PR TITLE
Fix permissions for version 2 SC

### DIFF
--- a/driver/csiplugin/connectors/rest_v2.go
+++ b/driver/csiplugin/connectors/rest_v2.go
@@ -555,11 +555,15 @@ func (s *spectrumRestV2) CreateFileset(filesystemName string, filesetName string
 
 	uid, uidSpecified := opts[UserSpecifiedUID]
 	gid, gidSpecified := opts[UserSpecifiedGID]
+	permissions, permissionsSpecified := opts[UserSpecifiedPermissions]
 
 	if uidSpecified && gidSpecified {
 		filesetreq.Owner = fmt.Sprintf("%s:%s", uid, gid)
 	} else if uidSpecified {
 		filesetreq.Owner = fmt.Sprintf("%s", uid)
+	}
+	if permissionsSpecified {
+		filesetreq.Permissions = fmt.Sprintf("%s", permissions)
 	}
 
 	createFilesetURL := utils.FormatURL(s.endpoint, fmt.Sprintf("scalemgmt/v2/filesystems/%s/filesets", filesystemName))

--- a/driver/csiplugin/controllerserver.go
+++ b/driver/csiplugin/controllerserver.go
@@ -350,6 +350,10 @@ func (cs *ScaleControllerServer) createFilesetBasedVol(scVol *scaleVolume, isNew
 		if scVol.VolGid != "" {
 			opt[connectors.UserSpecifiedGid] = scVol.VolGid
 		}
+		if scVol.VolPermissions != "" {
+			opt[connectors.UserSpecifiedPermissions] = scVol.VolPermissions
+		}
+
 		scVol.ParentFileset = indepFilesetName
 		createDataDir = true
 		filesetPath, err = cs.createFilesetVol(scVol, scVol.VolName, fsDetails, opt, createDataDir, false, isNewVolumeType)


### PR DESCRIPTION
- Set permissions for dependent fileset, if passed from version 2 SC


## Pull request type

Please check the type of change your PR introduces:
- [x] Bugfix
- [ ] Feature Enhancement
- [ ] Test Automation 
- [ ] Code Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Community Operator listing 
- [ ] Other (please describe): 

## What is the current behavior?
Permissions do not get set to dependent fileset directory for version 2 SC

## What is the new behavior?
Permissions are set to dependent fileset directory for version 2 SC

## How risky is this change?
- [x] Small, isolated change
- [ ] Medium, requires regression testing
- [ ] Large, requires functional and regression testing 

