### PR TITLE
Fix for gpfs mount path in power cluster

### DIFF
--- a/driver/csiplugin/nodeserver.go
+++ b/driver/csiplugin/nodeserver.go
@@ -48,7 +48,7 @@ const nodePublishMethod = "NODEPUBLISH_METHOD"
 const nodePublishMethodSymlink = "SYMLINK"
 
 const mountPathLength = 6
-const mountPath = "/proc/mounts"
+const mountPathFile = "/proc/mounts"
 
 const ENVClusterCNSAPresenceCheck = "CNSADeployment"
 
@@ -107,7 +107,7 @@ func checkGpfsType(ctx context.Context, path string) error {
 
 func getGpfsPaths(ctx context.Context) []string {
 	var gpfsPaths []string
-	file, err := os.Open(mountPath)
+	file, err := os.Open(mountPathFile)
         if err != nil {
                 klog.Errorf("[%s] Error in opening file: [%s]", utils.GetLoggerId(ctx), err)
         }


### PR DESCRIPTION
## Pull request checklist


Please check the type of change your PR introduces:
- [x ] Bugfix
- [ ] Feature Enhancement
- [ ] Test Automation 
- [ ] Code Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Community Operator listing 
- [ ] Other (please describe): 


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying -->
- Gpfs mount path identification is not working through "cat /proc/mounts | grep gpfs" in power8 cluster

## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->
- Gpfs mount path identification is now done through go library by reading /proc/mounts file

## How risky is this change?
- [x ] Small, isolated change
- [ ] Medium, requires regression testing
- [ ] Large, requires functional and regression testing 

