### PR TITLE
Fix pod restarts

### DIFF
--- a/operator/controllers/syncer/csi_node.go
+++ b/operator/controllers/syncer/csi_node.go
@@ -19,6 +19,7 @@ package syncer
 import (
 	"errors"
 	"os"
+	"sort"
 	"strconv"
 
 	"github.com/imdario/mergo"
@@ -98,10 +99,16 @@ func GetCSIDaemonsetSyncer(c client.Client, scheme *runtime.Scheme, driver *csis
 	UUID = CGPrefix
 
 	cmEnvVars = []corev1.EnvVar{}
-	for key, value := range envVars {
+	var keys []string
+	for k := range envVars {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+
+	for _, k := range keys {
 		cmEnvVars = append(cmEnvVars, corev1.EnvVar{
-			Name:  key,
-			Value: value,
+			Name:  k,
+			Value: envVars[k],
 		})
 	}
 

--- a/operator/controllers/syncer/csi_syncer.go
+++ b/operator/controllers/syncer/csi_syncer.go
@@ -89,7 +89,8 @@ func CSIConfigmapSyncer(c client.Client, scheme *runtime.Scheme, driver *csiscal
 }
 
 // GetAttacherSyncer returns a new kubernetes.Object syncer for k8s deployment object for CSI attacher service.
-func GetAttacherSyncer(c client.Client, scheme *runtime.Scheme, driver *csiscaleoperator.CSIScaleOperator) syncer.Interface {
+func GetAttacherSyncer(c client.Client, scheme *runtime.Scheme, driver *csiscaleoperator.CSIScaleOperator,
+	restartedAtKey string, restartedAtValue string) syncer.Interface {
 
 	logger := csiLog.WithName("GetAttacherSyncer")
 	logger.Info("Creating a syncer object for the attacher deployment.")
@@ -109,12 +110,13 @@ func GetAttacherSyncer(c client.Client, scheme *runtime.Scheme, driver *csiscale
 	}
 
 	return syncer.NewObjectSyncer(config.CSIController.String(), driver.Unwrap(), obj, c, func() error {
-		return sync.SyncAttacherFn()
+		return sync.SyncAttacherFn(restartedAtKey, restartedAtValue)
 	})
 }
 
 // GetProvisionerSyncer returns a new kubernetes.Object syncer for k8s deployment object for CSI provisioner service.
-func GetProvisionerSyncer(c client.Client, scheme *runtime.Scheme, driver *csiscaleoperator.CSIScaleOperator) syncer.Interface {
+func GetProvisionerSyncer(c client.Client, scheme *runtime.Scheme, driver *csiscaleoperator.CSIScaleOperator,
+	restartedAtKey string, restartedAtValue string) syncer.Interface {
 
 	logger := csiLog.WithName("GetProvisionerSyncer")
 	logger.Info("Creating a syncer object for the provisioner deployment.")
@@ -134,12 +136,13 @@ func GetProvisionerSyncer(c client.Client, scheme *runtime.Scheme, driver *csisc
 	}
 
 	return syncer.NewObjectSyncer(config.CSIController.String(), driver.Unwrap(), obj, c, func() error {
-		return sync.SyncProvisionerFn()
+		return sync.SyncProvisionerFn(restartedAtKey, restartedAtValue)
 	})
 }
 
 // GetSnapshotterSyncer returns a new kubernetes.Object syncer for k8s deployment object for CSI snapshotter service.
-func GetSnapshotterSyncer(c client.Client, scheme *runtime.Scheme, driver *csiscaleoperator.CSIScaleOperator) syncer.Interface {
+func GetSnapshotterSyncer(c client.Client, scheme *runtime.Scheme, driver *csiscaleoperator.CSIScaleOperator,
+	restartedAtKey string, restartedAtValue string) syncer.Interface {
 
 	logger := csiLog.WithName("GetSnapshotterSyncer")
 	logger.Info("Creating a syncer object for the snapshotter deployment.")
@@ -159,12 +162,13 @@ func GetSnapshotterSyncer(c client.Client, scheme *runtime.Scheme, driver *csisc
 	}
 
 	return syncer.NewObjectSyncer(config.CSIController.String(), driver.Unwrap(), obj, c, func() error {
-		return sync.SyncSnapshotterFn()
+		return sync.SyncSnapshotterFn(restartedAtKey, restartedAtValue)
 	})
 }
 
 // GetResizerSyncer returns a new kubernetes.Object syncer for k8s deployment object for CSI resizer service.
-func GetResizerSyncer(c client.Client, scheme *runtime.Scheme, driver *csiscaleoperator.CSIScaleOperator) syncer.Interface {
+func GetResizerSyncer(c client.Client, scheme *runtime.Scheme, driver *csiscaleoperator.CSIScaleOperator,
+	restartedAtKey string, restartedAtValue string) syncer.Interface {
 
 	logger := csiLog.WithName("GetResizerSyncer")
 	logger.Info("Creating a syncer object for the resizer deployment.")
@@ -184,7 +188,7 @@ func GetResizerSyncer(c client.Client, scheme *runtime.Scheme, driver *csiscaleo
 	}
 
 	return syncer.NewObjectSyncer(config.CSIController.String(), driver.Unwrap(), obj, c, func() error {
-		return sync.SyncResizerFn()
+		return sync.SyncResizerFn(restartedAtKey, restartedAtValue)
 	})
 }
 
@@ -210,7 +214,7 @@ func (s *csiControllerSyncer) SyncConfigMapFn() error {
 }
 
 // SyncAttacherFn is a function which mutates the existing attacher deployment object into it's desired state.
-func (s *csiControllerSyncer) SyncAttacherFn() error {
+func (s *csiControllerSyncer) SyncAttacherFn(restartedAtKey string, restartedAtValue string) error {
 
 	logger := csiLog.WithName("SyncAttacherFn")
 	logger.Info("Mutating the attacher deployment object into it's desired state.")
@@ -234,7 +238,7 @@ func (s *csiControllerSyncer) SyncAttacherFn() error {
 
 	// ensure template
 	out.Spec.Template.ObjectMeta.Labels = s.driver.GetCSIControllerPodLabels(config.GetNameForResource(config.CSIControllerAttacher, s.driver.Name))
-	out.Spec.Template.ObjectMeta.Annotations = s.driver.GetAnnotations("", "")
+	out.Spec.Template.ObjectMeta.Annotations = s.driver.GetAnnotations(restartedAtKey, restartedAtValue)
 	out.Spec.Template.Spec.NodeSelector = s.driver.GetNodeSelectors(s.driver.Spec.AttacherNodeSelector)
 	//out.Spec.Template.ObjectMeta.Annotations = s.driver.GetAnnotations()
 	out.Spec.Template.Spec.Tolerations = []corev1.Toleration{}
@@ -249,7 +253,7 @@ func (s *csiControllerSyncer) SyncAttacherFn() error {
 }
 
 // SyncProvisionerFn is a function which mutates the existing provisioner deployment object into it's desired state.
-func (s *csiControllerSyncer) SyncProvisionerFn() error {
+func (s *csiControllerSyncer) SyncProvisionerFn(restartedAtKey string, restartedAtValue string) error {
 
 	logger := csiLog.WithName("SyncProvisionerFn")
 	logger.Info("Mutating the provisioner deployment object into it's desired state.")
@@ -271,7 +275,7 @@ func (s *csiControllerSyncer) SyncProvisionerFn() error {
 
 	// ensure template
 	out.Spec.Template.ObjectMeta.Labels = s.driver.GetCSIControllerPodLabels(config.GetNameForResource(config.CSIControllerProvisioner, s.driver.Name))
-	out.Spec.Template.ObjectMeta.Annotations = s.driver.GetAnnotations("", "")
+	out.Spec.Template.ObjectMeta.Annotations = s.driver.GetAnnotations(restartedAtKey, restartedAtValue)
 	out.Spec.Template.Spec.NodeSelector = s.driver.GetNodeSelectors(s.driver.Spec.ProvisionerNodeSelector)
 	//out.Spec.Template.ObjectMeta.Annotations = s.driver.GetAnnotations()
 	out.Spec.Template.Spec.Tolerations = []corev1.Toleration{}
@@ -286,7 +290,7 @@ func (s *csiControllerSyncer) SyncProvisionerFn() error {
 }
 
 // SyncSnapshotterFn is a function which mutates the existing snapshotter deployment object into it's desired state.
-func (s *csiControllerSyncer) SyncSnapshotterFn() error {
+func (s *csiControllerSyncer) SyncSnapshotterFn(restartedAtKey string, restartedAtValue string) error {
 
 	logger := csiLog.WithName("SyncSnapshotterFn")
 	logger.Info("Mutating the snapshotter deployment object into it's desired state.")
@@ -308,7 +312,7 @@ func (s *csiControllerSyncer) SyncSnapshotterFn() error {
 
 	// ensure template
 	out.Spec.Template.ObjectMeta.Labels = s.driver.GetCSIControllerPodLabels(config.GetNameForResource(config.CSIControllerSnapshotter, s.driver.Name))
-	out.Spec.Template.ObjectMeta.Annotations = s.driver.GetAnnotations("", "")
+	out.Spec.Template.ObjectMeta.Annotations = s.driver.GetAnnotations(restartedAtKey, restartedAtValue)
 	out.Spec.Template.Spec.NodeSelector = s.driver.GetNodeSelectors(s.driver.Spec.SnapshotterNodeSelector)
 	//out.Spec.Template.ObjectMeta.Annotations = s.driver.GetAnnotations()
 	out.Spec.Template.Spec.Tolerations = []corev1.Toleration{}
@@ -323,7 +327,7 @@ func (s *csiControllerSyncer) SyncSnapshotterFn() error {
 }
 
 // SyncResizerFn is a function which mutates the existing resizer deployment object into it's desired state.
-func (s *csiControllerSyncer) SyncResizerFn() error {
+func (s *csiControllerSyncer) SyncResizerFn(restartedAtKey string, restartedAtValue string) error {
 
 	logger := csiLog.WithName("SyncResizerFn")
 	logger.Info("Mutating the resizer deployment object into it's desired state.")
@@ -345,7 +349,7 @@ func (s *csiControllerSyncer) SyncResizerFn() error {
 
 	// ensure template
 	out.Spec.Template.ObjectMeta.Labels = s.driver.GetCSIControllerPodLabels(config.GetNameForResource(config.CSIControllerResizer, s.driver.Name))
-	out.Spec.Template.ObjectMeta.Annotations = s.driver.GetAnnotations("", "")
+	out.Spec.Template.ObjectMeta.Annotations = s.driver.GetAnnotations(restartedAtKey, restartedAtValue)
 	out.Spec.Template.Spec.NodeSelector = s.driver.GetNodeSelectors(s.driver.Spec.ResizerNodeSelector)
 	//out.Spec.Template.ObjectMeta.Annotations = s.driver.GetAnnotations()
 	out.Spec.Template.Spec.Tolerations = []corev1.Toleration{}


### PR DESCRIPTION
- Fixing unnecessary driver pods restarts - https://github.com/IBM/ibm-spectrum-scale-csi/issues/926
- For the 1st volume operation after the optional configmap is updated, sidecars may still restart as sidecar pods may come up with a connection to socket of the old driver pod  before driver pod creates a new socket

Please check the type of change your PR introduces:
- [x] Bugfix
- [ ] Feature Enhancement
- [ ] Test Automation 
- [ ] Code Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Community Operator listing 
- [ ] Other (please describe): 


## What is the current behavior?
- Unnecessary driver pod restarts

## What is the new behavior?
- Driver pods don't restart on volume operation

## How risky is this change?
- [ ] Small, isolated change
- [x] Medium, requires regression testing
- [ ] Large, requires functional and regression testing 

