### PR TITLE
Fix preStop

### DIFF
--- a/operator/controllers/syncer/csi_node.go
+++ b/operator/controllers/syncer/csi_node.go
@@ -255,7 +255,7 @@ func (s *csiNodeSyncer) ensureContainersSpec() []corev1.Container {
 	nodePlugin.Lifecycle = &corev1.Lifecycle{
 		PreStop: &corev1.LifecycleHandler{
 			Exec: &corev1.ExecAction{
-				Command: []string{"/bin/sh", "-c", "rm -rf", s.driver.GetSocketPath()},
+				Command: []string{"/bin/sh", "-c", "rm -rf " + s.driver.GetSocketPath()},
 			},
 		},
 	}

--- a/operator/controllers/syncer/csi_node.go
+++ b/operator/controllers/syncer/csi_node.go
@@ -255,7 +255,7 @@ func (s *csiNodeSyncer) ensureContainersSpec() []corev1.Container {
 	nodePlugin.Lifecycle = &corev1.Lifecycle{
 		PreStop: &corev1.LifecycleHandler{
 			Exec: &corev1.ExecAction{
-				Command: []string{"/bin/sh", "-c", "rm -rf " + s.driver.GetSocketPath()},
+				Command: []string{"/bin/sh", "-c", "rm -f " + s.driver.GetSocketPath()},
 			},
 		},
 	}

--- a/operator/controllers/syncer/csi_node.go
+++ b/operator/controllers/syncer/csi_node.go
@@ -252,6 +252,14 @@ func (s *csiNodeSyncer) ensureContainersSpec() []corev1.Container {
 
 	nodePlugin.SecurityContext = sc
 
+	nodePlugin.Lifecycle = &corev1.Lifecycle{
+		PreStop: &corev1.LifecycleHandler{
+			Exec: &corev1.ExecAction{
+				Command: []string{"/bin/sh", "-c", "rm -rf", s.driver.GetSocketPath()},
+			},
+		},
+	}
+
 	// node driver registrar sidecar
 	registrar := s.ensureContainer(nodeDriverRegistrarContainerName,
 		s.getImage(config.CSINodeDriverRegistrar),
@@ -261,13 +269,7 @@ func (s *csiNodeSyncer) ensureContainersSpec() []corev1.Container {
 			"--v=5",
 		},
 	)
-	registrar.Lifecycle = &corev1.Lifecycle{
-		PreStop: &corev1.LifecycleHandler{
-			Exec: &corev1.ExecAction{
-				Command: []string{"/bin/sh", "-c", "rm -rf", s.driver.GetSocketPath()},
-			},
-		},
-	}
+
 	// registrar.SecurityContext = &corev1.SecurityContext{AllowPrivilegeEscalation: boolptr.True()}
 	registrar.SecurityContext = &corev1.SecurityContext{Privileged: boolptr.True()}
 	// fillSecurityContextCapabilities(registrar.SecurityContext)


### PR DESCRIPTION
- Set preStop hook (to delete the socket file) in CSI driver container instead of driver-registrar
- Fix for https://github.com/IBM/ibm-spectrum-scale-csi/issues/924
- Partial fix for https://github.com/IBM/ibm-spectrum-scale-csi/issues/864

Please check the type of change your PR introduces:
- [x] Bugfix
- [ ] Feature Enhancement
- [ ] Test Automation 
- [ ] Code Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Community Operator listing 
- [ ] Other (please describe): 


## What is the current behavior?
preStop hook is present in driver-registrar container, which fails due to absence of shell
## What is the new behavior?
preStop hook is moved to csi driver container

## How risky is this change?
- [x] Small, isolated change
- [ ] Medium, requires regression testing
- [ ] Large, requires functional and regression testing 

