### PR TITLE
Fix for tunable network policy

### DIFF
--- a/operator/controllers/config/constants.go
+++ b/operator/controllers/config/constants.go
@@ -149,6 +149,7 @@ const (
 	EnvNodePublishMethodKey           = "NODEPUBLISH_METHOD"
 	EnvVolumeStatsCapabilityKey       = "VOLUME_STATS_CAPABILITY"
 	EnvDiscoverCGFilesetKey           = "DISCOVER_CG_FILESET"
+	NetworkPolicyKey                  = "NETWORK_POLICY"
 
 	// Optional ConfigMap keys with prefix
 	EnvLogLevelKeyPrefixed              = EnvVarPrefix + EnvLogLevelKey
@@ -162,15 +163,17 @@ const (
 	EnvPersistentLogDefaultValue         = "DISABLED"
 	EnvNodePublishMethodDefaultValue     = "BINDMOUNT"
 	EnvVolumeStatsCapabilityDefaultValue = "ENABLED"
+	EnvNetworkPolicyDefaultValue         = "DISABLED"
 )
 
 var CSIOptionalConfigMapKeys = []string{EnvLogLevelKeyPrefixed, EnvPersistentLogKeyPrefixed,
-	EnvNodePublishMethodKeyPrefixed, EnvVolumeStatsCapabilityKeyPrefixed, DaemonSetUpgradeMaxUnavailableKey, EnvDiscoverCGFilesetKeyPrefixed}
+	EnvNodePublishMethodKeyPrefixed, EnvVolumeStatsCapabilityKeyPrefixed, DaemonSetUpgradeMaxUnavailableKey, EnvDiscoverCGFilesetKeyPrefixed, NetworkPolicyKey}
 var EnvLogLevelValues = []string{"TRACE", "DEBUG", "INFO", "WARNING", "ERROR", "FATAL"}
 var EnvNodePublishMethodValues = []string{"SYMLINK", "BINDMOUNT"}
 var EnvPersistentLogValues = []string{"ENABLED", "DISABLED"}
 var EnvVolumeStatsCapabilityValues = []string{"ENABLED", "DISABLED"}
 var EnvDiscoverCGFilesetValues = []string{"ENABLED", "DISABLED"}
+var EnvNetworkPolicyValues = []string{"ENABLED", "DISABLED"}
 
 const (
 	StatusConditionReady   = "Ready"

--- a/operator/controllers/config/constants.go
+++ b/operator/controllers/config/constants.go
@@ -149,7 +149,7 @@ const (
 	EnvNodePublishMethodKey           = "NODEPUBLISH_METHOD"
 	EnvVolumeStatsCapabilityKey       = "VOLUME_STATS_CAPABILITY"
 	EnvDiscoverCGFilesetKey           = "DISCOVER_CG_FILESET"
-	NetworkPolicyKey                  = "NETWORK_POLICY"
+	HostNetworkKey                    = "HOST_NETWORK"
 
 	// Optional ConfigMap keys with prefix
 	EnvLogLevelKeyPrefixed              = EnvVarPrefix + EnvLogLevelKey
@@ -163,17 +163,17 @@ const (
 	EnvPersistentLogDefaultValue         = "DISABLED"
 	EnvNodePublishMethodDefaultValue     = "BINDMOUNT"
 	EnvVolumeStatsCapabilityDefaultValue = "ENABLED"
-	EnvNetworkPolicyDefaultValue         = "DISABLED"
+	EnvHostNetworkDefaultValue           = "DISABLED"
 )
 
 var CSIOptionalConfigMapKeys = []string{EnvLogLevelKeyPrefixed, EnvPersistentLogKeyPrefixed,
-	EnvNodePublishMethodKeyPrefixed, EnvVolumeStatsCapabilityKeyPrefixed, DaemonSetUpgradeMaxUnavailableKey, EnvDiscoverCGFilesetKeyPrefixed, NetworkPolicyKey}
+	EnvNodePublishMethodKeyPrefixed, EnvVolumeStatsCapabilityKeyPrefixed, DaemonSetUpgradeMaxUnavailableKey, EnvDiscoverCGFilesetKeyPrefixed, HostNetworkKey}
 var EnvLogLevelValues = []string{"TRACE", "DEBUG", "INFO", "WARNING", "ERROR", "FATAL"}
 var EnvNodePublishMethodValues = []string{"SYMLINK", "BINDMOUNT"}
 var EnvPersistentLogValues = []string{"ENABLED", "DISABLED"}
 var EnvVolumeStatsCapabilityValues = []string{"ENABLED", "DISABLED"}
 var EnvDiscoverCGFilesetValues = []string{"ENABLED", "DISABLED"}
-var EnvNetworkPolicyValues = []string{"ENABLED", "DISABLED"}
+var EnvHostNetworkValues = []string{"ENABLED", "DISABLED"}
 
 const (
 	StatusConditionReady   = "Ready"

--- a/operator/controllers/config/constants.go
+++ b/operator/controllers/config/constants.go
@@ -163,7 +163,7 @@ const (
 	EnvPersistentLogDefaultValue         = "DISABLED"
 	EnvNodePublishMethodDefaultValue     = "BINDMOUNT"
 	EnvVolumeStatsCapabilityDefaultValue = "ENABLED"
-	EnvHostNetworkDefaultValue           = "DISABLED"
+	EnvHostNetworkDefaultValue           = "ENABLED"
 )
 
 var CSIOptionalConfigMapKeys = []string{EnvLogLevelKeyPrefixed, EnvPersistentLogKeyPrefixed,

--- a/operator/controllers/csiscaleoperator_controller.go
+++ b/operator/controllers/csiscaleoperator_controller.go
@@ -775,7 +775,7 @@ func (r *CSIScaleOperatorReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	//Do not restart driver pods when the configmap contains invalid Envs.
 	shouldRequeueOnCreateOrDelete := func(cfgmapData map[string]string) bool {
 		for key := range cfgmapData {
-			if strings.HasPrefix(strings.ToUpper(key), config.EnvVarPrefix) || strings.ToUpper(key) == config.DaemonSetUpgradeMaxUnavailableKey {
+			if strings.HasPrefix(strings.ToUpper(key), config.EnvVarPrefix) || strings.ToUpper(key) == config.DaemonSetUpgradeMaxUnavailableKey ||                                                                         strings.ToUpper(key) == config.NetworkPolicyKey{
 				return true
 			}
 		}
@@ -789,10 +789,11 @@ func (r *CSIScaleOperatorReconciler) SetupWithManager(mgr ctrl.Manager) error {
 		for key, newVal := range newCfgMapData {
 			//Allow restart of driver pods when a new valid env var is found or the value of existing valid env var is updated
 			if oldVal, ok := oldCfgMapData[key]; !ok {
-				if (strings.HasPrefix(strings.ToUpper(key), config.EnvVarPrefix)) || strings.ToUpper(key) == config.DaemonSetUpgradeMaxUnavailableKey {
+				if (strings.HasPrefix(strings.ToUpper(key), config.EnvVarPrefix)) || strings.ToUpper(key) == config.DaemonSetUpgradeMaxUnavailableKey || 
+                                    strings.ToUpper(key) == config.NetworkPolicyKey{
 					return true
 				}
-			} else if oldVal != newVal && (strings.HasPrefix(strings.ToUpper(key), config.EnvVarPrefix) || strings.ToUpper(key) == config.DaemonSetUpgradeMaxUnavailableKey) {
+			} else if oldVal != newVal && (strings.HasPrefix(strings.ToUpper(key), config.EnvVarPrefix) || strings.ToUpper(key) == config.DaemonSetUpgradeMaxUnavailableKey) ||                                                 strings.ToUpper(key) == config.NetworkPolicyKey{
 				return true
 			}
 		}
@@ -801,7 +802,7 @@ func (r *CSIScaleOperatorReconciler) SetupWithManager(mgr ctrl.Manager) error {
 			//look for deleted valid env vars of the old configmap in the new configmap
 			//if deleted restart driver pods
 			if _, ok := newCfgMapData[key]; !ok {
-				if (strings.HasPrefix(strings.ToUpper(key), config.EnvVarPrefix)) || (strings.ToUpper(key) == config.DaemonSetUpgradeMaxUnavailableKey) {
+				if (strings.HasPrefix(strings.ToUpper(key), config.EnvVarPrefix)) || (strings.ToUpper(key) == config.DaemonSetUpgradeMaxUnavailableKey) ||                                                                     (strings.ToUpper(key) == config.NetworkPolicyKey) {
 					return true
 				}
 			}
@@ -2318,6 +2319,8 @@ func (r *CSIScaleOperatorReconciler) parseConfigMap(instance *csiscaleoperator.C
 				}
 			} else if keyUpper == config.DaemonSetUpgradeMaxUnavailableKey {
 				validateMaxUnavailableValue(keyUpper, value, validEnvMap, invalidEnvValueMap)
+			} else if keyUpper == config.NetworkPolicyKey{
+				validateNetworkPolicyValue(config.EnvNetworkPolicyValues[:], keyUpper, value, validEnvMap, invalidEnvValueMap)
 			}
 		} else {
 			invalidEnvKeys = append(invalidEnvKeys, key)
@@ -2377,6 +2380,15 @@ func validateMaxUnavailableValue(key string, value string, data map[string]strin
 	}
 }
 
+func validateNetworkPolicyValue(inputSlice []string, key, value string, envMap, invalidEnvValue map[string]string) {
+	logger := csiLog.WithName("validateNetworkPolicyValue")
+        logger.Info("Validating network policy input", "inputNetworkPolicy", value)
+	
+	if containsStringInSlice(inputSlice, strings.ToUpper(value)) {
+		 envMap[key] = value
+	}
+}
+
 // containsStringInSlice checks if a string is present in a slice
 func containsStringInSlice(inputSlice []string, stringToFind string) bool {
 	for _, v := range inputSlice {
@@ -2430,6 +2442,12 @@ func setDefaultDriverEnvValues(envMap map[string]string) {
 		envDiscoverCGFilesetDefaultValue := getDiscoverCGFilesetDefaultValue()
 		logger.Info("DiscoverCGFileset is empty or incorrect.", "Defaulting DiscoverCGFileset to", envDiscoverCGFilesetDefaultValue)
 		envMap[config.EnvDiscoverCGFilesetKey] = envDiscoverCGFilesetDefaultValue
+	}
+
+	// set default NetworkPolicy env when it is not present in envMap
+	if _,ok := envMap[config.NetworkPolicyKey]; !ok{
+		logger.Info("Network Policy is empty or incorrect.", "Defaulting Network Policy to", config.EnvNetworkPolicyDefaultValue)
+		envMap[config.NetworkPolicyKey] = config.EnvNetworkPolicyDefaultValue
 	}
 }
 

--- a/operator/controllers/csiscaleoperator_controller.go
+++ b/operator/controllers/csiscaleoperator_controller.go
@@ -2386,6 +2386,8 @@ func validateHostNetworkValue(inputSlice []string, key, value string, envMap, in
 	
 	if containsStringInSlice(inputSlice, strings.ToUpper(value)) {
 		 envMap[key] = value
+	}else{
+		invalidEnvValue[key] = value
 	}
 }
 

--- a/operator/controllers/csiscaleoperator_controller.go
+++ b/operator/controllers/csiscaleoperator_controller.go
@@ -775,7 +775,7 @@ func (r *CSIScaleOperatorReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	//Do not restart driver pods when the configmap contains invalid Envs.
 	shouldRequeueOnCreateOrDelete := func(cfgmapData map[string]string) bool {
 		for key := range cfgmapData {
-			if strings.HasPrefix(strings.ToUpper(key), config.EnvVarPrefix) || strings.ToUpper(key) == config.DaemonSetUpgradeMaxUnavailableKey ||                                                                         strings.ToUpper(key) == config.NetworkPolicyKey{
+			if strings.HasPrefix(strings.ToUpper(key), config.EnvVarPrefix) || strings.ToUpper(key) == config.DaemonSetUpgradeMaxUnavailableKey ||                                                                         strings.ToUpper(key) == config.HostNetworkKey{
 				return true
 			}
 		}
@@ -790,10 +790,10 @@ func (r *CSIScaleOperatorReconciler) SetupWithManager(mgr ctrl.Manager) error {
 			//Allow restart of driver pods when a new valid env var is found or the value of existing valid env var is updated
 			if oldVal, ok := oldCfgMapData[key]; !ok {
 				if (strings.HasPrefix(strings.ToUpper(key), config.EnvVarPrefix)) || strings.ToUpper(key) == config.DaemonSetUpgradeMaxUnavailableKey || 
-                                    strings.ToUpper(key) == config.NetworkPolicyKey{
+                                    strings.ToUpper(key) == config.HostNetworkKey{
 					return true
 				}
-			} else if oldVal != newVal && (strings.HasPrefix(strings.ToUpper(key), config.EnvVarPrefix) || strings.ToUpper(key) == config.DaemonSetUpgradeMaxUnavailableKey) ||                                                 strings.ToUpper(key) == config.NetworkPolicyKey{
+			} else if oldVal != newVal && (strings.HasPrefix(strings.ToUpper(key), config.EnvVarPrefix) || strings.ToUpper(key) == config.DaemonSetUpgradeMaxUnavailableKey) ||                                                 strings.ToUpper(key) == config.HostNetworkKey{
 				return true
 			}
 		}
@@ -802,7 +802,7 @@ func (r *CSIScaleOperatorReconciler) SetupWithManager(mgr ctrl.Manager) error {
 			//look for deleted valid env vars of the old configmap in the new configmap
 			//if deleted restart driver pods
 			if _, ok := newCfgMapData[key]; !ok {
-				if (strings.HasPrefix(strings.ToUpper(key), config.EnvVarPrefix)) || (strings.ToUpper(key) == config.DaemonSetUpgradeMaxUnavailableKey) ||                                                                     (strings.ToUpper(key) == config.NetworkPolicyKey) {
+				if (strings.HasPrefix(strings.ToUpper(key), config.EnvVarPrefix)) || (strings.ToUpper(key) == config.DaemonSetUpgradeMaxUnavailableKey) ||                                                                     (strings.ToUpper(key) == config.HostNetworkKey) {
 					return true
 				}
 			}
@@ -2319,8 +2319,8 @@ func (r *CSIScaleOperatorReconciler) parseConfigMap(instance *csiscaleoperator.C
 				}
 			} else if keyUpper == config.DaemonSetUpgradeMaxUnavailableKey {
 				validateMaxUnavailableValue(keyUpper, value, validEnvMap, invalidEnvValueMap)
-			} else if keyUpper == config.NetworkPolicyKey{
-				validateNetworkPolicyValue(config.EnvNetworkPolicyValues[:], keyUpper, value, validEnvMap, invalidEnvValueMap)
+			} else if keyUpper == config.HostNetworkKey{
+				validateHostNetworkValue(config.EnvHostNetworkValues[:], keyUpper, value, validEnvMap, invalidEnvValueMap)
 			}
 		} else {
 			invalidEnvKeys = append(invalidEnvKeys, key)
@@ -2380,9 +2380,9 @@ func validateMaxUnavailableValue(key string, value string, data map[string]strin
 	}
 }
 
-func validateNetworkPolicyValue(inputSlice []string, key, value string, envMap, invalidEnvValue map[string]string) {
-	logger := csiLog.WithName("validateNetworkPolicyValue")
-        logger.Info("Validating network policy input", "inputNetworkPolicy", value)
+func validateHostNetworkValue(inputSlice []string, key, value string, envMap, invalidEnvValue map[string]string) {
+	logger := csiLog.WithName("validateHostNetworkValue")
+        logger.Info("Validating host network input", "inputHostNetwork", value)
 	
 	if containsStringInSlice(inputSlice, strings.ToUpper(value)) {
 		 envMap[key] = value
@@ -2444,10 +2444,10 @@ func setDefaultDriverEnvValues(envMap map[string]string) {
 		envMap[config.EnvDiscoverCGFilesetKey] = envDiscoverCGFilesetDefaultValue
 	}
 
-	// set default NetworkPolicy env when it is not present in envMap
-	if _,ok := envMap[config.NetworkPolicyKey]; !ok{
-		logger.Info("Network Policy is empty or incorrect.", "Defaulting Network Policy to", config.EnvNetworkPolicyDefaultValue)
-		envMap[config.NetworkPolicyKey] = config.EnvNetworkPolicyDefaultValue
+	// set default HostNetwork env when it is not present in envMap
+	if _,ok := envMap[config.HostNetworkKey]; !ok{
+		logger.Info("Host Network is empty or incorrect.", "Defaulting Host Network to", config.EnvHostNetworkDefaultValue)
+		envMap[config.HostNetworkKey] = config.EnvHostNetworkDefaultValue
 	}
 }
 

--- a/operator/controllers/csiscaleoperator_controller.go
+++ b/operator/controllers/csiscaleoperator_controller.go
@@ -775,7 +775,9 @@ func (r *CSIScaleOperatorReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	//Do not restart driver pods when the configmap contains invalid Envs.
 	shouldRequeueOnCreateOrDelete := func(cfgmapData map[string]string) bool {
 		for key := range cfgmapData {
-			if strings.HasPrefix(strings.ToUpper(key), config.EnvVarPrefix) || strings.ToUpper(key) == config.DaemonSetUpgradeMaxUnavailableKey ||                                                                         strings.ToUpper(key) == config.HostNetworkKey{
+			if strings.HasPrefix(strings.ToUpper(key), config.EnvVarPrefix) || 
+				strings.ToUpper(key) == config.DaemonSetUpgradeMaxUnavailableKey ||
+				strings.ToUpper(key) == config.HostNetworkKey{
 				return true
 			}
 		}
@@ -789,11 +791,14 @@ func (r *CSIScaleOperatorReconciler) SetupWithManager(mgr ctrl.Manager) error {
 		for key, newVal := range newCfgMapData {
 			//Allow restart of driver pods when a new valid env var is found or the value of existing valid env var is updated
 			if oldVal, ok := oldCfgMapData[key]; !ok {
-				if (strings.HasPrefix(strings.ToUpper(key), config.EnvVarPrefix)) || strings.ToUpper(key) == config.DaemonSetUpgradeMaxUnavailableKey || 
-                                    strings.ToUpper(key) == config.HostNetworkKey{
+				if (strings.HasPrefix(strings.ToUpper(key), config.EnvVarPrefix)) || 
+					strings.ToUpper(key) == config.DaemonSetUpgradeMaxUnavailableKey ||
+					strings.ToUpper(key) == config.HostNetworkKey{
 					return true
 				}
-			} else if oldVal != newVal && (strings.HasPrefix(strings.ToUpper(key), config.EnvVarPrefix) || strings.ToUpper(key) == config.DaemonSetUpgradeMaxUnavailableKey) ||                                                 strings.ToUpper(key) == config.HostNetworkKey{
+			} else if oldVal != newVal && (strings.HasPrefix(strings.ToUpper(key), config.EnvVarPrefix) || 
+				strings.ToUpper(key) == config.DaemonSetUpgradeMaxUnavailableKey) ||
+				strings.ToUpper(key) == config.HostNetworkKey{
 				return true
 			}
 		}
@@ -802,7 +807,9 @@ func (r *CSIScaleOperatorReconciler) SetupWithManager(mgr ctrl.Manager) error {
 			//look for deleted valid env vars of the old configmap in the new configmap
 			//if deleted restart driver pods
 			if _, ok := newCfgMapData[key]; !ok {
-				if (strings.HasPrefix(strings.ToUpper(key), config.EnvVarPrefix)) || (strings.ToUpper(key) == config.DaemonSetUpgradeMaxUnavailableKey) ||                                                                     (strings.ToUpper(key) == config.HostNetworkKey) {
+				if (strings.HasPrefix(strings.ToUpper(key), config.EnvVarPrefix)) || 
+					(strings.ToUpper(key) == config.DaemonSetUpgradeMaxUnavailableKey) ||
+					strings.ToUpper(key) == config.HostNetworkKey{
 					return true
 				}
 			}

--- a/operator/controllers/syncer/csi_node.go
+++ b/operator/controllers/syncer/csi_node.go
@@ -95,7 +95,7 @@ func GetCSIDaemonsetSyncer(c client.Client, scheme *runtime.Scheme, driver *csis
 
 	UUID = CGPrefix
 	maxUnavailable := envVars[config.DaemonSetUpgradeMaxUnavailableKey]
-	networkPolicy := envVars[config.NetworkPolicyKey]
+	hostNetwork := envVars[config.HostNetworkKey]
 
 	cmEnvVars = []corev1.EnvVar{}
 	var keys []string
@@ -115,12 +115,12 @@ func GetCSIDaemonsetSyncer(c client.Client, scheme *runtime.Scheme, driver *csis
 	}
 
 	return syncer.NewObjectSyncer(config.CSINode.String(), driver.Unwrap(), obj, c, func() error {
-		return sync.SyncCSIDaemonsetFn(daemonSetRestartedKey, daemonSetRestartedValue, maxUnavailable, networkPolicy)
+		return sync.SyncCSIDaemonsetFn(daemonSetRestartedKey, daemonSetRestartedValue, maxUnavailable, hostNetwork)
 	})
 }
 
 // SyncCSIDaemonsetFn handles reconciliation of CSI driver daemonset.
-func (s *csiNodeSyncer) SyncCSIDaemonsetFn(daemonSetRestartedKey, daemonSetRestartedValue, maxUnavailable, networkPolicy string) error {
+func (s *csiNodeSyncer) SyncCSIDaemonsetFn(daemonSetRestartedKey, daemonSetRestartedValue, maxUnavailable, hostNetwork string) error {
 	logger := csiLog.WithName("SyncCSIDaemonsetFn")
 
 	out := s.obj.(*appsv1.DaemonSet)
@@ -169,7 +169,7 @@ func (s *csiNodeSyncer) SyncCSIDaemonsetFn(daemonSetRestartedKey, daemonSetResta
 		Type:          strategyType,
 	}
 	out.Spec.UpdateStrategy = strategy
-	if networkPolicy == "ENABLED"{
+	if hostNetwork == "ENABLED"{
                 out.Spec.Template.Spec.HostNetwork = false
         }else{
 		out.Spec.Template.Spec.HostNetwork = true

--- a/operator/controllers/syncer/csi_node.go
+++ b/operator/controllers/syncer/csi_node.go
@@ -170,9 +170,9 @@ func (s *csiNodeSyncer) SyncCSIDaemonsetFn(daemonSetRestartedKey, daemonSetResta
 	}
 	out.Spec.UpdateStrategy = strategy
 	if hostNetwork == "ENABLED"{
-                out.Spec.Template.Spec.HostNetwork = false
+                out.Spec.Template.Spec.HostNetwork = true
         }else{
-		out.Spec.Template.Spec.HostNetwork = true
+		out.Spec.Template.Spec.HostNetwork = false
 	}
 
 	err := mergo.Merge(&out.Spec.Template.Spec, s.ensurePodSpec(secrets), mergo.WithOverride)

--- a/operator/controllers/syncer/csi_node.go
+++ b/operator/controllers/syncer/csi_node.go
@@ -21,7 +21,6 @@ import (
 	"os"
 	"sort"
 	"strconv"
-	"fmt"
 	"github.com/imdario/mergo"
 	"github.com/presslabs/controller-util/pkg/syncer"
 	appsv1 "k8s.io/api/apps/v1"

--- a/operator/controllers/syncer/csi_node.go
+++ b/operator/controllers/syncer/csi_node.go
@@ -100,7 +100,7 @@ func GetCSIDaemonsetSyncer(c client.Client, scheme *runtime.Scheme, driver *csis
 	cmEnvVars = []corev1.EnvVar{}
 	var keys []string
 	for k := range envVars {
-		if k != config.DaemonSetUpgradeMaxUnavailableKey {
+		if !(k == config.DaemonSetUpgradeMaxUnavailableKey || k == config.HostNetworkKey){
 			keys = append(keys, k)
 		}
 	}


### PR DESCRIPTION
Please check the type of change your PR introduces:
- [x] Bugfix
- [ ] Feature Enhancement
- [ ] Test Automation 
- [ ] Code Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Community Operator listing 
- [ ] Other (please describe): 


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying -->
Host network will always be enabled for driver pods

## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->
With current fix host network for driver pods is controlled by optional config map parameter "HOST_NETWORK". Default value will be ENABLED. If you DISABLED the parameter then host network for driver pods will be made false.

## How risky is this change?
- [ ] Small, isolated change
- [x] Medium, requires regression testing
- [ ] Large, requires functional and regression testing 

