### PR TITLE
changes for pod security-2.10

### DIFF
--- a/operator/controllers/syncer/csi_node.go
+++ b/operator/controllers/syncer/csi_node.go
@@ -171,6 +171,7 @@ func (s *csiNodeSyncer) SyncCSIDaemonsetFn(daemonSetRestartedKey string, daemonS
 	}
 	out.Spec.UpdateStrategy = strategy
 
+	// TODO: When an alternative for mergo package is found, this should be done at only one place
 	if out.Spec.Template.Spec.Containers != nil {
 		for i := range out.Spec.Template.Spec.Containers {
 			if out.Spec.Template.Spec.Containers[i].Name == nodeDriverRegistrarContainerName {

--- a/operator/controllers/syncer/csi_node.go
+++ b/operator/controllers/syncer/csi_node.go
@@ -171,6 +171,15 @@ func (s *csiNodeSyncer) SyncCSIDaemonsetFn(daemonSetRestartedKey string, daemonS
 	}
 	out.Spec.UpdateStrategy = strategy
 
+	if out.Spec.Template.Spec.Containers != nil {
+		for i := range out.Spec.Template.Spec.Containers {
+			if out.Spec.Template.Spec.Containers[i].Name == nodeDriverRegistrarContainerName {
+				out.Spec.Template.Spec.Containers[i].SecurityContext = &corev1.SecurityContext{
+					Privileged: boolptr.False()}
+			}
+		}
+	}
+
 	err := mergo.Merge(&out.Spec.Template.Spec, s.ensurePodSpec(secrets), mergo.WithTransformers(transformers.PodSpec))
 	if err != nil {
 		return err

--- a/operator/controllers/syncer/csi_node.go
+++ b/operator/controllers/syncer/csi_node.go
@@ -266,7 +266,7 @@ func (s *csiNodeSyncer) ensureContainersSpec() []corev1.Container {
 		},
 	)
 
-	registrar.SecurityContext = ensureDriverContainersSecurityContext(true, true, true, true)
+	registrar.SecurityContext = ensureDriverContainersSecurityContext(false, false, true, false)
 	fillSecurityContextCapabilities(registrar.SecurityContext)
 	registrar.ImagePullPolicy = config.CSINodeDriverRegistrarImagePullPolicy
 	registrar.Resources = ensureSidecarResources()

--- a/operator/controllers/syncer/csi_syncer.go
+++ b/operator/controllers/syncer/csi_syncer.go
@@ -417,7 +417,7 @@ func (s *csiControllerSyncer) ensureAttacherPodSpec(secrets []corev1.LocalObject
 		ServiceAccountName: config.GetNameForResource(config.CSIAttacherServiceAccount, s.driver.Name),
 		ImagePullSecrets:   secrets,
 		PriorityClassName:  "system-node-critical",
-		SecurityContext:    ensurePodSecurityContext(config.RunAsUser, config.RunAsGroup, true),
+		//SecurityContext:    ensurePodSecurityContext(config.RunAsUser, config.RunAsGroup, true),
 	}
 
 	pod.Tolerations = append(pod.Tolerations, s.driver.GetNodeTolerations()...)
@@ -440,7 +440,7 @@ func (s *csiControllerSyncer) ensureProvisionerPodSpec(secrets []corev1.LocalObj
 		Affinity:           s.driver.GetAffinity(config.Provisioner.String()),
 		ServiceAccountName: config.GetNameForResource(config.CSIProvisionerServiceAccount, s.driver.Name),
 		ImagePullSecrets:   secrets,
-		SecurityContext:    ensurePodSecurityContext(config.RunAsUser, config.RunAsGroup, true),
+		//SecurityContext:    ensurePodSecurityContext(config.RunAsUser, config.RunAsGroup, true),
 	}
 
 	pod.Tolerations = append(pod.Tolerations, s.driver.GetNodeTolerations()...)
@@ -463,7 +463,7 @@ func (s *csiControllerSyncer) ensureSnapshotterPodSpec(secrets []corev1.LocalObj
 		Affinity:           s.driver.GetAffinity(config.Snapshotter.String()),
 		ServiceAccountName: config.GetNameForResource(config.CSISnapshotterServiceAccount, s.driver.Name),
 		ImagePullSecrets:   secrets,
-		SecurityContext:    ensurePodSecurityContext(config.RunAsUser, config.RunAsGroup, true),
+		//SecurityContext:    ensurePodSecurityContext(config.RunAsUser, config.RunAsGroup, true),
 	}
 
 	pod.Tolerations = append(pod.Tolerations, s.driver.GetNodeTolerations()...)
@@ -486,7 +486,7 @@ func (s *csiControllerSyncer) ensureResizerPodSpec(secrets []corev1.LocalObjectR
 		Affinity:           s.driver.GetAffinity(config.Resizer.String()),
 		ServiceAccountName: config.GetNameForResource(config.CSIResizerServiceAccount, s.driver.Name),
 		ImagePullSecrets:   secrets,
-		SecurityContext:    ensurePodSecurityContext(config.RunAsUser, config.RunAsGroup, true),
+		//SecurityContext:    ensurePodSecurityContext(config.RunAsUser, config.RunAsGroup, true),
 	}
 
 	pod.Tolerations = append(pod.Tolerations, s.driver.GetNodeTolerations()...)
@@ -721,7 +721,7 @@ func (s *csiControllerSyncer) ensureContainer(name, image string, args []string)
 		LivenessProbe: s.driver.GetLivenessProbe(),
 		Resources:     ensureSidecarResources(),
 	}
-	container.SecurityContext = ensureContainerSecurityContext(true, true, true)
+	container.SecurityContext = ensureContainerSecurityContext(false, false, true)
 	fillSecurityContextCapabilities(container.SecurityContext)
 	return container
 }
@@ -896,6 +896,7 @@ func ensureProbe(delay, timeout, period int32, handler corev1.ProbeHandler) *cor
 	}
 }
 
+/*
 // ensurePodSecurityContext set pod security with runAsUser, runAsGroup and runAsNonRoot.
 func ensurePodSecurityContext(runAsUser int64, runAsGroup int64, runAsNonRoot bool) *corev1.PodSecurityContext {
 	var localRunAsNonRoot bool
@@ -909,7 +910,7 @@ func ensurePodSecurityContext(runAsUser int64, runAsGroup int64, runAsNonRoot bo
 		RunAsUser:    &runAsUser,
 		RunAsGroup:   &runAsGroup,
 	}
-}
+}*/
 
 // ensureContainerSecurityContext configure AllowPrivilegeEscalation, Privileged, ReadOnlyRootFilesystem for the container.
 func ensureContainerSecurityContext(allowPrivilegeEscalation bool, privileged bool, readOnlyRootFilesystem bool) *corev1.SecurityContext {
@@ -930,5 +931,6 @@ func ensureContainerSecurityContext(allowPrivilegeEscalation bool, privileged bo
 	return &corev1.SecurityContext{
 		AllowPrivilegeEscalation: localAllowPrivilegeEscalation,
 		Privileged:               localPrivileged,
-		ReadOnlyRootFilesystem:   localReadOnlyRootFilesystem}
+		ReadOnlyRootFilesystem:   localReadOnlyRootFilesystem,
+		RunAsNonRoot:             boolptr.False()}
 }

--- a/operator/controllers/syncer/csi_syncer.go
+++ b/operator/controllers/syncer/csi_syncer.go
@@ -896,7 +896,7 @@ func ensureProbe(delay, timeout, period int32, handler corev1.ProbeHandler) *cor
 	}
 }
 
-/*
+/* // TODO: Keeping this function because this might be used if we got any way to run side-cars as non-root users.
 // ensurePodSecurityContext set pod security with runAsUser, runAsGroup and runAsNonRoot.
 func ensurePodSecurityContext(runAsUser int64, runAsGroup int64, runAsNonRoot bool) *corev1.PodSecurityContext {
 	var localRunAsNonRoot bool


### PR DESCRIPTION
## Pull request checklist

<!-- Add your one liner release notes here -->
<!-- eg... -->
<!--   - Major functionality adds -->
<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->
<!--   - are you changing our ScaleCluster CR file? -->

This is the PR for issue [Check on security settings](https://github.ibm.com/ibmspectrumscale/csi-tracker/issues/282)
```release-notes

```

## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [ ] Bugfix
- [x] Feature Enhancement
- [ ] Test Automation 
- [ ] Code Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Community Operator listing 
- [ ] Other (please describe): 


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying -->
The currently running pods/containers are not following recommended security specs. Some are running with priviledged and with root user. 

## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->
The new changes will restrict pods/containers to run explicitly with required permission where ever applicable. We have listed out all the changes into boxnote [Pod Security](https://ibm.ent.box.com/file/1233061703646).
Sheet-1 contains the running securityContext whereas Sheet-1(release-1.10) contains the latest changes of the secuityContexts.


## How risky is this change?
- [ ] Small, isolated change
- [x] Medium, requires regression testing
- [ ] Large, requires functional and regression testing 

