### PR TITLE
volume stat support

### DIFF
--- a/driver/csiplugin/gpfs.go
+++ b/driver/csiplugin/gpfs.go
@@ -221,7 +221,9 @@ func (driver *ScaleDriver) SetupScaleDriver(name, vendorVersion, nodeID string) 
 	}
 	_ = driver.AddControllerServiceCapabilities(csc)
 
-	ns := []csi.NodeServiceCapability_RPC_Type{}
+	ns := []csi.NodeServiceCapability_RPC_Type{
+		csi.NodeServiceCapability_RPC_GET_VOLUME_STATS,
+	}
 	_ = driver.AddNodeServiceCapabilities(ns)
 
 	driver.ids = NewIdentityServer(driver)

--- a/driver/csiplugin/utils/utils.go
+++ b/driver/csiplugin/utils/utils.go
@@ -24,6 +24,7 @@ import (
 	"strings"
 
 	"github.com/golang/glog"
+	"golang.org/x/sys/unix"
 )
 
 func ReadFile(path string) ([]byte, error) {
@@ -166,4 +167,21 @@ func GetEnv(envName string, defaultValue string) string {
 		envValue = defaultValue
 	}
 	return envValue
+}
+
+func FsStatInfo(path string) (int64, int64, int64, int64, int64, int64, error) {
+	statfs := &unix.Statfs_t{}
+	err := unix.Statfs(path, statfs)
+
+	if err != nil {
+		return 0, 0, 0, 0, 0, 0, err
+	}
+	available := int64(statfs.Bavail) * int64(statfs.Bsize)
+	capacity := int64(statfs.Blocks) * int64(statfs.Bsize)
+	usage := (int64(statfs.Blocks) - int64(statfs.Bfree)) * int64(statfs.Bsize)
+	inodes := int64(statfs.Files)
+	inodesFree := int64(statfs.Ffree)
+	inodesUsed := inodes - inodesFree
+
+	return available, capacity, usage, inodes, inodesFree, inodesUsed, nil
 }


### PR DESCRIPTION
## Pull request checklist

When Volume is Attached to Running pod, The PersistentVolumeClaims panel on OpenShift UI shows used size under **Used** column. 
- The Used size is only visible for Fileset based volume
- The Used size is not visible for lightweight based volume since we don't have quota on it 
   The logs will show `volume stat not supported for lightweight volumes` for lightweight based volumes

<!-- Add your one liner release notes here -->
<!-- eg... -->
<!--   - Major functionality adds -->
<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->
<!--   - are you changing our ScaleCluster CR file? -->
```release-notes

```

## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [ ] Bugfix
- [x] Feature Enhancement
- [ ] Test Automation 
- [ ] Code Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Community Operator listing 
- [ ] Other (please describe): 


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying -->
-

## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->
-

## How risky is this change?
- [ ] Small, isolated change
- [ ] Medium, requires regression testing
- [ ] Large, requires functional and regression testing 

