### PR TITLE
driver logging improvment #816

### DIFF
--- a/driver/csiplugin/connectors/connectors.go
+++ b/driver/csiplugin/connectors/connectors.go
@@ -31,10 +31,10 @@ type SpectrumScaleConnector interface {
 	GetTimeZoneOffset() (string, error)
 	GetScaleVersion() (string, error)
 	//Filesystem operations
-	GetFilesystemMountDetails(filesystemName string) (MountInfo, error)
+	GetFilesystemMountDetails(ctx context.Context, filesystemName string) (MountInfo, error)
 	IsFilesystemMountedOnGUINode(filesystemName string) (bool, error)
 	ListFilesystems() ([]string, error)
-	GetFilesystemDetails(filesystemName string) (FileSystem_v2, error)
+	GetFilesystemDetails(ctx context.Context, filesystemName string) (FileSystem_v2, error)
 	GetFilesystemMountpoint(filesystemName string) (string, error)
 	//Fileset operations
 	CreateFileset(filesystemName string, filesetName string, opts map[string]interface{}) error
@@ -46,34 +46,34 @@ type SpectrumScaleConnector interface {
 	//ListFilesets(filesystemName string) ([]resources.Volume, error)
 	ListFileset(filesystemName string, filesetName string) (Fileset_v2, error)
 	GetFilesetsInodeSpace(filesystemName string, inodeSpace int) ([]Fileset_v2, error)
-	IsFilesetLinked(filesystemName string, filesetName string) (bool, error)
+	IsFilesetLinked(ctx context.Context, filesystemName string, filesetName string) (bool, error)
 	FilesetRefreshTask() error
 	//TODO modify quota from string to Capacity (see kubernetes)
-	ListFilesetQuota(filesystemName string, filesetName string) (string, error)
+	ListFilesetQuota(ctx context.Context, filesystemName string, filesetName string) (string, error)
 	GetFilesetQuotaDetails(filesystemName string, filesetName string) (Quota_v2, error)
 	SetFilesetQuota(filesystemName string, filesetName string, quota string) error
 	CheckIfFSQuotaEnabled(filesystem string) error
-	CheckIfFilesetExist(filesystemName string, filesetName string) (bool, error)
+	CheckIfFilesetExist(ctx context.Context, filesystemName string, filesetName string) (bool, error)
 	//Directory operations
 	MakeDirectory(filesystemName string, relativePath string, uid string, gid string) error
 	MakeDirectoryV2(filesystemName string, relativePath string, uid string, gid string, permissions string) error
 	MountFilesystem(filesystemName string, nodeName string) error
 	UnmountFilesystem(filesystemName string, nodeName string) error
-	GetFilesystemName(filesystemUUID string) (string, error)
+	GetFilesystemName(ctx context.Context, filesystemUUID string) (string, error)
 	CheckIfFileDirPresent(filesystemName string, relPath string) (bool, error)
 	CreateSymLink(SlnkfilesystemName string, TargetFs string, relativePath string, LnkPath string) error
 	GetFsUid(filesystemName string) (string, error)
-	DeleteDirectory(filesystemName string, dirName string, safe bool) error
+	DeleteDirectory(ctx context.Context, filesystemName string, dirName string, safe bool) error
 	StatDirectory(filesystemName string, dirName string) (string, error)
 	GetFileSetUid(filesystemName string, filesetName string) (string, error)
-	GetFileSetNameFromId(filesystemName string, Id string) (string, error)
-	DeleteSymLnk(filesystemName string, LnkName string) error
-	GetFileSetResponseFromId(filesystemName string, Id string) (Fileset_v2, error)
+	GetFileSetNameFromId(ctx context.Context, filesystemName string, Id string) (string, error)
+	DeleteSymLnk(ctx context.Context, filesystemName string, LnkName string) error
+	GetFileSetResponseFromId(ctx context.Context, filesystemName string, Id string) (Fileset_v2, error)
 	GetFileSetResponseFromName(filesystemName string, filesetName string) (Fileset_v2, error)
-	SetFilesystemPolicy(policy *Policy, filesystemName string) error
-	DoesTierExist(tierName string, filesystemName string) error
+	SetFilesystemPolicy(ctx context.Context, policy *Policy, filesystemName string) error
+	DoesTierExist(ctx context.Context, tierName string, filesystemName string) error
 	GetTierInfoFromName(tierName string, filesystemName string) (*StorageTier, error)
-	GetFirstDataTier(filesystemName string) (string, error)
+	GetFirstDataTier(ctx context.Context, filesystemName string) (string, error)
 	IsValidNodeclass(nodeclass string) (bool, error)
 	IsSnapshotSupported() (bool, error)
 	CheckIfDefaultPolicyPartitionExists(ctx context.Context, partitionName string, filesystemName string) bool
@@ -82,16 +82,16 @@ type SpectrumScaleConnector interface {
 	WaitForJobCompletion(statusCode int, jobID uint64) error
 	WaitForJobCompletionWithResp(statusCode int, jobID uint64) (GenericResponse, error)
 	CreateSnapshot(filesystemName string, filesetName string, snapshotName string) error
-	DeleteSnapshot(filesystemName string, filesetName string, snapshotName string) error
+	DeleteSnapshot(ctx context.Context, filesystemName string, filesetName string, snapshotName string) error
 	GetLatestFilesetSnapshots(filesystemName string, filesetName string) ([]Snapshot_v2, error)
 	GetSnapshotUid(filesystemName string, filesetName string, snapName string) (string, error)
 	GetSnapshotCreateTimestamp(filesystemName string, filesetName string, snapName string) (string, error)
-	CheckIfSnapshotExist(filesystemName string, filesetName string, snapshotName string) (bool, error)
-	ListFilesetSnapshots(filesystemName string, filesetName string) ([]Snapshot_v2, error)
+	CheckIfSnapshotExist(ctx context.Context, filesystemName string, filesetName string, snapshotName string) (bool, error)
+	ListFilesetSnapshots(ctx context.Context, filesystemName string, filesetName string) ([]Snapshot_v2, error)
 	CopyFsetSnapshotPath(filesystemName string, filesetName string, snapshotName string, srcPath string, targetPath string, nodeclass string) (int, uint64, error)
 	CopyFilesetPath(filesystemName string, filesetName string, srcPath string, targetPath string, nodeclass string) (int, uint64, error)
 	CopyDirectoryPath(filesystemName string, srcPath string, targetPath string, nodeclass string) (int, uint64, error)
-	IsNodeComponentHealthy(nodeName string, component string) (bool, error)
+	IsNodeComponentHealthy(ctx context.Context, nodeName string, component string) (bool, error)
 }
 
 const (

--- a/driver/csiplugin/connectors/connectors.go
+++ b/driver/csiplugin/connectors/connectors.go
@@ -51,7 +51,7 @@ type SpectrumScaleConnector interface {
 	//TODO modify quota from string to Capacity (see kubernetes)
 	ListFilesetQuota(ctx context.Context, filesystemName string, filesetName string) (string, error)
 	GetFilesetQuotaDetails(filesystemName string, filesetName string) (Quota_v2, error)
-	SetFilesetQuota(filesystemName string, filesetName string, quota string) error
+	SetFilesetQuota(ctx context.Context, filesystemName string, filesetName string, quota string) error
 	CheckIfFSQuotaEnabled(filesystem string) error
 	CheckIfFilesetExist(ctx context.Context, filesystemName string, filesetName string) (bool, error)
 	//Directory operations

--- a/driver/csiplugin/connectors/connectors.go
+++ b/driver/csiplugin/connectors/connectors.go
@@ -31,7 +31,7 @@ type SpectrumScaleConnector interface {
 	GetTimeZoneOffset() (string, error)
 	GetScaleVersion() (string, error)
 	//Filesystem operations
-	GetFilesystemMountDetails(ctx context.Context, filesystemName string) (MountInfo, error)
+	GetFilesystemMountDetails(filesystemName string) (MountInfo, error)
 	IsFilesystemMountedOnGUINode(filesystemName string) (bool, error)
 	ListFilesystems() ([]string, error)
 	GetFilesystemDetails(ctx context.Context, filesystemName string) (FileSystem_v2, error)
@@ -81,7 +81,7 @@ type SpectrumScaleConnector interface {
 	//Snapshot operations
 	WaitForJobCompletion(statusCode int, jobID uint64) error
 	WaitForJobCompletionWithResp(statusCode int, jobID uint64) (GenericResponse, error)
-	CreateSnapshot(filesystemName string, filesetName string, snapshotName string) error
+	CreateSnapshot(ctx context.Context, filesystemName string, filesetName string, snapshotName string) error
 	DeleteSnapshot(ctx context.Context, filesystemName string, filesetName string, snapshotName string) error
 	GetLatestFilesetSnapshots(filesystemName string, filesetName string) ([]Snapshot_v2, error)
 	GetSnapshotUid(filesystemName string, filesetName string, snapName string) (string, error)

--- a/driver/csiplugin/connectors/connectors.go
+++ b/driver/csiplugin/connectors/connectors.go
@@ -17,6 +17,8 @@
 package connectors
 
 import (
+	"context"
+
 	"github.com/IBM/ibm-spectrum-scale-csi/driver/csiplugin/settings"
 	"github.com/golang/glog"
 )
@@ -74,7 +76,7 @@ type SpectrumScaleConnector interface {
 	GetFirstDataTier(filesystemName string) (string, error)
 	IsValidNodeclass(nodeclass string) (bool, error)
 	IsSnapshotSupported() (bool, error)
-	CheckIfDefaultPolicyPartitionExists(partitionName string, filesystemName string) bool
+	CheckIfDefaultPolicyPartitionExists(ctx context.Context, partitionName string, filesystemName string) bool
 
 	//Snapshot operations
 	WaitForJobCompletion(statusCode int, jobID uint64) error

--- a/driver/csiplugin/connectors/rest_v2.go
+++ b/driver/csiplugin/connectors/rest_v2.go
@@ -685,8 +685,7 @@ func (s *spectrumRestV2) UnlinkFileset(filesystemName string, filesetName string
 	return nil
 }
 
-func (s *spectrumRestV2) ListFileset(ctx context.Context, filesystemName string, filesetName string) (Fileset_v2, error) {
-	loggerId := GetLoggerId(ctx)
+func (s *spectrumRestV2) ListFileset(filesystemName string, filesetName string) (Fileset_v2, error) {
 	glog.V(4).Infof("[%s] rest_v2 ListFileset. filesystem: %s, fileset: %s", loggerId, filesystemName, filesetName)
 
 	getFilesetURL := fmt.Sprintf("scalemgmt/v2/filesystems/%s/filesets/%s", filesystemName, filesetName)
@@ -725,7 +724,7 @@ func (s *spectrumRestV2) IsFilesetLinked(ctx context.Context, filesystemName str
 	loggerId := GetLoggerId(ctx)
 	glog.V(4).Infof("[%s] rest_v2 IsFilesetLinked. filesystem: %s, fileset: %s", loggerId, filesystemName, filesetName)
 
-	fileset, err := s.ListFileset(filesystemName, filesetName)
+	fileset, err := s.ListFileset(ctx, filesystemName, filesetName)
 	if err != nil {
 		return false, err
 	}
@@ -872,7 +871,7 @@ func (s *spectrumRestV2) MakeDirectoryV2(filesystemName string, relativePath str
 	return nil
 }
 
-func (s *spectrumRestV2) SetFilesetQuota(filesystemName string, filesetName string, quota string) error {
+func (s *spectrumRestV2) SetFilesetQuota(ctx context.Context, filesystemName string, filesetName string, quota string) error {
 	glog.V(4).Infof("rest_v2 SetFilesetQuota. filesystem: %s, fileset: %s, quota: %s", filesystemName, filesetName, quota)
 
 	setQuotaURL := fmt.Sprintf("scalemgmt/v2/filesystems/%s/quotas", filesystemName)
@@ -1199,7 +1198,7 @@ func (s *spectrumRestV2) DeleteSymLnk(ctx context.Context, filesystemName string
 	return nil
 }
 
-func (s *spectrumRestV2) DeleteDirectory(filesystemName string, dirName string, safe bool) error {
+func (s *spectrumRestV2) DeleteDirectory(ctx context.Context, filesystemName string, dirName string, safe bool) error {
 	loggerId := GetLoggerId(ctx)
 	glog.V(4).Infof("[%s] rest_v2 DeleteDirectory. filesystem: %s, dir: %s, safe: %v", loggerId, filesystemName, dirName, safe)
 
@@ -1268,9 +1267,9 @@ func (s *spectrumRestV2) GetFileSetUid(filesystemName string, filesetName string
 	return fmt.Sprintf("%d", filesetResponse.Config.Id), nil
 }
 
-func (s *spectrumRestV2) GetFileSetResponseFromName(ctx context.Context, filesystemName string, filesetName string) (Fileset_v2, error) {
-	loggerId := GetLoggerId(ctx)
-	glog.V(4).Infof("[%s] rest_v2 GetFileSetResponseFromName. filesystem: %s, fileset: %s", loggerId, filesystemName, filesetName)
+func (s *spectrumRestV2) GetFileSetResponseFromName(filesystemName string, filesetName string) (Fileset_v2, error) {
+
+	glog.V(4).Infof("rest_v2 GetFileSetResponseFromName. filesystem: %s, fileset: %s", filesystemName, filesetName)
 
 	getFilesetURL := fmt.Sprintf("scalemgmt/v2/filesystems/%s/filesets/%s", filesystemName, filesetName)
 	getFilesetResponse := GetFilesetResponse_v2{}

--- a/driver/csiplugin/connectors/rest_v2.go
+++ b/driver/csiplugin/connectors/rest_v2.go
@@ -28,6 +28,7 @@ import (
 
 	"github.com/IBM/ibm-spectrum-scale-csi/driver/csiplugin/settings"
 	"github.com/IBM/ibm-spectrum-scale-csi/driver/csiplugin/utils"
+	"github.com/IBM/ibm-spectrum-scale-csi/driver/scale"
 	"github.com/golang/glog"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
@@ -245,7 +246,7 @@ func (s *spectrumRestV2) GetScaleVersion() (string, error) {
 }
 
 func (s *spectrumRestV2) GetFilesystemMountDetails(ctx context.Context, filesystemName string) (MountInfo, error) {
-	loggerId := GetLoggerId(ctx)
+	loggerId := scale.GetLoggerId(ctx)
 	glog.V(4).Infof("[%s] rest_v2 GetFilesystemMountDetails. filesystemName: %s", loggerId, filesystemName)
 
 	getFilesystemURL := fmt.Sprintf("%s%s", "scalemgmt/v2/filesystems/", filesystemName)
@@ -449,7 +450,7 @@ func (s *spectrumRestV2) CreateSnapshot(filesystemName string, filesetName strin
 }
 
 func (s *spectrumRestV2) DeleteSnapshot(ctx context.Context, filesystemName string, filesetName string, snapshotName string) error {
-	loggerId := GetLoggerId(ctx)
+	loggerId := scale.GetLoggerId(ctx)
 	glog.V(4).Infof("[%s] rest_v2 DeleteSnapshot. filesystem: %s, fileset: %s, snapshot: %v", loggerId, filesystemName, filesetName, snapshotName)
 
 	deleteSnapshotURL := fmt.Sprintf("scalemgmt/v2/filesystems/%s/filesets/%s/snapshots/%s", filesystemName, filesetName, snapshotName)
@@ -684,7 +685,7 @@ func (s *spectrumRestV2) UnlinkFileset(filesystemName string, filesetName string
 }
 
 func (s *spectrumRestV2) ListFileset(ctx context.Context, filesystemName string, filesetName string) (Fileset_v2, error) {
-	loggerId := GetLoggerId(ctx)
+	loggerId := scale.GetLoggerId(ctx)
 	glog.V(4).Infof("[%s] rest_v2 ListFileset. filesystem: %s, fileset: %s", loggerId, filesystemName, filesetName)
 
 	getFilesetURL := fmt.Sprintf("scalemgmt/v2/filesystems/%s/filesets/%s", filesystemName, filesetName)
@@ -720,7 +721,7 @@ func (s *spectrumRestV2) GetFilesetsInodeSpace(filesystemName string, inodeSpace
 }
 
 func (s *spectrumRestV2) IsFilesetLinked(ctx context.Context, filesystemName string, filesetName string) (bool, error) {
-	loggerId := GetLoggerId(ctx)
+	loggerId := scale.GetLoggerId(ctx)
 	glog.V(4).Infof("[%s] rest_v2 IsFilesetLinked. filesystem: %s, fileset: %s", loggerId, filesystemName, filesetName)
 
 	fileset, err := s.ListFileset(filesystemName, filesetName)
@@ -975,7 +976,7 @@ func (s *spectrumRestV2) GetFilesetQuotaDetails(filesystemName string, filesetNa
 }
 
 func (s *spectrumRestV2) ListFilesetQuota(ctx context.Context, filesystemName string, filesetName string) (string, error) {
-	loggerId := GetLoggerId(ctx)
+	loggerId := scale.GetLoggerId(ctx)
 	glog.V(4).Infof("[%s] rest_v2 ListFilesetQuota. filesystem: %s, fileset: %s", loggerId, filesystemName, filesetName)
 
 	listQuotaResponse, err := s.GetFilesetQuotaDetails(filesystemName, filesetName)
@@ -1108,7 +1109,7 @@ func (s *spectrumRestV2) UnmountFilesystem(filesystemName string, nodeName strin
 }
 
 func (s *spectrumRestV2) GetFilesystemName(ctx context.Context, filesystemUUID string) (string, error) { //nolint:dupl
-	loggerId := GetLoggerId(ctx)
+	loggerId := scale.GetLoggerId(ctx)
 	glog.V(4).Infof("[%s] rest_v2 GetFilesystemName. UUID: %s", loggerId, filesystemUUID)
 
 	getFilesystemNameURL := fmt.Sprintf("scalemgmt/v2/filesystems?filter=uuid=%s", filesystemUUID)
@@ -1128,7 +1129,7 @@ func (s *spectrumRestV2) GetFilesystemName(ctx context.Context, filesystemUUID s
 }
 
 func (s *spectrumRestV2) GetFilesystemDetails(ctx context.Context, filesystemName string) (FileSystem_v2, error) { //nolint:dupl
-	loggerId := GetLoggerId(ctx)
+	loggerId := scale.GetLoggerId(ctx)
 	glog.V(4).Infof("[%s] rest_v2 GetFilesystemDetails. Name: %s", loggerId, filesystemName)
 
 	getFilesystemDetailsURL := fmt.Sprintf("scalemgmt/v2/filesystems/%s", filesystemName)

--- a/driver/csiplugin/connectors/rest_v2.go
+++ b/driver/csiplugin/connectors/rest_v2.go
@@ -686,19 +686,19 @@ func (s *spectrumRestV2) UnlinkFileset(filesystemName string, filesetName string
 }
 
 func (s *spectrumRestV2) ListFileset(filesystemName string, filesetName string) (Fileset_v2, error) {
-	glog.V(4).Infof("[%s] rest_v2 ListFileset. filesystem: %s, fileset: %s", loggerId, filesystemName, filesetName)
+	glog.V(4).Infof("rest_v2 ListFileset. filesystem: %s, fileset: %s", filesystemName, filesetName)
 
 	getFilesetURL := fmt.Sprintf("scalemgmt/v2/filesystems/%s/filesets/%s", filesystemName, filesetName)
 	getFilesetResponse := GetFilesetResponse_v2{}
 
 	err := s.doHTTP(getFilesetURL, "GET", &getFilesetResponse, nil)
 	if err != nil {
-		glog.Errorf("[%s] Error in list fileset request: %v", loggerId, err)
+		glog.Errorf(" Error in list fileset request: %v", err)
 		return Fileset_v2{}, err
 	}
 
 	if len(getFilesetResponse.Filesets) == 0 {
-		glog.Errorf("[%s] No fileset returned for %s", loggerId, filesetName)
+		glog.Errorf(" No fileset returned for %s", filesetName)
 		return Fileset_v2{}, fmt.Errorf("No fileset returned for %s", filesetName)
 	}
 
@@ -724,7 +724,7 @@ func (s *spectrumRestV2) IsFilesetLinked(ctx context.Context, filesystemName str
 	loggerId := GetLoggerId(ctx)
 	glog.V(4).Infof("[%s] rest_v2 IsFilesetLinked. filesystem: %s, fileset: %s", loggerId, filesystemName, filesetName)
 
-	fileset, err := s.ListFileset(ctx, filesystemName, filesetName)
+	fileset, err := s.ListFileset(filesystemName, filesetName)
 	if err != nil {
 		return false, err
 	}

--- a/driver/csiplugin/connectors/rest_v2.go
+++ b/driver/csiplugin/connectors/rest_v2.go
@@ -28,7 +28,6 @@ import (
 
 	"github.com/IBM/ibm-spectrum-scale-csi/driver/csiplugin/settings"
 	"github.com/IBM/ibm-spectrum-scale-csi/driver/csiplugin/utils"
-	"github.com/IBM/ibm-spectrum-scale-csi/driver/scale"
 	"github.com/golang/glog"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
@@ -36,6 +35,8 @@ import (
 
 const errConnectionRefused string = "connection refused"
 const errNoSuchHost string = "no such host"
+
+var GetLoggerId = utils.GetLoggerId
 
 type spectrumRestV2 struct {
 	httpClient    *http.Client
@@ -246,7 +247,7 @@ func (s *spectrumRestV2) GetScaleVersion() (string, error) {
 }
 
 func (s *spectrumRestV2) GetFilesystemMountDetails(ctx context.Context, filesystemName string) (MountInfo, error) {
-	loggerId := scale.GetLoggerId(ctx)
+	loggerId := GetLoggerId(ctx)
 	glog.V(4).Infof("[%s] rest_v2 GetFilesystemMountDetails. filesystemName: %s", loggerId, filesystemName)
 
 	getFilesystemURL := fmt.Sprintf("%s%s", "scalemgmt/v2/filesystems/", filesystemName)
@@ -450,7 +451,7 @@ func (s *spectrumRestV2) CreateSnapshot(filesystemName string, filesetName strin
 }
 
 func (s *spectrumRestV2) DeleteSnapshot(ctx context.Context, filesystemName string, filesetName string, snapshotName string) error {
-	loggerId := scale.GetLoggerId(ctx)
+	loggerId := GetLoggerId(ctx)
 	glog.V(4).Infof("[%s] rest_v2 DeleteSnapshot. filesystem: %s, fileset: %s, snapshot: %v", loggerId, filesystemName, filesetName, snapshotName)
 
 	deleteSnapshotURL := fmt.Sprintf("scalemgmt/v2/filesystems/%s/filesets/%s/snapshots/%s", filesystemName, filesetName, snapshotName)
@@ -685,7 +686,7 @@ func (s *spectrumRestV2) UnlinkFileset(filesystemName string, filesetName string
 }
 
 func (s *spectrumRestV2) ListFileset(ctx context.Context, filesystemName string, filesetName string) (Fileset_v2, error) {
-	loggerId := scale.GetLoggerId(ctx)
+	loggerId := GetLoggerId(ctx)
 	glog.V(4).Infof("[%s] rest_v2 ListFileset. filesystem: %s, fileset: %s", loggerId, filesystemName, filesetName)
 
 	getFilesetURL := fmt.Sprintf("scalemgmt/v2/filesystems/%s/filesets/%s", filesystemName, filesetName)
@@ -721,7 +722,7 @@ func (s *spectrumRestV2) GetFilesetsInodeSpace(filesystemName string, inodeSpace
 }
 
 func (s *spectrumRestV2) IsFilesetLinked(ctx context.Context, filesystemName string, filesetName string) (bool, error) {
-	loggerId := scale.GetLoggerId(ctx)
+	loggerId := GetLoggerId(ctx)
 	glog.V(4).Infof("[%s] rest_v2 IsFilesetLinked. filesystem: %s, fileset: %s", loggerId, filesystemName, filesetName)
 
 	fileset, err := s.ListFileset(filesystemName, filesetName)
@@ -976,7 +977,7 @@ func (s *spectrumRestV2) GetFilesetQuotaDetails(filesystemName string, filesetNa
 }
 
 func (s *spectrumRestV2) ListFilesetQuota(ctx context.Context, filesystemName string, filesetName string) (string, error) {
-	loggerId := scale.GetLoggerId(ctx)
+	loggerId := GetLoggerId(ctx)
 	glog.V(4).Infof("[%s] rest_v2 ListFilesetQuota. filesystem: %s, fileset: %s", loggerId, filesystemName, filesetName)
 
 	listQuotaResponse, err := s.GetFilesetQuotaDetails(filesystemName, filesetName)
@@ -1109,7 +1110,7 @@ func (s *spectrumRestV2) UnmountFilesystem(filesystemName string, nodeName strin
 }
 
 func (s *spectrumRestV2) GetFilesystemName(ctx context.Context, filesystemUUID string) (string, error) { //nolint:dupl
-	loggerId := scale.GetLoggerId(ctx)
+	loggerId := GetLoggerId(ctx)
 	glog.V(4).Infof("[%s] rest_v2 GetFilesystemName. UUID: %s", loggerId, filesystemUUID)
 
 	getFilesystemNameURL := fmt.Sprintf("scalemgmt/v2/filesystems?filter=uuid=%s", filesystemUUID)
@@ -1129,7 +1130,7 @@ func (s *spectrumRestV2) GetFilesystemName(ctx context.Context, filesystemUUID s
 }
 
 func (s *spectrumRestV2) GetFilesystemDetails(ctx context.Context, filesystemName string) (FileSystem_v2, error) { //nolint:dupl
-	loggerId := scale.GetLoggerId(ctx)
+	loggerId := GetLoggerId(ctx)
 	glog.V(4).Infof("[%s] rest_v2 GetFilesystemDetails. Name: %s", loggerId, filesystemName)
 
 	getFilesystemDetailsURL := fmt.Sprintf("scalemgmt/v2/filesystems/%s", filesystemName)

--- a/driver/csiplugin/controllerserver.go
+++ b/driver/csiplugin/controllerserver.go
@@ -127,7 +127,7 @@ func (cs *ScaleControllerServer) generateVolID(ctx context.Context, scVol *scale
 			glog.Errorf("[%s] unable to get connector for primary cluster", loggerId)
 			return "", status.Error(codes.Internal, "unable to find primary cluster details in custom resource")
 		}
-		fsMountPoint, err := primaryConn.GetFilesystemMountDetails(ctx, scVol.LocalFS)
+		fsMountPoint, err := primaryConn.GetFilesystemMountDetails(scVol.LocalFS)
 		if err != nil {
 			return "", status.Error(codes.Internal, fmt.Sprintf("unable to get mount info for FS [%v] in cluster", scVol.LocalFS))
 		}
@@ -1521,7 +1521,7 @@ func (cs *ScaleControllerServer) DeleteVolume(ctx context.Context, req *csi.Dele
 		return nil, status.Error(codes.Internal, fmt.Sprintf("unable to get filesystem Name for Id [%v] and clusterId [%v]. Error [%v]", volumeIdMembers.FsUUID, volumeIdMembers.ClusterId, err))
 	}
 
-	mountInfo, err := primaryConn.GetFilesystemMountDetails(ctx, FilesystemName)
+	mountInfo, err := primaryConn.GetFilesystemMountDetails(FilesystemName)
 
 	if err != nil {
 		return nil, status.Error(codes.Internal, fmt.Sprintf("unable to get mount info for FS [%v] in primary cluster", FilesystemName))
@@ -1696,7 +1696,7 @@ func (cs *ScaleControllerServer) ControllerPublishVolume(ctx context.Context, re
 
 	//Check if primary filesystem is mounted.
 	primaryfsName := cs.Driver.primary.GetPrimaryFs()
-	pfsMount, err := cs.Driver.connmap["primary"].GetFilesystemMountDetails(ctx, primaryfsName)
+	pfsMount, err := cs.Driver.connmap["primary"].GetFilesystemMountDetails(primaryfsName)
 	if err != nil {
 		glog.Errorf("[%s] ControllerPublishVolume : Error in getting filesystem mount details for %s", loggerId, primaryfsName)
 		return nil, status.Error(codes.Internal, fmt.Sprintf("ControllerPublishVolume : Error in getting filesystem mount details for %s. Error [%v]", primaryfsName, err))
@@ -1899,7 +1899,7 @@ func (cs *ScaleControllerServer) CreateSnapshot(ctx context.Context, req *csi.Cr
 		return nil, status.Error(codes.Internal, fmt.Sprintf("CreateSnapshot - Unable to get filesystem Name for Filesystem Uid [%v] and clusterId [%v]. Error [%v]", volumeIDMembers.FsUUID, volumeIDMembers.ClusterId, err))
 	}
 
-	mountInfo, err := primaryConn.GetFilesystemMountDetails(ctx, filesystemName)
+	mountInfo, err := primaryConn.GetFilesystemMountDetails(filesystemName)
 	if err != nil {
 		return nil, status.Error(codes.Internal, fmt.Sprintf("CreateSnapshot - unable to get mount info for FS [%v] in primary cluster", filesystemName))
 	}
@@ -2211,9 +2211,9 @@ func (cs *ScaleControllerServer) DeleteSnapshot(ctx context.Context, req *csi.De
 
 	filesetExist := false
 	if snapIdMembers.StorageClassType == STORAGECLASS_ADVANCED {
-		filesetExist, err = conn.CheckIfFilesetExist(filesystemName, snapIdMembers.ConsistencyGroup)
+		filesetExist, err = conn.CheckIfFilesetExist(ctx, filesystemName, snapIdMembers.ConsistencyGroup)
 	} else {
-		filesetExist, err = conn.CheckIfFilesetExist(filesystemName, snapIdMembers.FsetName)
+		filesetExist, err = conn.CheckIfFilesetExist(ctx, filesystemName, snapIdMembers.FsetName)
 	}
 	if err != nil {
 		return nil, status.Error(codes.Internal, fmt.Sprintf("DeleteSnapshot - unable to get the fileset %s details details. Error [%v]", snapIdMembers.FsetName, err))

--- a/driver/csiplugin/controllerserver.go
+++ b/driver/csiplugin/controllerserver.go
@@ -74,7 +74,7 @@ func (cs *ScaleControllerServer) GetPriConnAndSLnkPath() (connectors.SpectrumSca
 	return nil, "", "", "", "", "", status.Error(codes.Internal, "Primary connector not present in configMap")
 }
 
-//createLWVol: Create lightweight volume - return relative path of directory created
+// createLWVol: Create lightweight volume - return relative path of directory created
 func (cs *ScaleControllerServer) createLWVol(scVol *scaleVolume) (string, error) {
 	glog.V(4).Infof("volume: [%v] - ControllerServer:createLWVol", scVol.VolName)
 	var err error
@@ -106,7 +106,7 @@ func (cs *ScaleControllerServer) createLWVol(scVol *scaleVolume) (string, error)
 //generateVolID: Generate volume ID
 //VolID format for all newly created volumes (from 2.5.0 onwards):
 
-//<storageclass_type>;<volume_type>;<cluster_id>;<filesystem_uuid>;<consistency_group>;<fileset_name>;<path>
+// <storageclass_type>;<volume_type>;<cluster_id>;<filesystem_uuid>;<consistency_group>;<fileset_name>;<path>
 func (cs *ScaleControllerServer) generateVolID(scVol *scaleVolume, uid string, isNewVolumeType bool, targetPath string) (string, error) {
 	glog.V(4).Infof("volume: [%v] - ControllerServer:generateVolId", scVol.VolName)
 	var volID string
@@ -156,7 +156,7 @@ func (cs *ScaleControllerServer) generateVolID(scVol *scaleVolume, uid string, i
 	return volID, nil
 }
 
-//getTargetPath: retrun relative volume path from filesystem mount point
+// getTargetPath: retrun relative volume path from filesystem mount point
 func (cs *ScaleControllerServer) getTargetPath(fsetLinkPath, fsMountPoint, volumeName string, createDataDir bool, isNewVolumeType bool) (string, error) {
 	if fsetLinkPath == "" || fsMountPoint == "" {
 		glog.Errorf("volume:[%v] - missing details to generate target path fileset junctionpath: [%v], filesystem mount point: [%v]", volumeName, fsetLinkPath, fsMountPoint)
@@ -172,7 +172,7 @@ func (cs *ScaleControllerServer) getTargetPath(fsetLinkPath, fsMountPoint, volum
 	return targetPath, nil
 }
 
-//createDirectory: Create directory if not present
+// createDirectory: Create directory if not present
 func (cs *ScaleControllerServer) createDirectory(scVol *scaleVolume, volName string, targetPath string) error {
 	glog.V(4).Infof("volume: [%v] - ControllerServer:createDirectory", volName)
 	dirExists, err := scVol.Connector.CheckIfFileDirPresent(scVol.VolBackendFs, targetPath)
@@ -201,7 +201,7 @@ func (cs *ScaleControllerServer) createDirectory(scVol *scaleVolume, volName str
 	return nil
 }
 
-//createSoftlink: Create soft link if not present
+// createSoftlink: Create soft link if not present
 func (cs *ScaleControllerServer) createSoftlink(scVol *scaleVolume, target string) error {
 	glog.V(4).Infof("volume: [%v] - ControllerServer:createSoftlink", scVol.VolName)
 	volSlnkPath := fmt.Sprintf("%s/%s", scVol.PrimarySLnkRelPath, scVol.VolName)
@@ -222,7 +222,7 @@ func (cs *ScaleControllerServer) createSoftlink(scVol *scaleVolume, target strin
 	return nil
 }
 
-//setQuota: Set quota if not set
+// setQuota: Set quota if not set
 func (cs *ScaleControllerServer) setQuota(scVol *scaleVolume, volName string) error {
 	glog.V(4).Infof("volume: [%v] - ControllerServer:setQuota", volName)
 	quota, err := scVol.Connector.ListFilesetQuota(scVol.VolBackendFs, volName)
@@ -256,7 +256,7 @@ func (cs *ScaleControllerServer) setQuota(scVol *scaleVolume, volName string) er
 	return nil
 }
 
-//createFilesetBasedVol: Create fileset based volume  - return relative path of volume created
+// createFilesetBasedVol: Create fileset based volume  - return relative path of volume created
 func (cs *ScaleControllerServer) createFilesetBasedVol(scVol *scaleVolume, isNewVolumeType bool) (string, error) { //nolint:gocyclo,funlen
 	glog.V(4).Infof("volume: [%v] - ControllerServer:createFilesetBasedVol", scVol.VolName)
 	opt := make(map[string]interface{})
@@ -523,8 +523,9 @@ func checkSCSupportedParams(params map[string]string) (string, bool) {
 
 // CreateVolume - Create Volume
 func (cs *ScaleControllerServer) CreateVolume(ctx context.Context, req *csi.CreateVolumeRequest) (*csi.CreateVolumeResponse, error) { //nolint:gocyclo,funlen
-	glog.V(3).Infof("create volume req: %v", req)
-
+	loggerId := utils.GetLoggerId(ctx)
+	glog.V(3).Infof("[%s] create volume req: %v", loggerId, req)
+	glog.V(3).Infof("ctx value: ", ctx)
 	if err := cs.Driver.ValidateControllerServiceRequest(csi.ControllerServiceCapability_RPC_CREATE_DELETE_VOLUME); err != nil {
 		glog.V(3).Infof("invalid create volume req: %v", req)
 		return nil, status.Error(codes.Internal, fmt.Sprintf("CreateVolume ValidateControllerServiceRequest failed: %v", err))
@@ -1824,7 +1825,7 @@ func (cs *ScaleControllerServer) MakeSnapMetadataDir(conn connectors.SpectrumSca
 	return nil
 }
 
-//CreateSnapshot Create Snapshot
+// CreateSnapshot Create Snapshot
 func (cs *ScaleControllerServer) CreateSnapshot(ctx context.Context, req *csi.CreateSnapshotRequest) (*csi.CreateSnapshotResponse, error) { //nolint:gocyclo,funlen
 	glog.V(3).Infof("CreateSnapshot - create snapshot req: %v", req)
 

--- a/driver/csiplugin/gpfs.go
+++ b/driver/csiplugin/gpfs.go
@@ -17,6 +17,7 @@
 package scale
 
 import (
+	"context"
 	"fmt"
 	"path"
 	"strings"
@@ -53,7 +54,7 @@ const (
 	FILE_DEPENDENTFILESET_VOLUME   = "1"
 	FILE_INDEPENDENTFILESET_VOLUME = "2"
 
-//	BLOCK_FILESET_VOLUME = 3
+// BLOCK_FILESET_VOLUME = 3
 )
 
 type SnapCopyJobDetails struct {
@@ -178,8 +179,9 @@ func (driver *ScaleDriver) AddNodeServiceCapabilities(nl []csi.NodeServiceCapabi
 	return nil
 }
 
-func (driver *ScaleDriver) ValidateControllerServiceRequest(c csi.ControllerServiceCapability_RPC_Type) error {
-	glog.V(3).Infof("gpfs ValidateControllerServiceRequest")
+func (driver *ScaleDriver) ValidateControllerServiceRequest(ctx context.Context, c csi.ControllerServiceCapability_RPC_Type) error {
+	loggerId := GetLoggerId(ctx)
+	glog.V(3).Infof("[%s] gpfs ValidateControllerServiceRequest", loggerId)
 	if c == csi.ControllerServiceCapability_RPC_UNKNOWN {
 		return nil
 	}

--- a/driver/csiplugin/gpfs_util.go
+++ b/driver/csiplugin/gpfs_util.go
@@ -18,6 +18,7 @@ package scale
 
 import (
 	"bytes"
+	"context"
 	"fmt"
 	"os/exec"
 	"strconv"
@@ -96,7 +97,7 @@ type scaleSnapId struct {
 	VolType          string
 }
 
-//nolint
+// nolint
 type scaleVolSnapshot struct {
 	SnapName   string `json:"snapName"`
 	SourceVol  string `json:"sourceVol"`
@@ -106,7 +107,7 @@ type scaleVolSnapshot struct {
 	SnapSize   uint64 `json:"snapSize"`
 } //nolint
 
-//nolint
+// nolint
 type scaleVolSnapId struct {
 	ClusterId string
 	FsUUID    string
@@ -133,7 +134,9 @@ func getRemoteFsName(remoteDeviceName string) string {
 	return remDevFs
 }
 
-func getScaleVolumeOptions(volOptions map[string]string) (*scaleVolume, error) { //nolint:gocyclo,funlen
+func getScaleVolumeOptions(ctx context.Context, volOptions map[string]string) (*scaleVolume, error) { //nolint:gocyclo,funlen
+
+	loggerId := GetLoggerId(ctx)
 	//var err error
 	scaleVol := &scaleVolume{}
 
@@ -385,23 +388,23 @@ func getScaleVolumeOptions(volOptions map[string]string) (*scaleVolume, error) {
 	if isCompressionSpecified {
 		// Default compression will be Z if set but not specified
 		if strings.ToLower(compression) == "true" {
-			glog.V(5).Infof("gpfs_util compression was set to true. Defaulting to Z")
+			glog.V(5).Infof("[%s] gpfs_util compression was set to true. Defaulting to Z", loggerId)
 			compression = "z"
 		}
 
 		if !IsValidCompressionAlgorithm(compression) {
-			glog.V(5).Infof("gpfs_util invalid compression algorithm specified: %s",
+			glog.V(5).Infof("[%s] gpfs_util invalid compression algorithm specified: %s", loggerId,
 				compression)
 			return &scaleVolume{}, status.Errorf(codes.InvalidArgument,
 				"invalid compression algorithm specified: %s", compression)
 		}
 		scaleVol.Compression = compression
-		glog.V(5).Infof("gpfs_util compression was set to %s", compression)
+		glog.V(5).Infof("[%s] gpfs_util compression was set to %s", loggerId, compression)
 	}
 
 	if isTierSpecified && tier != "" {
 		scaleVol.Tier = tier
-		glog.V(5).Infof("gpfs_util tier was set: %s", tier)
+		glog.V(5).Infof("[%s] gpfs_util tier was set: %s", loggerId, tier)
 	}
 
 	return scaleVol, nil

--- a/driver/csiplugin/identityserver.go
+++ b/driver/csiplugin/identityserver.go
@@ -56,7 +56,7 @@ func (is *ScaleIdentityServer) Probe(ctx context.Context, req *csi.ProbeRequest)
 	scalenodeID := getNodeMapping(is.Driver.nodeID)
 	glog.V(4).Infof("[%s] Probe: scalenodeID:%s --known as-- k8snodeName: %s", loggerId, scalenodeID, is.Driver.nodeID)
 	// IsNodeComponentHealthy accepts nodeName as admin node name, daemon node name, etc.
-	ghealthy, err := is.Driver.connmap["primary"].IsNodeComponentHealthy(scalenodeID, "GPFS")
+	ghealthy, err := is.Driver.connmap["primary"].IsNodeComponentHealthy(ctx, scalenodeID, "GPFS")
 	if ghealthy == false {
 		glog.Errorf("[%s] Probe: GPFS component on node %v is not healthy. Error: %v", loggerId, scalenodeID, err)
 		return &csi.ProbeResponse{Ready: &wrappers.BoolValue{Value: true}}, nil

--- a/driver/csiplugin/identityserver.go
+++ b/driver/csiplugin/identityserver.go
@@ -45,7 +45,8 @@ func (is *ScaleIdentityServer) GetPluginCapabilities(ctx context.Context, req *c
 }
 
 func (is *ScaleIdentityServer) Probe(ctx context.Context, req *csi.ProbeRequest) (*csi.ProbeResponse, error) {
-	glog.V(4).Infof("Probe called with args: %#v", req)
+	loggerId := GetLoggerId(ctx)
+	glog.V(4).Infof("[%s] Probe called with args: %#v", loggerId, req)
 
 	// Determine plugin health
 	// If unhealthy return gRPC error code
@@ -53,11 +54,11 @@ func (is *ScaleIdentityServer) Probe(ctx context.Context, req *csi.ProbeRequest)
 
 	// Node mapping check
 	scalenodeID := getNodeMapping(is.Driver.nodeID)
-	glog.V(4).Infof("Probe: scalenodeID:%s --known as-- k8snodeName: %s", scalenodeID, is.Driver.nodeID)
+	glog.V(4).Infof("[%s] Probe: scalenodeID:%s --known as-- k8snodeName: %s", loggerId, scalenodeID, is.Driver.nodeID)
 	// IsNodeComponentHealthy accepts nodeName as admin node name, daemon node name, etc.
 	ghealthy, err := is.Driver.connmap["primary"].IsNodeComponentHealthy(scalenodeID, "GPFS")
 	if ghealthy == false {
-		glog.Errorf("Probe: GPFS component on node %v is not healthy. Error: %v", scalenodeID, err)
+		glog.Errorf("[%s] Probe: GPFS component on node %v is not healthy. Error: %v", loggerId, scalenodeID, err)
 		return &csi.ProbeResponse{Ready: &wrappers.BoolValue{Value: true}}, nil
 	}
 
@@ -67,13 +68,14 @@ func (is *ScaleIdentityServer) Probe(ctx context.Context, req *csi.ProbeRequest)
 	// 	return &csi.ProbeResponse{Ready: &wrappers.BoolValue{Value: true}}, err
 	// }
 
-	glog.V(4).Infof("Probe: GPFS on node %v is healthy", scalenodeID)
+	glog.V(4).Infof("[%s] Probe: GPFS on node %v is healthy", loggerId, scalenodeID)
 
 	return &csi.ProbeResponse{Ready: &wrappers.BoolValue{Value: true}}, nil
 }
 
 func (is *ScaleIdentityServer) GetPluginInfo(ctx context.Context, req *csi.GetPluginInfoRequest) (*csi.GetPluginInfoResponse, error) {
-	glog.V(5).Infof("Using default GetPluginInfo")
+	loggerId := GetLoggerId(ctx)
+	glog.V(5).Infof("[%s] Using default GetPluginInfo", loggerId)
 
 	if is.Driver.name == "" {
 		return nil, status.Error(codes.Unavailable, "Driver name not configured")

--- a/driver/csiplugin/nodeserver.go
+++ b/driver/csiplugin/nodeserver.go
@@ -40,6 +40,8 @@ type ScaleNodeServer struct {
 
 const hostDir = "/host"
 
+var GetLoggerId = utils.GetLoggerId
+
 // checkGpfsType checks if a given path is of type gpfs and
 // returns nil if it is a gpfs type, otherwise returns
 // corresponding error.

--- a/driver/csiplugin/nodeserver.go
+++ b/driver/csiplugin/nodeserver.go
@@ -58,9 +58,10 @@ func checkGpfsType(path string) (bool error) {
 }
 
 func (ns *ScaleNodeServer) NodePublishVolume(ctx context.Context, req *csi.NodePublishVolumeRequest) (*csi.NodePublishVolumeResponse, error) {
-	glog.V(3).Infof("nodeserver NodePublishVolume")
+	loggerId := GetLoggerId(ctx)
+	glog.V(3).Infof("[%s] nodeserver NodePublishVolume", loggerId)
 
-	glog.V(4).Infof("NodePublishVolume called with req: %#v", req)
+	glog.V(4).Infof("[%s] NodePublishVolume called with req: %#v", loggerId, req)
 
 	// Validate Arguments
 	targetPath := req.GetTargetPath()
@@ -83,7 +84,7 @@ func (ns *ScaleNodeServer) NodePublishVolume(ctx context.Context, req *csi.NodeP
 	}
 	volScalePath := volumeIDMembers.Path
 
-	glog.V(4).Infof("Target SpectrumScale Path : %v\n", volScalePath)
+	glog.V(4).Infof("[%s] Target SpectrumScale Path : %v\n", loggerId, volScalePath)
 
 	volScalePathInContainer := hostDir + volScalePath
 	f, err := os.Lstat(volScalePathInContainer)
@@ -97,7 +98,7 @@ func (ns *ScaleNodeServer) NodePublishVolume(ctx context.Context, req *csi.NodeP
 		}
 		volScalePathInContainer = hostDir + symlinkTarget
 		volScalePath = symlinkTarget
-		glog.V(4).Infof("NodePublishVolume: symlink tarrget path is [%s]\n", volScalePathInContainer)
+		glog.V(4).Infof("[%s] NodePublishVolume: symlink tarrget path is [%s]\n", loggerId, volScalePathInContainer)
 	}
 
 	err = checkGpfsType(volScalePathInContainer)
@@ -121,7 +122,7 @@ func (ns *ScaleNodeServer) NodePublishVolume(ctx context.Context, req *csi.NodeP
 	// create bind mount
 	options := []string{"bind"}
 	mounter := mount.New("")
-	glog.V(4).Infof("NodePublishVolume - creating bind mount [%v] -> [%v]", targetPath, volScalePath)
+	glog.V(4).Infof("[%s] NodePublishVolume - creating bind mount [%v] -> [%v]", loggerId, targetPath, volScalePath)
 	if err := mounter.Mount(volScalePath, targetPath, "", options); err != nil {
 		return nil, fmt.Errorf("failed to mount: [%s] at [%s]. Error [%v]", volScalePath, targetPath, err)
 	}
@@ -135,13 +136,14 @@ func (ns *ScaleNodeServer) NodePublishVolume(ctx context.Context, req *csi.NodeP
 		}
 		return nil, err
 	}
-	glog.V(4).Infof("successfully mounted %s", targetPath)
+	glog.V(4).Infof("[%s] successfully mounted %s", loggerId, targetPath)
 	return &csi.NodePublishVolumeResponse{}, nil
 }
 
 func (ns *ScaleNodeServer) NodeUnpublishVolume(ctx context.Context, req *csi.NodeUnpublishVolumeRequest) (*csi.NodeUnpublishVolumeResponse, error) {
-	glog.V(3).Infof("nodeserver NodeUnpublishVolume")
-	glog.V(4).Infof("NodeUnpublishVolume called with args: %v", req)
+	loggerId := GetLoggerId(ctx)
+	glog.V(3).Infof("[%s] nodeserver NodeUnpublishVolume", loggerId)
+	glog.V(4).Infof("[%s] NodeUnpublishVolume called with args: %v", loggerId, req)
 	// Validate Arguments
 	targetPath := req.GetTargetPath()
 	volID := req.GetVolumeId()
@@ -152,7 +154,7 @@ func (ns *ScaleNodeServer) NodeUnpublishVolume(ctx context.Context, req *csi.Nod
 		return nil, status.Error(codes.InvalidArgument, "target path must be provided")
 	}
 
-	glog.V(4).Infof("NodeUnpublishVolume - deleting the targetPath - [%v]", targetPath)
+	glog.V(4).Infof("[%s] NodeUnpublishVolume - deleting the targetPath - [%v]", loggerId, targetPath)
 
 	//Check if target is a symlink or bind mount and cleanup accordingly
 	f, err := os.Lstat(targetPath)
@@ -160,17 +162,17 @@ func (ns *ScaleNodeServer) NodeUnpublishVolume(ctx context.Context, req *csi.Nod
 		return nil, fmt.Errorf("failed to get lstat of target path [%s]. Error %v", targetPath, err)
 	}
 	if f.Mode()&os.ModeSymlink != 0 {
-		glog.V(4).Infof("%v is a symlink", targetPath)
+		glog.V(4).Infof("[%s] %v is a symlink", loggerId, targetPath)
 		if err := os.Remove(targetPath); err != nil {
 			return nil, status.Error(codes.Internal, fmt.Sprintf("failed to remove symlink targetPath [%v]. Error [%v]", targetPath, err.Error()))
 		}
 	} else {
-		glog.V(4).Infof("%v is a bind mount", targetPath)
+		glog.V(4).Infof("[%s] %v is a bind mount", loggerId, targetPath)
 		targetPathInContainer := hostDir + targetPath
 		notMP, err := mount.IsNotMountPoint(mount.New(""), targetPathInContainer)
 		if err != nil {
 			if os.IsNotExist(err) {
-				glog.V(4).Infof("target path %v is already deleted", targetPathInContainer)
+				glog.V(4).Infof("[%s] target path %v is already deleted", loggerId, targetPathInContainer)
 				return &csi.NodeUnpublishVolumeResponse{}, nil
 			}
 			return nil, fmt.Errorf("failed to check if target path [%s] is mount point. Error %v", targetPathInContainer, err)
@@ -181,23 +183,24 @@ func (ns *ScaleNodeServer) NodeUnpublishVolume(ctx context.Context, req *csi.Nod
 			if err != nil {
 				return nil, fmt.Errorf("failed to unmount the mount point [%s]. Error %v", targetPath, err)
 			}
-			glog.V(4).Infof("%v is a unmounted successfully", targetPath)
+			glog.V(4).Infof("[%s] %v is a unmounted successfully", loggerId, targetPath)
 		}
 		// Delete the mount point
 		if err = os.Remove(targetPathInContainer); err != nil {
 			return nil, fmt.Errorf("failed to remove the mount point [%s]. Error %v", targetPathInContainer, err)
 		}
 	}
-	glog.V(4).Infof("successfully unpublished %s", targetPath)
+	glog.V(4).Infof("[%s] successfully unpublished %s", loggerId, targetPath)
 	return &csi.NodeUnpublishVolumeResponse{}, nil
 }
 
 func (ns *ScaleNodeServer) NodeStageVolume(ctx context.Context, req *csi.NodeStageVolumeRequest) (
 	*csi.NodeStageVolumeResponse, error) {
-	glog.V(3).Infof("nodeserver NodeStageVolume")
+	loggerId := GetLoggerId(ctx)
+	glog.V(3).Infof("[%s] nodeserver NodeStageVolume", loggerId)
 	ns.mux.Lock()
 	defer ns.mux.Unlock()
-	glog.V(4).Infof("NodeStageVolume called with req: %#v", req)
+	glog.V(4).Infof("[%s] NodeStageVolume called with req: %#v", loggerId, req)
 
 	// Validate Arguments
 	volumeID := req.GetVolumeId()
@@ -217,10 +220,11 @@ func (ns *ScaleNodeServer) NodeStageVolume(ctx context.Context, req *csi.NodeSta
 
 func (ns *ScaleNodeServer) NodeUnstageVolume(ctx context.Context, req *csi.NodeUnstageVolumeRequest) (
 	*csi.NodeUnstageVolumeResponse, error) {
-	glog.V(3).Infof("nodeserver NodeUnstageVolume")
+	loggerId := GetLoggerId(ctx)
+	glog.V(3).Infof("[%s] nodeserver NodeUnstageVolume", loggerId)
 	ns.mux.Lock()
 	defer ns.mux.Unlock()
-	glog.V(4).Infof("NodeUnstageVolume called with req: %#v", req)
+	glog.V(4).Infof("[%s] NodeUnstageVolume called with req: %#v", loggerId, req)
 
 	// Validate arguments
 	volumeID := req.GetVolumeId()
@@ -236,14 +240,16 @@ func (ns *ScaleNodeServer) NodeUnstageVolume(ctx context.Context, req *csi.NodeU
 }
 
 func (ns *ScaleNodeServer) NodeGetCapabilities(ctx context.Context, req *csi.NodeGetCapabilitiesRequest) (*csi.NodeGetCapabilitiesResponse, error) {
-	glog.V(4).Infof("NodeGetCapabilities called with req: %#v", req)
+	loggerId := GetLoggerId(ctx)
+	glog.V(4).Infof("[%s] NodeGetCapabilities called with req: %#v", loggerId, req)
 	return &csi.NodeGetCapabilitiesResponse{
 		Capabilities: ns.Driver.nscap,
 	}, nil
 }
 
 func (ns *ScaleNodeServer) NodeGetInfo(ctx context.Context, req *csi.NodeGetInfoRequest) (*csi.NodeGetInfoResponse, error) {
-	glog.V(4).Infof("NodeGetInfo called with req: %#v", req)
+	loggerId := GetLoggerId(ctx)
+	glog.V(4).Infof("[%s] NodeGetInfo called with req: %#v", loggerId, req)
 	return &csi.NodeGetInfoResponse{
 		NodeId: ns.Driver.nodeID,
 	}, nil
@@ -254,7 +260,8 @@ func (ns *ScaleNodeServer) NodeExpandVolume(ctx context.Context, req *csi.NodeEx
 }
 
 func (ns *ScaleNodeServer) NodeGetVolumeStats(ctx context.Context, req *csi.NodeGetVolumeStatsRequest) (*csi.NodeGetVolumeStatsResponse, error) {
-	glog.V(4).Infof("NodeGetVolumeStats called with req: %#v", req)
+	loggerId := GetLoggerId(ctx)
+	glog.V(4).Infof("[%s] NodeGetVolumeStats called with req: %#v", loggerId, req)
 
 	if len(req.VolumeId) == 0 {
 		return nil, status.Error(codes.InvalidArgument, "NodeGetVolumeStats Volume ID must be provided")
@@ -285,15 +292,15 @@ func (ns *ScaleNodeServer) NodeGetVolumeStats(ctx context.Context, req *csi.Node
 	}
 
 	if available > capacity || used > capacity {
-		glog.V(4).Infof("incorrect values reported for volume (%v) against Available(%v) or Capacity(%v)",
-			volumeIDMembers.FsetName, available, capacity)
+		glog.V(4).Infof("[%s] incorrect values reported for volume (%v) against Available(%v) or Capacity(%v)",
+			loggerId, volumeIDMembers.FsetName, available, capacity)
 
 		return nil, status.Error(codes.InvalidArgument, fmt.Sprintf("incorrect values reported for volume (%v) against Available(%v) or Capacity(%v)",
 			volumeIDMembers.FsetName, available, capacity))
 	}
 
-	glog.V(4).Infof("stat for volume:%v, Total:%v, Used:%v Available:%v, Total Inodes:%v, Used Inodes:%v, Available Inodes:%v,",
-		volumeIDMembers.FsetName, capacity, used, available, inodes, inodesUsed, inodesFree)
+	glog.V(4).Infof("[%s] stat for volume:%v, Total:%v, Used:%v Available:%v, Total Inodes:%v, Used Inodes:%v, Available Inodes:%v,",
+		loggerId, volumeIDMembers.FsetName, capacity, used, available, inodes, inodesUsed, inodesFree)
 
 	return &csi.NodeGetVolumeStatsResponse{
 		Usage: []*csi.VolumeUsage{

--- a/driver/csiplugin/nodeserver.go
+++ b/driver/csiplugin/nodeserver.go
@@ -40,8 +40,6 @@ type ScaleNodeServer struct {
 
 const hostDir = "/host"
 
-var GetLoggerId = utils.GetLoggerId
-
 // checkGpfsType checks if a given path is of type gpfs and
 // returns nil if it is a gpfs type, otherwise returns
 // corresponding error.

--- a/driver/csiplugin/utils.go
+++ b/driver/csiplugin/utils.go
@@ -19,9 +19,9 @@ package scale
 import (
 	"context"
 
+	"github.com/IBM/ibm-spectrum-scale-csi/driver/csiplugin/utils"
 	csi "github.com/container-storage-interface/spec/lib/go/csi"
 	"github.com/golang/glog"
-	"golang.org/x/net/context"
 	"google.golang.org/grpc"
 )
 
@@ -50,15 +50,15 @@ func NewNodeServiceCapability(cap csi.NodeServiceCapability_RPC_Type) *csi.NodeS
 }
 
 func logGRPC(ctx context.Context, req interface{}, info *grpc.UnaryServerInfo, handler grpc.UnaryHandler) (interface{}, error) {
-	newCtx := setLoggerId(ctx)
-	loggerId
-	glog.V(3).Infof("[%s] GRPC call: %s", GetLoggerId(newCtx), info.FullMethod)
-	glog.V(5).Infof("[%s] GRPC request: %+v", GetLoggerId(newCtx), req)
+	newCtx := utils.SetLoggerId(ctx)
+	loggerId := utils.GetLoggerId(ctx)
+	glog.V(3).Infof("[%s] GRPC call: %s", loggerId, info.FullMethod)
+	glog.V(5).Infof("[%s] GRPC request: %+v", loggerId, req)
 	resp, err := handler(newCtx, req)
 	if err != nil {
-		glog.Errorf("[%s] GRPC error: %v", GetLoggerId(newCtx), err)
+		glog.Errorf("[%s] GRPC error: %v", loggerId, err)
 	} else {
-		glog.V(5).Infof("[%s] GRPC response: %+v", GetLoggerId(newCtx), resp)
+		glog.V(5).Infof("[%s] GRPC response: %+v", loggerId, resp)
 	}
 	return resp, err
 }

--- a/driver/csiplugin/utils.go
+++ b/driver/csiplugin/utils.go
@@ -66,7 +66,8 @@ func logGRPC(ctx context.Context, req interface{}, info *grpc.UnaryServerInfo, h
 }
 
 func setLoggerId(ctx context.Context) context.Context {
-	id := uuid.New()
+	id := uuid.New().String()
+	glog.V(3).Infof("uuid: %s", id.String())
 	return context.WithValue(ctx, loggerId, id)
 }
 

--- a/driver/csiplugin/utils.go
+++ b/driver/csiplugin/utils.go
@@ -22,6 +22,7 @@ import (
 	"github.com/IBM/ibm-spectrum-scale-csi/driver/csiplugin/utils"
 	csi "github.com/container-storage-interface/spec/lib/go/csi"
 	"github.com/golang/glog"
+
 	"google.golang.org/grpc"
 )
 
@@ -51,8 +52,9 @@ func NewNodeServiceCapability(cap csi.NodeServiceCapability_RPC_Type) *csi.NodeS
 
 func logGRPC(ctx context.Context, req interface{}, info *grpc.UnaryServerInfo, handler grpc.UnaryHandler) (interface{}, error) {
 	newCtx := utils.SetLoggerId(ctx)
-	loggerId := utils.GetLoggerId(ctx)
+	loggerId := utils.GetLoggerId(newCtx)
 	glog.V(3).Infof("[%s] GRPC call: %s", loggerId, info.FullMethod)
+	startTime := utils.GetExecutionTime()
 	glog.V(5).Infof("[%s] GRPC request: %+v", loggerId, req)
 	resp, err := handler(newCtx, req)
 	if err != nil {
@@ -60,5 +62,8 @@ func logGRPC(ctx context.Context, req interface{}, info *grpc.UnaryServerInfo, h
 	} else {
 		glog.V(5).Infof("[%s] GRPC response: %+v", loggerId, resp)
 	}
+	endTime := utils.GetExecutionTime()
+	diffTime := endTime - startTime
+	glog.V(5).Infof("[%s] Time taken to execute GRPC request(in milli): %d", loggerId, diffTime)
 	return resp, err
 }

--- a/driver/csiplugin/utils.go
+++ b/driver/csiplugin/utils.go
@@ -54,6 +54,7 @@ func NewNodeServiceCapability(cap csi.NodeServiceCapability_RPC_Type) *csi.NodeS
 
 func logGRPC(ctx context.Context, req interface{}, info *grpc.UnaryServerInfo, handler grpc.UnaryHandler) (interface{}, error) {
 	newCtx := setLoggerId(ctx)
+	loggerId
 	glog.V(3).Infof("[%s] GRPC call: %s", GetLoggerId(newCtx), info.FullMethod)
 	glog.V(5).Infof("[%s] GRPC request: %+v", GetLoggerId(newCtx), req)
 	resp, err := handler(newCtx, req)

--- a/driver/csiplugin/utils.go
+++ b/driver/csiplugin/utils.go
@@ -21,12 +21,9 @@ import (
 
 	csi "github.com/container-storage-interface/spec/lib/go/csi"
 	"github.com/golang/glog"
-	"github.com/google/uuid"
 	"golang.org/x/net/context"
 	"google.golang.org/grpc"
 )
-
-const loggerId = "logger_id"
 
 func NewVolumeCapabilityAccessMode(mode csi.VolumeCapability_AccessMode_Mode) *csi.VolumeCapability_AccessMode {
 	return &csi.VolumeCapability_AccessMode{Mode: mode}
@@ -64,15 +61,4 @@ func logGRPC(ctx context.Context, req interface{}, info *grpc.UnaryServerInfo, h
 		glog.V(5).Infof("[%s] GRPC response: %+v", GetLoggerId(newCtx), resp)
 	}
 	return resp, err
-}
-
-func setLoggerId(ctx context.Context) context.Context {
-	id := uuid.New().String()
-	glog.V(3).Infof("uuid: %s", id.String())
-	return context.WithValue(ctx, loggerId, id)
-}
-
-func GetLoggerId(ctx context.Context) (string, bool) {
-	logger, ok := ctx.Value(loggerId).(string)
-	return logger, ok
 }

--- a/driver/csiplugin/utils/utils.go
+++ b/driver/csiplugin/utils/utils.go
@@ -190,13 +190,13 @@ func FsStatInfo(path string) (int64, int64, int64, int64, int64, int64, error) {
 	return available, capacity, usage, inodes, inodesFree, inodesUsed, nil
 }
 
-func setLoggerId(ctx context.Context) context.Context {
+func SetLoggerId(ctx context.Context) context.Context {
 	id := uuid.New().String()
 	glog.V(3).Infof("uuid: %s", id.String())
 	return context.WithValue(ctx, loggerId, id)
 }
 
-func GetLoggerId(ctx context.Context) (string, bool) {
-	logger, ok := ctx.Value(loggerId).(string)
-	return logger, ok
+func GetLoggerId(ctx context.Context) string {
+	logger, _ := ctx.Value(loggerId).(string)
+	return logger
 }

--- a/driver/csiplugin/utils/utils.go
+++ b/driver/csiplugin/utils/utils.go
@@ -17,6 +17,7 @@
 package utils
 
 import (
+	"context"
 	"fmt"
 	"io/ioutil"
 	"os"
@@ -24,8 +25,11 @@ import (
 	"strings"
 
 	"github.com/golang/glog"
+	"github.com/google/uuid"
 	"golang.org/x/sys/unix"
 )
+
+const loggerId = "logger_id"
 
 func ReadFile(path string) ([]byte, error) {
 	glog.V(6).Infof("utils ReadFile. path: %s", path)
@@ -184,4 +188,15 @@ func FsStatInfo(path string) (int64, int64, int64, int64, int64, int64, error) {
 	inodesUsed := inodes - inodesFree
 
 	return available, capacity, usage, inodes, inodesFree, inodesUsed, nil
+}
+
+func setLoggerId(ctx context.Context) context.Context {
+	id := uuid.New().String()
+	glog.V(3).Infof("uuid: %s", id.String())
+	return context.WithValue(ctx, loggerId, id)
+}
+
+func GetLoggerId(ctx context.Context) (string, bool) {
+	logger, ok := ctx.Value(loggerId).(string)
+	return logger, ok
 }

--- a/driver/csiplugin/utils/utils.go
+++ b/driver/csiplugin/utils/utils.go
@@ -23,6 +23,7 @@ import (
 	"os"
 	"strconv"
 	"strings"
+	"time"
 
 	"github.com/golang/glog"
 	"github.com/google/uuid"
@@ -192,11 +193,16 @@ func FsStatInfo(path string) (int64, int64, int64, int64, int64, int64, error) {
 
 func SetLoggerId(ctx context.Context) context.Context {
 	id := uuid.New().String()
-	glog.V(3).Infof("uuid: %s", id.String())
 	return context.WithValue(ctx, loggerId, id)
 }
 
 func GetLoggerId(ctx context.Context) string {
 	logger, _ := ctx.Value(loggerId).(string)
 	return logger
+}
+
+func GetExecutionTime() int64 {
+	t := time.Now()
+	timeinMilliSec := int64(time.Nanosecond) * t.UnixNano() / int64(time.Millisecond)
+	return timeinMilliSec
 }

--- a/driver/go.mod
+++ b/driver/go.mod
@@ -6,6 +6,7 @@ require (
 	github.com/container-storage-interface/spec v1.5.0
 	github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b
 	github.com/golang/protobuf v1.3.2
+	github.com/google/uuid v1.3.0
 	golang.org/x/net v0.0.0-20191028085509-fe3aa8a45271
 	golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a
 	google.golang.org/grpc v1.26.0

--- a/driver/go.mod
+++ b/driver/go.mod
@@ -7,13 +7,13 @@ require (
 	github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b
 	github.com/golang/protobuf v1.3.2
 	golang.org/x/net v0.0.0-20191028085509-fe3aa8a45271
+	golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a
 	google.golang.org/grpc v1.26.0
 	k8s.io/mount-utils v0.23.5
 )
 
 require (
 	github.com/go-logr/logr v1.2.0 // indirect
-	golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a // indirect
 	golang.org/x/text v0.3.0 // indirect
 	google.golang.org/genproto v0.0.0-20190819201941-24fa4b261c55 // indirect
 	k8s.io/klog/v2 v2.30.0 // indirect

--- a/driver/go.sum
+++ b/driver/go.sum
@@ -21,6 +21,8 @@ github.com/golang/protobuf v1.3.2 h1:6nsPYzhq5kReh6QImI3k5qWzO4PEbvbIW2cwSfR/6xs
 github.com/golang/protobuf v1.3.2/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
 github.com/google/go-cmp v0.2.0 h1:+dTQ8DZQJz0Mb/HjFlkptS1FeQ4cWSnN941F8aEG4SQ=
 github.com/google/go-cmp v0.2.0/go.mod h1:oXzfMopK8JAjlY9xF4vHSVASa0yLyX7SntLO5aqRK0M=
+github.com/google/uuid v1.3.0 h1:t6JiXgmwXMjEs8VusXIJk2BXHsn+wx8BZdTaoZ5fu7I=
+github.com/google/uuid v1.3.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=
 github.com/kr/text v0.1.0/go.mod h1:4Jbv+DJW3UT/LiOwJeYQe1efqtUx/iVham/4vfdArNI=
 github.com/kr/text v0.2.0/go.mod h1:eLer722TekiGuMkidMxC/pM04lWEeraHUUmBw8l2grE=


### PR DESCRIPTION
Addressed below requirements:

When volume creation or other operations are tried in parallel, it is very difficult to track the flow of operation in the csi logs. Having context/transaction id passed in the flow will help track the flow of operations individually.

Logging the time taken for each operation like volume create delete
Marking when operation started and completed


