### PR TITLE
Enable/Disable volume stats capability

### DIFF
--- a/driver/csiplugin/gpfs.go
+++ b/driver/csiplugin/gpfs.go
@@ -225,14 +225,13 @@ func (driver *ScaleDriver) SetupScaleDriver(ctx context.Context, name, vendorVer
 	}
 	_ = driver.AddControllerServiceCapabilities(ctx, csc)
 
+	ns := []csi.NodeServiceCapability_RPC_Type{}
 	statsCapability := os.Getenv(volumeStatsCapability)
 	if strings.ToUpper(statsCapability) != "DISABLED" {
 		klog.Infof("[%s] volume stats capabililty is enabled", utils.GetLoggerId(ctx))
-		ns := []csi.NodeServiceCapability_RPC_Type{
-			csi.NodeServiceCapability_RPC_GET_VOLUME_STATS,
-		}
-		_ = driver.AddNodeServiceCapabilities(ctx, ns)
+		ns = append(ns, csi.NodeServiceCapability_RPC_GET_VOLUME_STATS)
 	}
+	_ = driver.AddNodeServiceCapabilities(ctx, ns)
 
 	driver.ids = NewIdentityServer(ctx, driver)
 	driver.ns = NewNodeServer(ctx, driver)

--- a/driver/csiplugin/gpfs.go
+++ b/driver/csiplugin/gpfs.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"strings"
 	"sync"
 	"time"
 
@@ -225,8 +226,8 @@ func (driver *ScaleDriver) SetupScaleDriver(ctx context.Context, name, vendorVer
 	_ = driver.AddControllerServiceCapabilities(ctx, csc)
 
 	statsCapability := os.Getenv(volumeStatsCapability)
-	if statsCapability == "ENABLED" {
-		klog.Infof("[%s] volume stats capabililty in node is enabled", utils.GetLoggerId(ctx))
+	if strings.ToUpper(statsCapability) != "DISABLED" {
+		klog.Infof("[%s] volume stats capabililty is enabled", utils.GetLoggerId(ctx))
 		ns := []csi.NodeServiceCapability_RPC_Type{
 			csi.NodeServiceCapability_RPC_GET_VOLUME_STATS,
 		}

--- a/driver/csiplugin/gpfs.go
+++ b/driver/csiplugin/gpfs.go
@@ -230,6 +230,8 @@ func (driver *ScaleDriver) SetupScaleDriver(ctx context.Context, name, vendorVer
 	if strings.ToUpper(statsCapability) != "DISABLED" {
 		klog.Infof("[%s] volume stats capabililty is enabled", utils.GetLoggerId(ctx))
 		ns = append(ns, csi.NodeServiceCapability_RPC_GET_VOLUME_STATS)
+	} else {
+		klog.Infof("[%s] volume stats capabililty is disabled", utils.GetLoggerId(ctx))
 	}
 	_ = driver.AddNodeServiceCapabilities(ctx, ns)
 


### PR DESCRIPTION
## Pull request checklist

<!-- Add your one liner release notes here -->
<!-- eg... -->
<!--   - Major functionality adds -->
<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->
<!--   - are you changing our ScaleCluster CR file? -->
```No
```

## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [x] Bugfix
- [ ] Feature Enhancement
- [ ] Test Automation 
- [ ] Code Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Community Operator listing 
- [ ] Other (please describe): 


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying -->
- stats call is causing timeout during mount

## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->
- to control the volume stats capability so it would not make stats call when it is disabled

## How risky is this change?
- [x] Small, isolated change
- [ ] Medium, requires regression testing
- [ ] Large, requires functional and regression testing 

