### PR TITLE
Fix upgrade path

### DIFF
--- a/driver/csiplugin/gpfs.go
+++ b/driver/csiplugin/gpfs.go
@@ -262,6 +262,11 @@ func (driver *ScaleDriver) PluginInitialize(ctx context.Context) (map[string]con
 
 			scaleConnMap["primary"] = sc
 			scaleConfig.Clusters[i].Primary.PrimaryCid = clusterId
+
+			//If primary fileset value is not specified then use the default one
+			if scaleConfig.Clusters[i].Primary.PrimaryFset == "" {
+				scaleConfig.Clusters[i].Primary.PrimaryFset = defaultPrimaryFileset
+			}
 			primaryInfo = scaleConfig.Clusters[i].Primary
 		}
 	}

--- a/operator/controllers/csiscaleoperator_controller.go
+++ b/operator/controllers/csiscaleoperator_controller.go
@@ -1874,8 +1874,8 @@ func (r *CSIScaleOperatorReconciler) handleSpectrumScaleConnectors(instance *csi
 //directory and error if there is any.
 func (r *CSIScaleOperatorReconciler) handlePrimaryFSandFileset(instance *csiscaleoperator.CSIScaleOperator) (string, error) {
 	logger := csiLog.WithName("handlePrimaryFSandFileset")
-	primary := r.getPrimaryCluster(instance)
-	if primary == nil {
+	primaryReference := r.getPrimaryCluster(instance)
+	if primaryReference == nil {
 		message := fmt.Sprintf("No primary cluster is defined in the Spectrum Scale CSI configurations under Spec.Clusters section in the CSISCaleOperator instance %s/%s", instance.Kind, instance.Name)
 		err := fmt.Errorf(message)
 		logger.Error(err, "")
@@ -1885,6 +1885,7 @@ func (r *CSIScaleOperatorReconciler) handlePrimaryFSandFileset(instance *csiscal
 		return "", err
 	}
 
+	primary := *primaryReference
 	sc := scaleConnMap[config.Primary]
 
 	// check if primary filesystem exists


### PR DESCRIPTION
## Pull request checklist
-  Fix for upgrade path
    - https://github.com/IBM/ibm-spectrum-scale-csi/issues/898 and 
    - https://github.com/IBM/ibm-spectrum-scale-csi/issues/873

Please check the type of change your PR introduces:
- [x] Bugfix
- [ ] Feature Enhancement
- [ ] Test Automation 
- [ ] Code Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Community Operator listing 
- [ ] Other (please describe): 


## What is the current behavior?
- Operator sets default primary fileset in 1st pass, which causes inconsistency between the CRs of CSI 2.8.0 and 2.9.0. For upgrade case (which is not a 1st pass) - operator does not set default primary fileset if it is empty in CR, which leads to an incorrect fileset/path for volume creation

## What is the new behavior?
Operator now does not update CR with the default primary fileset when primary fileset is empty in CR, instead driver sets default primary fileset to avoid upgrade path failures.

## How risky is this change?
- [x] Small, isolated change
- [ ] Medium, requires regression testing
- [ ] Large, requires functional and regression testing 

