### PR TITLE
consistencyGroupPrefix is set as hidden in OCP UI

### DIFF
--- a/generated/installer/ibm-spectrum-scale-csi-operator-dev.yaml
+++ b/generated/installer/ibm-spectrum-scale-csi-operator-dev.yaml
@@ -33,7 +33,7 @@ spec:
       serviceAccountName: ibm-spectrum-scale-csi-operator
       containers:
       - name: operator
-        image: quay.io/ibm-spectrum-scale-dev/ibm-spectrum-scale-csi-operator:dev
+        image: cp.icr.io/cp/spectrum/scale/csi/ibm-spectrum-scale-csi-operator@sha256:0ec50ce354216dc3b872b1fda06c6e723cf22121057383cd42d5dc238ba47d5f
         args:
         - --leaderElection=true
         env:
@@ -44,7 +44,7 @@ spec:
             fieldRef:
               fieldPath: metadata.namespace
         - name: CSI_DRIVER_IMAGE
-          value: quay.io/ibm-spectrum-scale-dev/ibm-spectrum-scale-csi-driver:dev
+          value: cp.icr.io/cp/spectrum/scale/csi/ibm-spectrum-scale-csi-driver@sha256:cab17303df75d2ac9dcb7327a4deeb70991de29ffd58f027c50afe0e8b8428fb
         resources:
           limits:
             cpu: 600m

--- a/generated/installer/ibm-spectrum-scale-csi-operator-dev.yaml
+++ b/generated/installer/ibm-spectrum-scale-csi-operator-dev.yaml
@@ -33,7 +33,7 @@ spec:
       serviceAccountName: ibm-spectrum-scale-csi-operator
       containers:
       - name: operator
-        image: cp.icr.io/cp/spectrum/scale/csi/ibm-spectrum-scale-csi-operator@sha256:0ec50ce354216dc3b872b1fda06c6e723cf22121057383cd42d5dc238ba47d5f
+        image: quay.io/ibm-spectrum-scale-dev/ibm-spectrum-scale-csi-operator:dev
         args:
         - --leaderElection=true
         env:
@@ -44,7 +44,7 @@ spec:
             fieldRef:
               fieldPath: metadata.namespace
         - name: CSI_DRIVER_IMAGE
-          value: cp.icr.io/cp/spectrum/scale/csi/ibm-spectrum-scale-csi-driver@sha256:cab17303df75d2ac9dcb7327a4deeb70991de29ffd58f027c50afe0e8b8428fb
+          value: quay.io/ibm-spectrum-scale-dev/ibm-spectrum-scale-csi-driver:dev
         resources:
           limits:
             cpu: 600m

--- a/operator/api/v1/csiscaleoperator_types.go
+++ b/operator/api/v1/csiscaleoperator_types.go
@@ -129,6 +129,7 @@ type CSIScaleOperatorSpec struct {
 
 	// consistencyGroupPrefix is a prefix of consistency group of an application.
 	// This is expected to be an RFC4122 UUID value (xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx in hexadecimal values)
+	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Consistency Group Prefix",xDescriptors="urn:alm:descriptor:com.tectonic.ui:hidden"
 	CGPrefix string `json:"consistencyGroupPrefix,omitempty"`
 }
 

--- a/operator/config/manifests/bases/ibm-spectrum-scale-csi-operator.clusterserviceversion.yaml
+++ b/operator/config/manifests/bases/ibm-spectrum-scale-csi-operator.clusterserviceversion.yaml
@@ -116,6 +116,13 @@ spec:
         path: clusters[0].secureSslMode
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
+      - description: consistencyGroupPrefix is a prefix of consistency group of an
+          application. This is expected to be an RFC4122 UUID value (xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx
+          in hexadecimal values)
+        displayName: Consistency Group Prefix
+        path: consistencyGroupPrefix
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:hidden
       - description: PodSecurityPolicy name for CSI driver and sidecar pods.
         displayName: CSI Pod Security Policy Name
         path: csipspname

--- a/operator/config/olm-catalog/ibm-spectrum-scale-csi-operator/2.5.0/ibm-spectrum-scale-csi-operator.v2.5.0.clusterserviceversion.yaml
+++ b/operator/config/olm-catalog/ibm-spectrum-scale-csi-operator/2.5.0/ibm-spectrum-scale-csi-operator.v2.5.0.clusterserviceversion.yaml
@@ -182,6 +182,13 @@ spec:
         path: clusters[0].secureSslMode
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
+      - description: consistencyGroupPrefix is a prefix of consistency group of an
+          application. This is expected to be an RFC4122 UUID value (xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx
+          in hexadecimal values)
+        displayName: Consistency Group Prefix
+        path: consistencyGroupPrefix
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:hidden
       - description: PodSecurityPolicy name for CSI driver and sidecar pods.
         displayName: CSI Pod Security Policy Name
         path: csipspname
@@ -478,8 +485,8 @@ spec:
                     fieldRef:
                       fieldPath: metadata.annotations['olm.targetNamespaces']
                 - name: CSI_DRIVER_IMAGE
-                  value: quay.io/ibm-spectrum-scale/ibm-spectrum-scale-csi-driver:v2.5.0
-                image: quay.io/ibm-spectrum-scale/ibm-spectrum-scale-csi-operator:v2.5.0
+                  value: cp.icr.io/cp/spectrum/scale/csi/ibm-spectrum-scale-csi-driver@sha256:cab17303df75d2ac9dcb7327a4deeb70991de29ffd58f027c50afe0e8b8428fb
+                image: cp.icr.io/cp/spectrum/scale/csi/ibm-spectrum-scale-csi-operator@sha256:0ec50ce354216dc3b872b1fda06c6e723cf22121057383cd42d5dc238ba47d5f
                 imagePullPolicy: IfNotPresent
                 livenessProbe:
                   exec:

--- a/operator/config/olm-catalog/ibm-spectrum-scale-csi-operator/manifests/ibm-spectrum-scale-csi-operator.clusterserviceversion.yaml
+++ b/operator/config/olm-catalog/ibm-spectrum-scale-csi-operator/manifests/ibm-spectrum-scale-csi-operator.clusterserviceversion.yaml
@@ -182,6 +182,13 @@ spec:
         path: clusters[0].secureSslMode
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
+      - description: consistencyGroupPrefix is a prefix of consistency group of an
+          application. This is expected to be an RFC4122 UUID value (xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx
+          in hexadecimal values)
+        displayName: Consistency Group Prefix
+        path: consistencyGroupPrefix
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:hidden
       - description: PodSecurityPolicy name for CSI driver and sidecar pods.
         displayName: CSI Pod Security Policy Name
         path: csipspname
@@ -478,8 +485,8 @@ spec:
                     fieldRef:
                       fieldPath: metadata.annotations['olm.targetNamespaces']
                 - name: CSI_DRIVER_IMAGE
-                  value: quay.io/ibm-spectrum-scale/ibm-spectrum-scale-csi-driver:v2.5.0
-                image: quay.io/ibm-spectrum-scale/ibm-spectrum-scale-csi-operator:v2.5.0
+                  value: cp.icr.io/cp/spectrum/scale/csi/ibm-spectrum-scale-csi-driver@sha256:cab17303df75d2ac9dcb7327a4deeb70991de29ffd58f027c50afe0e8b8428fb
+                image: cp.icr.io/cp/spectrum/scale/csi/ibm-spectrum-scale-csi-operator@sha256:0ec50ce354216dc3b872b1fda06c6e723cf22121057383cd42d5dc238ba47d5f
                 imagePullPolicy: IfNotPresent
                 livenessProbe:
                   exec:

--- a/operator/docs/dev/security/results.golint.txt
+++ b/operator/docs/dev/security/results.golint.txt
@@ -5,10 +5,10 @@ api/v1/csiscaleoperator_types.go:297:1: comment on exported type CSICluster shou
 api/v1/csiscaleoperator_types.go:307:2: struct field Id should be ID
 api/v1/csiscaleoperator_types.go:316:2: struct field RestApi should be RestAPI
 api/v1/csiscaleoperator_types.go:329:1: comment on exported type CSIFilesystem should be of the form "CSIFilesystem ..." (with optional leading article)
-api/v1/csiscaleoperator_types.go:349:1: comment on exported type RestApi should be of the form "RestApi ..." (with optional leading article)
-api/v1/csiscaleoperator_types.go:350:6: type RestApi should be RestAPI
-api/v1/csiscaleoperator_types.go:393:6: exported type CSIReason should have comment or be unexported
-api/v1/csiscaleoperator_types.go:396:2: exported const CSIConfigured should have comment (or a comment on this block) or be unexported
+api/v1/csiscaleoperator_types.go:347:1: comment on exported type RestApi should be of the form "RestApi ..." (with optional leading article)
+api/v1/csiscaleoperator_types.go:348:6: type RestApi should be RestAPI
+api/v1/csiscaleoperator_types.go:390:6: exported type CSIReason should have comment or be unexported
+api/v1/csiscaleoperator_types.go:393:2: exported const CSIConfigured should have comment (or a comment on this block) or be unexported
 controllers/csiscaleoperator_controller.go:67:7: exported const MinControllerReplicas should have comment or be unexported
 controllers/csiscaleoperator_controller.go:518:1: exported function Contains should have comment or be unexported
 controllers/csiscaleoperator_controller.go:1101:2: don't use underscores in Go names; var csiaccess_users_new should be csiaccessUsersNew

--- a/operator/docs/dev/security/results.gosec.json
+++ b/operator/docs/dev/security/results.gosec.json
@@ -3,7 +3,7 @@
 	"Issues": [],
 	"Stats": {
 		"files": 14,
-		"lines": 4936,
+		"lines": 4933,
 		"nosec": 3,
 		"found": 0
 	},


### PR DESCRIPTION
## Pull request checklist

<!-- Add your one liner release notes here -->
<!-- eg... -->
<!--   - Major functionality adds -->
<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->
<!--   - are you changing our ScaleCluster CR file? -->


## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [x] Bugfix
- [ ] Feature Enhancement
- [ ] Test Automation 
- [ ] Code Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Community Operator listing 
- [ ] Other (please describe): 


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying -->
- In OCP UI, Consistency Group Prefix is set as visible and available for user to modify.

## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->
- Consistency Group Prefix is set as hidden by default.
- Since consistency group prefix is fetched from the cluster, users don't need to explicitly provide a input for this unless they want to modify it. 

## How risky is this change?
- [x] Small, isolated change
- [ ] Medium, requires regression testing
- [ ] Large, requires functional and regression testing 

