### PR TITLE
Fix whitespaces in secret credentials + add REST call info

### DIFF
--- a/operator/controllers/csiscaleoperator_controller.go
+++ b/operator/controllers/csiscaleoperator_controller.go
@@ -1732,8 +1732,8 @@ func (r *CSIScaleOperatorReconciler) newConnector(instance *csiscaleoperator.CSI
 			)
 			return nil, err
 		}
-		username = string(secret.Data[config.SecretUsername])
-		password = string(secret.Data[config.SecretPassword])
+		username = strings.TrimSpace(string(secret.Data[config.SecretUsername]))
+		password = strings.TrimSuffix(string(secret.Data[config.SecretPassword]), "\n")
 	}
 
 	if cluster.SecureSslMode == true && cluster.Cacert != "" {


### PR DESCRIPTION
- Fix whitespaces read from secret username and password
- Add more details like the URL, username, params, etc in error returned when REST call to GUI fails

Please check the type of change your PR introduces:
- [x] Bugfix
- [ ] Feature Enhancement
- [ ] Test Automation 
- [ ] Code Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Community Operator listing 
- [ ] Other (please describe): 


## What is the current behavior?
- Whitespaces (including newlines) are not trimmed from username, newline at the end of password is not trimmed - which leads to authentication issue with GUI.
- If a REST call fails, operator does not have details about the called REST API.

## What is the new behavior?
- Whitespaces (including newlines) are trimmed from username, newline at the end of password is  trimmed. 
- If a REST call fails, operator will have the details about the called REST API after operator points to the driver once the PR is merged.

## How risky is this change?
- [x] Small, isolated change
- [ ] Medium, requires regression testing
- [ ] Large, requires functional and regression testing 

