### PR TITLE
Restrict length of CG prefix

### DIFF
--- a/operator/go.mod
+++ b/operator/go.mod
@@ -3,7 +3,7 @@ module github.com/IBM/ibm-spectrum-scale-csi/operator
 go 1.20
 
 require (
-	github.com/IBM/ibm-spectrum-scale-csi/driver v0.0.0-20230529112832-85319addc49a
+	github.com/IBM/ibm-spectrum-scale-csi/driver v0.0.0-20230616124659-a1ef411b1d0d
 	github.com/google/uuid v1.3.0
 	github.com/imdario/mergo v0.3.12
 	github.com/onsi/ginkgo v1.16.5

--- a/operator/go.sum
+++ b/operator/go.sum
@@ -35,6 +35,8 @@ github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03
 github.com/BurntSushi/xgb v0.0.0-20160522181843-27f122750802/go.mod h1:IVnqGOEym/WlBOVXweHU+Q+/VP0lqqI8lqeDx9IjBqo=
 github.com/IBM/ibm-spectrum-scale-csi/driver v0.0.0-20230529112832-85319addc49a h1:qpglq7bwVaNWF4fxYJM/EaY5O2FlhrkxLlt1AcvlCfM=
 github.com/IBM/ibm-spectrum-scale-csi/driver v0.0.0-20230529112832-85319addc49a/go.mod h1:uh9AEol21serVp8iOrRmlVBUSHfwoqxtpBfPrS1rzEQ=
+github.com/IBM/ibm-spectrum-scale-csi/driver v0.0.0-20230616124659-a1ef411b1d0d h1:JSPFBAuSJxzzL0H+YrOxwB3fpLSd9ymoMnutX14KWEQ=
+github.com/IBM/ibm-spectrum-scale-csi/driver v0.0.0-20230616124659-a1ef411b1d0d/go.mod h1:uh9AEol21serVp8iOrRmlVBUSHfwoqxtpBfPrS1rzEQ=
 github.com/NYTimes/gziphandler v0.0.0-20170623195520-56545f4a5d46/go.mod h1:3wb06e3pkSAbeQ52E9H9iFoQsEEwGN64994WTCIhntQ=
 github.com/PuerkitoBio/purell v1.1.1/go.mod h1:c11w/QuzBsJSee3cPx9rAFu61PvFxuPbtSwDGJws/X0=
 github.com/PuerkitoBio/urlesc v0.0.0-20170810143723-de5bf2ad4578/go.mod h1:uGdkoq3SwY9Y+13GIhn11/XLaGBb4BfwItxLd5jeuXE=


### PR DESCRIPTION
* Restrict length of CG prefix to 36
* Update driver module dependency in operator module to pickup the fix for wrong config from https://github.com/IBM/ibm-spectrum-scale-csi/pull/991
Please check the type of change your PR introduces:
- [x] Bugfix
- [x] Feature Enhancement
- [ ] Test Automation 
- [ ] Code Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Community Operator listing 
- [ ] Other (please describe): 


## What is the current behavior?
Any length of CG prefix is accepted

## What is the new behavior?
CG prefix length is restricted to 36

## How risky is this change?
- [x] Small, isolated change
- [ ] Medium, requires regression testing
- [ ] Large, requires functional and regression testing 

