### PR TITLE
Fix dot in secret/cacert and wrong config issue

### DIFF
--- a/driver/csiplugin/settings/scale_config.go
+++ b/driver/csiplugin/settings/scale_config.go
@@ -47,6 +47,11 @@ type Primary struct {
 	SymlinkRelativePath string
 }
 
+const (
+	secretFileSuffix = "-secret" // #nosec G101 false positive
+	cacertFileSuffix = "-cacert"
+)
+
 /*
 To support backwards compatibility if the PrimaryFs field is not defined then
 
@@ -125,7 +130,7 @@ func HandleSecretsAndCerts(ctx context.Context, cmap *ScaleSettingsConfigMap) er
 	klog.V(6).Infof("[%s] scale_config HandleSecrets", utils.GetLoggerId(ctx))
 	for i := 0; i < len(cmap.Clusters); i++ {
 		if cmap.Clusters[i].Secrets != "" {
-			unamePath := path.Join(SecretBasePath, cmap.Clusters[i].Secrets, "username")
+			unamePath := path.Join(SecretBasePath, cmap.Clusters[i].ID+secretFileSuffix, "username")
 			file, e := os.ReadFile(unamePath) // #nosec G304 Valid Path is generated internally
 			if e != nil {
 				return fmt.Errorf("the IBM Storage Scale secret not found: %v", e)
@@ -135,7 +140,7 @@ func HandleSecretsAndCerts(ctx context.Context, cmap *ScaleSettingsConfigMap) er
 			file_s = strings.TrimSuffix(file_s, "\n")
 			cmap.Clusters[i].MgmtUsername = file_s
 
-			pwdPath := path.Join(SecretBasePath, cmap.Clusters[i].Secrets, "password")
+			pwdPath := path.Join(SecretBasePath, cmap.Clusters[i].ID+secretFileSuffix, "password")
 			file, e = os.ReadFile(pwdPath) // #nosec G304 Valid Path is generated internally
 			if e != nil {
 				return fmt.Errorf("the IBM Storage Scale secret not found: %v", e)
@@ -147,7 +152,7 @@ func HandleSecretsAndCerts(ctx context.Context, cmap *ScaleSettingsConfigMap) er
 		}
 
 		if cmap.Clusters[i].SecureSslMode && cmap.Clusters[i].Cacert != "" {
-			certPath := path.Join(CertificatePath, cmap.Clusters[i].Cacert)
+			certPath := path.Join(CertificatePath, cmap.Clusters[i].ID+cacertFileSuffix)
 			certPath = path.Join(certPath, cmap.Clusters[i].Cacert)
 			file, e := os.ReadFile(certPath) // #nosec G304 Valid Path is generated internally
 			if e != nil {

--- a/operator/controllers/config/constants.go
+++ b/operator/controllers/config/constants.go
@@ -166,10 +166,12 @@ const (
 	StatusConditionSuccess = "Success"
 	StatusConditionEnabled = "Enabled"
 
-	SecretUsername    = "username" // #nosec G101 false positive
-	SecretPassword    = "password" // #nosec G101 false positive
-	Primary           = "primary"
-	HTTPClientTimeout = 60
+	SecretUsername     = "username" // #nosec G101 false positive
+	SecretPassword     = "password" // #nosec G101 false positive
+	SecretVolumeSuffix = "-secret"  // #nosec G101 false positive
+	CacertVolumeSuffix = "-cacert"
+	Primary            = "primary"
+	HTTPClientTimeout  = 60
 
 	DefaultPrimaryFileset = "spectrum-scale-csi-volume-store"
 	SymlinkDir            = ".volumes"


### PR DESCRIPTION
Please check the type of change your PR introduces:
- [x] Bugfix
- [ ] Feature Enhancement
- [ ] Test Automation 
- [ ] Code Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Community Operator listing 
- [ ] Other (please describe): 


## What is the current behavior?
* Dot in secret/cacert cm name causes problem with volume name in driver
* Wrong config in CSO causes operator to panic, see https://github.com/IBM/ibm-spectrum-scale-csi/issues/988

## What is the new behavior?
* Dot in secret/cacert cm name works fine, as we are now using `<cluster-id>-secret` as a volume name for secrets and `<cluster-id>-cacert` for cacert volume name
* Wrong config in CSO is handled fine, the issue will be actually fixed when operator points to the driver code after merging this PR.


## How risky is this change?
- [x] Small, isolated change
- [ ] Medium, requires regression testing
- [ ] Large, requires functional and regression testing 

