### PR TITLE
added events func in case of wrong optional cm data

### DIFF
--- a/operator/api/v1/csiscaleoperator_types.go
+++ b/operator/api/v1/csiscaleoperator_types.go
@@ -406,6 +406,7 @@ const (
 	CreateFilesetFailed          CSIReason = "CreateFilesetFailed"
 	LinkFilesetFailed            CSIReason = "LinkFilesetFailed"
 	ValidationFailed             CSIReason = "ValidationFailed"
+	ValidationWarning            CSIReason = "ValidationWarning"
 	GUIConnFailed                CSIReason = "GUIConnFailed"
 	ClusterIDMismatch            CSIReason = "ClusterIDMismatch"
 	PrimaryClusterUndefined      CSIReason = "PrimaryClusterUndefined"

--- a/operator/controllers/csiscaleoperator_controller.go
+++ b/operator/controllers/csiscaleoperator_controller.go
@@ -2281,9 +2281,18 @@ func (r *CSIScaleOperatorReconciler) parseConfigMap(instance *csiscaleoperator.C
 	// setting default values if values are empty/wrong
 	setDefaultDriverEnvValues(data)
 	logger.Info("Final accepted value ", "from the optional configmap", data)
+	var message string = ""
+	if len(invalidEnv) > 0 && len(invalidEnvValue) > 0 {
+		message = fmt.Sprintf("There are few entries %v with wrong key which will not be processed and few entries having wrong values %v in the configmap %s, default values will be used", invalidEnv, invalidEnvValue, config.CSIEnvVarConfigMap)
 
-	if len(invalidEnv) > 0 || len(invalidEnvValue) > 0 {
-		message := fmt.Sprintf("There are few entries %v with wrong key which will not be processed and there are few entries having wrong values %v in the configmap %s, default values will be used", invalidEnv, invalidEnvValue, config.CSIEnvVarConfigMap)
+	} else if len(invalidEnv) > 0 {
+		message = fmt.Sprintf("There are few entries %v with wrong key in the configmap %s which will not be processed", invalidEnv, config.CSIEnvVarConfigMap)
+
+	} else if len(invalidEnvValue) > 0 {
+		message = fmt.Sprintf("There are few entries having wrong values %v in the configmap %s, default values will be used", invalidEnvValue, config.CSIEnvVarConfigMap)
+	}
+
+	if len(message) > 0 {
 		logger.Info(message)
 		RaiseCSOEvent(instance, r.Recorder, corev1.EventTypeWarning,
 			string(csiv1.ValidationWarning), message,


### PR DESCRIPTION
## Pull request checklist

Zenhub Tracker: [Generate events for configmap parameter validation](https://github.ibm.com/IBMSpectrumScale/csi-tracker/issues/315)

<!-- Add your one liner release notes here -->
<!-- eg... -->
<!--   - Major functionality adds -->
<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->
<!--   - are you changing our ScaleCluster CR file? -->
```release-notes

```

## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [ ] Bugfix
- [x] Feature Enhancement
- [ ] Test Automation 
- [ ] Code Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Community Operator listing 
- [ ] Other (please describe): 


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying -->
- In the current behavior, there are no feature to show CSO events whenever any wrong data comes in the optional configMap.

## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->
- In the new behavior, there will have functionality to show CSO events in case of any wrong data comes in the optional configMap.

## How risky is this change?
- [x] Small, isolated change
- [ ] Medium, requires regression testing
- [ ] Large, requires functional and regression testing 

