### PR TITLE
Add a separate SCC file for OCP RHEL

### DIFF
--- a/operator/config/overlays/ocp-rhel/security_context_constraint.yaml
+++ b/operator/config/overlays/ocp-rhel/security_context_constraint.yaml
@@ -1,0 +1,45 @@
+apiVersion: security.openshift.io/v1
+kind: SecurityContextConstraints
+metadata:
+  name: spectrum-scale-csiaccess
+  annotations:
+    kubernetes.io/description: allows hostpath and host network to be accessible
+allowHostDirVolumePlugin: true
+allowHostIPC: false
+allowHostNetwork: true
+allowHostPID: false
+allowHostPorts: false
+allowPrivilegeEscalation: true
+allowPrivilegedContainer: true
+allowedCapabilities: []
+defaultAddCapabilities: []
+fsGroup:
+  type: MustRunAs
+groups: []
+priority: null
+readOnlyRootFilesystem: false
+requiredDropCapabilities:
+- KILL
+- MKNOD
+- SETUID
+- SETGID
+runAsUser:
+  type: RunAsAny
+seLinuxContext:
+  type: RunAsAny
+supplementalGroups:
+  type: RunAsAny
+users:
+- system:serviceaccount:ibm-spectrum-scale-csi-driver:ibm-spectrum-scale-csi-attacher
+- system:serviceaccount:ibm-spectrum-scale-csi-driver:ibm-spectrum-scale-csi-provisioner
+- system:serviceaccount:ibm-spectrum-scale-csi-driver:ibm-spectrum-scale-csi-node
+- system:serviceaccount:ibm-spectrum-scale-csi-driver:ibm-spectrum-scale-csi-snapshotter
+- system:serviceaccount:ibm-spectrum-scale-csi-driver:ibm-spectrum-scale-csi-resizer
+volumes:
+- configMap
+- downwardAPI
+- emptyDir
+- hostPath
+- persistentVolumeClaim
+- projected
+- secret


### PR DESCRIPTION
* Add a separate SCC file having service account namespace `ibm-spectrum-scale-csi-driver` for OLM install.
* Note: this file doesn't impact current kustomization overlay, it is  only for OLM install documentation. It will be removed in 2.7.0 along with OLM support.