### PR TITLE
Mount fix

### DIFF
--- a/driver/csiplugin/nodeserver.go
+++ b/driver/csiplugin/nodeserver.go
@@ -79,6 +79,7 @@ func (ns *ScaleNodeServer) NodePublishVolume(ctx context.Context, req *csi.NodeP
 			return nil, fmt.Errorf("NodePublishVolume: failed to get symlink target for [%s]. Error [%v]", volScalePathInContainer, readlinkErr)
 		}
 		volScalePathInContainer = hostDir + symlinkTarget
+		volScalePath = symlinkTarget
 		glog.V(4).Infof("NodePublishVolume: symlink tarrget path is [%s]\n", volScalePathInContainer)
 	}
 	args := []string{"-f", "-c", "%T", volScalePathInContainer}


### PR DESCRIPTION
- Fix for https://github.ibm.com/IBMSpectrumScale/scale-core/issues/3957
- In case of symlink: instead of the symlink, use the target of symlink as the source for bind mount.
- Add a check for gpfs type after bind mount, if not gpfs type then unmount

Signed-off-by: amdabhad <amdabhad@in.ibm.com>

