### PR TITLE
Fix systemd high load with recursive mount

### DIFF
--- a/operator/controllers/internal/csiscaleoperator/csiscaleoperator.go
+++ b/operator/controllers/internal/csiscaleoperator/csiscaleoperator.go
@@ -148,6 +148,13 @@ func (c *CSIScaleOperator) GetDefaultImage(name string) string {
 	return image
 }
 
+func (c *CSIScaleOperator) GetKubeletPodsDir() string {
+	logger := csiLog.WithName("GetKubeletPodsDir")
+	kubeletPodsDir := c.GetKubeletRootDirPath() + "/pods"
+	logger.Info("GetKubeletPodsDir", "kubeletPodsDir: ", kubeletPodsDir)
+	return kubeletPodsDir
+}
+
 func (c *CSIScaleOperator) GetKubeletRootDirPath() string {
 	logger := csiLog.WithName("GetKubeletRootDirPath")
 

--- a/operator/controllers/syncer/csi_node.go
+++ b/operator/controllers/syncer/csi_node.go
@@ -366,11 +366,11 @@ func (s *csiNodeSyncer) getVolumeMountsFor(name string) []corev1.VolumeMount {
 				MountPath:        hostDirMountPath,
 				MountPropagation: &mountPropagationB,
 			},
-
-			{
-				Name:      pluginDir,
-				MountPath: s.driver.GetSocketDir(),
-			},
+			// warning: do not mount pluginDir if it exists within the podMountDir
+			// doing so will cause excessive systemd load if this pod fails in crash loop backoff.
+			// Instead, opt for only podMountDir as it will mount pluginDir because it is a subdir.
+			// for now, this code assumes the pluginDir is a subdir.
+			// future improvement would be to actually get both paths and validate this.
 			{
 				Name:             podMountDir,
 				MountPath:        s.driver.GetKubeletRootDirPath(),

--- a/operator/controllers/syncer/csi_node.go
+++ b/operator/controllers/syncer/csi_node.go
@@ -366,14 +366,13 @@ func (s *csiNodeSyncer) getVolumeMountsFor(name string) []corev1.VolumeMount {
 				MountPath:        hostDirMountPath,
 				MountPropagation: &mountPropagationB,
 			},
-			// warning: do not mount pluginDir if it exists within the podMountDir
-			// doing so will cause excessive systemd load if this pod fails in crash loop backoff.
-			// Instead, opt for only podMountDir as it will mount pluginDir because it is a subdir.
-			// for now, this code assumes the pluginDir is a subdir.
-			// future improvement would be to actually get both paths and validate this.
+			{
+				Name:      pluginDir,
+				MountPath: s.driver.GetSocketDir(),
+			},
 			{
 				Name:             podMountDir,
-				MountPath:        s.driver.GetKubeletRootDirPath(),
+				MountPath:        s.driver.GetKubeletPodsDir(),
 				MountPropagation: &mountPropagationB,
 			},
 			{
@@ -436,7 +435,7 @@ func (s *csiNodeSyncer) ensureVolumes() []corev1.Volume {
 	volumes := []corev1.Volume{
 		k8sutil.EnsureVolume(pluginDir, k8sutil.EnsureHostPathVolumeSource(s.driver.GetSocketDir(), "DirectoryOrCreate")),
 		k8sutil.EnsureVolume(registrationDir, k8sutil.EnsureHostPathVolumeSource(s.driver.GetKubeletRootDirPath()+config.PluginsRegistry, "Directory")),
-		k8sutil.EnsureVolume(podMountDir, k8sutil.EnsureHostPathVolumeSource(s.driver.GetKubeletRootDirPath(), "Directory")),
+		k8sutil.EnsureVolume(podMountDir, k8sutil.EnsureHostPathVolumeSource(s.driver.GetKubeletPodsDir(), "Directory")),
 		k8sutil.EnsureVolume(hostDev, k8sutil.EnsureHostPathVolumeSource(hostDevPath, "Directory")),
 		k8sutil.EnsureVolume(config.CSIConfigMap, k8sutil.EnsureConfigMapVolumeSource(config.CSIConfigMap)),
 		k8sutil.EnsureVolume(hostDir, k8sutil.EnsureHostPathVolumeSource(hostDirPath, "Directory")),


### PR DESCRIPTION
## Pull request checklist

<!-- Add your one liner release notes here -->
<!-- eg... -->
<!--   - Major functionality adds -->
<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->
<!--   - are you changing our ScaleCluster CR file? -->
```release-notes
Fix systemd high load with recursive mount
```

## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [x] Bugfix
- [ ] Feature Enhancement
- [ ] Test Automation 
- [ ] Code Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Community Operator listing 
- [ ] Other (please describe): 


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying -->
- If driver container is in crash loop backoff, bidirectional mount combined with a mount of a subdir eats up `mountinfo` under `systemd`. This cause extremely high CPU utilization and eventually leads to the node being unusable.

## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->
- Only mount `/var/lib/kubelet` rather than both `/var/lib/kubelet` and `/var/lib/kubelet/plugins/spectrumscale.csi.ibm.com`
- I believe the driver container will fail in crash loop until another container creates the `/var/lib/kubelet/plugins/spectrumscale.csi.ibm.com` directory. This a future improvement that could be done here.

## How risky is this change?
- [ ] Small, isolated change
- [x] Medium, requires regression testing
- [ ] Large, requires functional and regression testing 

