### PR TITLE
Fix node affinity

### DIFF
--- a/operator/controllers/internal/csiscaleoperator/csiscaleoperator_package.go
+++ b/operator/controllers/internal/csiscaleoperator/csiscaleoperator_package.go
@@ -843,22 +843,12 @@ func (c CSIScaleOperator) GetHTTPGetAction() *corev1.HTTPGetAction {
 func (c CSIScaleOperator) GetAffinity(resource string) *corev1.Affinity {
 	affinity := &corev1.Affinity{}
 
+	affinity = &corev1.Affinity{
+		NodeAffinity: c.GetNodeAffinity(resource),
+		PodAffinity:  c.GetPodAffinity(),
+	}
 	if resource == config.Attacher.String() {
-		affinity = &corev1.Affinity{
-			NodeAffinity:    c.GetNodeAffinity(resource),
-			PodAntiAffinity: c.GetPodAntiAffinity(resource),
-			PodAffinity:     c.GetPodAffinity(),
-		}
-	} else if resource == config.NodePlugin.String() {
-		affinity = &corev1.Affinity{
-			NodeAffinity: c.GetNodeAffinity(resource),
-		}
-	} else {
-		affinity = &corev1.Affinity{
-			NodeAffinity:    c.GetNodeAffinity(resource),
-			PodAntiAffinity: c.GetPodAntiAffinity(resource),
-			PodAffinity:     c.GetPodAffinity(),
-		}
+		affinity.PodAntiAffinity = c.GetPodAntiAffinity(resource)
 	}
 	return affinity
 }


### PR DESCRIPTION
* Remove duplicate node affinity blocks
* Add affinity passed from CR to driver pods too
* Note: Though arch based node affinity (or any node affinity) is added for driver pods (this is not visible in pod spec, because of getting scheduled by a daemonset, and node affinity being overwritten by the daemonset, the arch based affinity will be used by k8s to decide on which nodes daemonet pods should be run, otherwise by default daemonset pods will be scheduled on all worker nodes in the cluster)