### PR TITLE
Fix for log rotate

### DIFF
--- a/driver/cmd/ibm-spectrum-scale-csi/main.go
+++ b/driver/cmd/ibm-spectrum-scale-csi/main.go
@@ -208,25 +208,14 @@ func InitFileLogger() func() {
 		panic(fmt.Sprintf("failed to init logger %v", err))
 	}
 
-	fileStat, err := logFile.Stat()
-	if err != nil {
-		panic(fmt.Sprintf("failed to stat logger file %v", err))
-	}
-
-	fileStatSize := int(fileStat.Size()) / 1024 / 1024
-
-	// If log file size bigger than rotateSize, will use lumberjack to run the logrotate
-	if fileStatSize < rotateSize {
-		klog.SetOutput(logFile)
-	} else {
-		klog.SetOutput(&lumberjack.Logger{
-			Filename:   filePath,
-			MaxSize:    rotateSize,
-			MaxBackups: 5,
-			MaxAge:     0,
-			Compress:   true,
-		})
-	}
+	l := &lumberjack.Logger{
+                Filename:   filePath,
+                MaxSize:    rotateSize,
+                MaxBackups: 5,
+                MaxAge:     0,
+                Compress:   true,
+        }
+        klog.SetOutput(l)
 	
 	closeFn := func(){
 		err := logFile.Close()


### PR DESCRIPTION
Signed-off-by: “hemalathagajendran” <“hemalatha.gajendran@ibm.com”>

## Pull request checklist

<!-- Add your one liner release notes here -->
<!-- eg... -->
<!--   - Major functionality adds -->
<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->
<!--   - are you changing our ScaleCluster CR file? -->
No


## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [x] Bugfix
- [ ] Feature Enhancement
- [ ] Test Automation 
- [ ] Code Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Community Operator listing 
- [ ] Other (please describe): 


## What is the current behavior?
Log rotate doesn't consider existing log file size if pod restarts
-

## What is the new behavior?
Log rotate considers existing log file size if pod restarts
-

## How risky is this change?
- [ x] Small, isolated change
- [ ] Medium, requires regression testing
- [ ] Large, requires functional and regression testing 

