### PR TITLE
Fix probe

### DIFF
--- a/driver/csiplugin/identityserver.go
+++ b/driver/csiplugin/identityserver.go
@@ -58,7 +58,7 @@ func (is *ScaleIdentityServer) Probe(ctx context.Context, req *csi.ProbeRequest)
 	ghealthy, err := is.Driver.connmap["primary"].IsNodeComponentHealthy(scalenodeID, "GPFS")
 	if ghealthy == false {
 		glog.Errorf("Probe: GPFS component on node %v is not healthy. Error: %v", scalenodeID, err)
-		return &csi.ProbeResponse{Ready: &wrappers.BoolValue{Value: true}}, err
+		return &csi.ProbeResponse{Ready: &wrappers.BoolValue{Value: true}}, nil
 	}
 
 	// nhealthy, err := is.Driver.connmap["primary"].IsNodeComponentHealthy(scalenodeID, "NODE")


### PR DESCRIPTION
For GUI failure case, we return Ready=true, but along with that we also return error, which causes probe to restart driver pods, so returning nil here.

## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [x] Bugfix
- [ ] Feature Enhancement
- [ ] Test Automation 
- [ ] Code Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Community Operator listing 
- [ ] Other (please describe): 


## What is the current behavior?
Driver pods restart for GUI failures

## What is the new behavior?
Driver pods do not restart for GUI failures

## How risky is this change?
- [x] Small, isolated change
- [ ] Medium, requires regression testing
- [ ] Large, requires functional and regression testing 

