### PR TITLE
Skip checking for snapshots for dependent filesets

### DIFF
--- a/driver/csiplugin/controllerserver.go
+++ b/driver/csiplugin/controllerserver.go
@@ -1626,25 +1626,29 @@ func (cs *ScaleControllerServer) GetSnapIdMembers(sId string) (scaleSnapId, erro
 	return sIdMem, nil
 }
 
-func (cs *ScaleControllerServer) DeleteFilesetVol(ctx context.Context, FilesystemName string, FilesetName string, volumeIdMembers scaleVolId, conn connectors.SpectrumScaleConnector) (bool, error) {
+func (cs *ScaleControllerServer) DeleteFilesetVol(ctx context.Context, FilesystemName string, FilesetName string, volumeIdMembers scaleVolId, conn connectors.SpectrumScaleConnector, checkForSnapshots bool) (bool, error) {
 	//Check if fileset exist has any snapshot
-	snapshotList, err := conn.ListFilesetSnapshots(ctx, FilesystemName, FilesetName)
 	loggerId := utils.GetLoggerId(ctx)
-	if err != nil {
-		if strings.Contains(err.Error(), "EFSSG0072C") ||
-			strings.Contains(err.Error(), "400 Invalid value in 'filesetName'") { // fileset is already deleted
-			klog.V(4).Infof("[%s] fileset seems already deleted - %v", loggerId, err)
-			return true, nil
+	if checkForSnapshots {
+		klog.Infof("[%s] Checking if there is any snapshot present in the fileset [%v]", loggerId, FilesetName)
+		snapshotList, err := conn.ListFilesetSnapshots(ctx, FilesystemName, FilesetName)
+
+		if err != nil {
+			if strings.Contains(err.Error(), "EFSSG0072C") ||
+				strings.Contains(err.Error(), "400 Invalid value in 'filesetName'") { // fileset is already deleted
+				klog.V(4).Infof("[%s] fileset seems already deleted - %v", loggerId, err)
+				return true, nil
+			}
+			return false, status.Error(codes.Internal, fmt.Sprintf("unable to list snapshot for fileset [%v]. Error: [%v]", FilesetName, err))
 		}
-		return false, status.Error(codes.Internal, fmt.Sprintf("unable to list snapshot for fileset [%v]. Error: [%v]", FilesetName, err))
+
+		if len(snapshotList) > 0 {
+			return false, status.Error(codes.Internal, fmt.Sprintf("volume fileset [%v] contains one or more snapshot, delete snapshot/volumesnapshot", FilesetName))
+		}
+		klog.Infof("[%s] there is no snapshot present in the fileset [%v], continue DeleteFilesetVol", loggerId, FilesetName)
 	}
 
-	if len(snapshotList) > 0 {
-		return false, status.Error(codes.Internal, fmt.Sprintf("volume fileset [%v] contains one or more snapshot, delete snapshot/volumesnapshot", FilesetName))
-	}
-	klog.Infof("[%s] there is no snapshot present in the fileset [%v], continue DeleteFilesetVol", loggerId, FilesetName)
-
-	err = conn.DeleteFileset(ctx, FilesystemName, FilesetName)
+	err := conn.DeleteFileset(ctx, FilesystemName, FilesetName)
 	if err != nil {
 		if strings.Contains(err.Error(), "EFSSG0072C") ||
 			strings.Contains(err.Error(), "400 Invalid value in 'filesetName'") { // fileset is already deleted
@@ -1688,7 +1692,7 @@ func (cs *ScaleControllerServer) DeleteCGFileset(ctx context.Context, Filesystem
 		}
 
 		// Delete independent fileset for consistency group
-		_, err = cs.DeleteFilesetVol(ctx, FilesystemName, volumeIdMembers.ConsistencyGroup, volumeIdMembers, conn)
+		_, err = cs.DeleteFilesetVol(ctx, FilesystemName, volumeIdMembers.ConsistencyGroup, volumeIdMembers, conn, true)
 		if err != nil {
 			return err
 		}
@@ -1777,7 +1781,11 @@ func (cs *ScaleControllerServer) DeleteVolume(ctx context.Context, req *csi.Dele
 			/* Confirm it is same fileset which was created for this PV */
 			pvName := filepath.Base(relPath)
 			if pvName == FilesetName {
-				isFilesetAlreadyDel, err := cs.DeleteFilesetVol(ctx, FilesystemName, FilesetName, volumeIdMembers, conn)
+				checkForSnapshots := false
+				if volumeIdMembers.VolType == FILE_INDEPENDENTFILESET_VOLUME {
+					checkForSnapshots = true
+				}
+				isFilesetAlreadyDel, err := cs.DeleteFilesetVol(ctx, FilesystemName, FilesetName, volumeIdMembers, conn, checkForSnapshots)
 				if err != nil {
 					return nil, err
 				}
@@ -1792,6 +1800,8 @@ func (cs *ScaleControllerServer) DeleteVolume(ctx context.Context, req *csi.Dele
 
 				if volumeIdMembers.StorageClassType == STORAGECLASS_ADVANCED {
 					err := cs.DeleteCGFileset(ctx, FilesystemName, volumeIdMembers, conn)
+					// DeleteCGFileset calls DeleteFilesetVol function with checkForSnapshots=true to
+					// check for snapshots before deleting the CG independent fileset
 					if err != nil {
 						return nil, err
 					}


### PR DESCRIPTION
## Pull request checklist

While deleting a volume, skip checking for snapshots for dependent filesets

Please check the type of change your PR introduces:
- [x] Bugfix
- [ ] Feature Enhancement
- [ ] Test Automation 
- [ ] Code Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Community Operator listing 
- [ ] Other (please describe): 


## What is the current behavior?
- CSI driver checks for snapshots for dependent filesets in volume deletion path
## What is the new behavior?
- CSI driver skips checking for snapshots for dependent filesets in volume deletion path


## How risky is this change?
- [x] Small, isolated change
- [ ] Medium, requires regression testing
- [ ] Large, requires functional and regression testing 

