### PR TITLE
adding PriorityClass to driver pod and attacher

### DIFF
--- a/operator/controllers/syncer/csi_node.go
+++ b/operator/controllers/syncer/csi_node.go
@@ -193,6 +193,7 @@ func (s *csiNodeSyncer) ensurePodSpec(secrets []corev1.LocalObjectReference) cor
 		Tolerations:        s.driver.Spec.Tolerations,
 		ImagePullSecrets:   secrets,
 		Affinity:           s.driver.GetAffinity(config.NodePlugin.String()),
+		PriorityClassName:  "system-node-critical",
 	}
 	return pod
 }

--- a/operator/controllers/syncer/csi_syncer.go
+++ b/operator/controllers/syncer/csi_syncer.go
@@ -421,6 +421,7 @@ func (s *csiControllerSyncer) ensureAttacherPodSpec(secrets []corev1.LocalObject
 		Affinity:           s.driver.GetAffinity(config.Attacher.String()),
 		ServiceAccountName: config.GetNameForResource(config.CSIAttacherServiceAccount, s.driver.Name),
 		ImagePullSecrets:   secrets,
+		PriorityClassName:  "system-node-critical",
 	}
 
 	pod.Tolerations = append(pod.Tolerations, s.driver.GetNodeTolerations()...)


### PR DESCRIPTION
CSI driver pod and Attacher pod should be drained after all application pods since unmount/detach operation has to succeed 