### PR TITLE
removing noSchedule  and noExecute toleration from sidecar controller…

### DIFF
--- a/operator/controllers/config/constants.go
+++ b/operator/controllers/config/constants.go
@@ -72,7 +72,7 @@ const (
 	// Number of replica pods for CSI Sidecar deployment
 	ReplicaCount = int32(2)
 	// Tolerations seconds for the CSI Sidecar deployment
-	TolerationsSeconds = int64(60)
+	TolerationsSeconds = int64(300)
 	// ContainerPort for /healthz/leader-election endpoint
 	LeaderLivenessPort = int32(8080)
 

--- a/operator/controllers/syncer/csi_syncer.go
+++ b/operator/controllers/syncer/csi_syncer.go
@@ -20,6 +20,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
+	"reflect"
 
 	"github.com/imdario/mergo"
 	"github.com/presslabs/controller-util/mergo/transformers"
@@ -863,8 +864,7 @@ func (s *csiControllerSyncer) ensurePodTolerations(tolerations []corev1.Tolerati
 	}
 
 	for _, toleration := range tolerations {
-		// if reflect.DeepEqual(toleration, noScheduleToleration) || reflect.DeepEqual(toleration, noExecuteToleration) {
-		if toleration != noScheduleToleration || toleration != noExecuteToleration {
+		if !(reflect.DeepEqual(toleration, noScheduleToleration)) && !(reflect.DeepEqual(toleration, noExecuteToleration)) {
 			podTolerations = append(podTolerations, toleration)
 		}
 	}

--- a/operator/controllers/syncer/csi_syncer.go
+++ b/operator/controllers/syncer/csi_syncer.go
@@ -410,6 +410,8 @@ func (s *csiControllerSyncer) ensureAttacherPodSpec(secrets []corev1.LocalObject
 		ServiceAccountName: config.GetNameForResource(config.CSIAttacherServiceAccount, s.driver.Name),
 		ImagePullSecrets:   secrets,
 	}
+
+	pod.Tolerations = append(pod.Tolerations, s.driver.GetNodeTolerations()...)
 	return pod
 }
 


### PR DESCRIPTION
… pods

## Pull request checklist

<!-- Add your one liner release notes here -->
<!-- eg... -->
<!--   - Major functionality adds -->
<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->
<!--   - are you changing our ScaleCluster CR file? -->
This pull request fixes the following issue.
- https://github.com/IBM/ibm-spectrum-scale-csi/issues/711

## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [x] Bugfix
- [ ] Feature Enhancement
- [ ] Test Automation 
- [ ] Code Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Community Operator listing 
- [ ] Other (please describe): 


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying -->
- Sidecar controller pods were not evicting when node on which pods were scheduled becomes not-ready.

## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->
- When node is down, sidecar controller pods scheduled on it are evicted after 330 seconds.
- 330 sec (300 seconds default pod eviction timeout, 30 seconds for node status to update to not-ready)
- Pods are scheduled to another healthy node. 

## How risky is this change?
- [x] Small, isolated change
- [ ] Medium, requires regression testing
- [ ] Large, requires functional and regression testing 

