### PR TITLE
Make resources limits configurable for all the containers

### DIFF
--- a/operator/controllers/config/constants.go
+++ b/operator/controllers/config/constants.go
@@ -175,9 +175,8 @@ const (
 	EnvHostNetworkDefaultValue           = "ENABLED"
 
 	// Driver and Sidecar Containers Resources limits
-	PodsCPULimitsLowerValue      = 20    //20 is 20m
-	PodsCPULimitsFloatLowerValue = 0.020 // 0.020 is equivalent to 20m
-	PodsMemoryLimitsLowerValue   = 20    // 20 is 20Mi
+	PodsCPULimitsLowerValue    = "20m"
+	PodsMemoryLimitsLowerValue = "20Mi"
 )
 
 var CSIOptionalConfigMapKeys = []string{

--- a/operator/controllers/config/constants.go
+++ b/operator/controllers/config/constants.go
@@ -146,6 +146,9 @@ const (
 	// Optional ConfigMap keys
 	DaemonSetUpgradeMaxUnavailableKey = "DRIVER_UPGRADE_MAXUNAVAILABLE"
 	DriverCPULimits                   = "DRIVER_CPU_LIMITS"
+	DriverMemoryLimits                = "DRIVER_MEMORY_LIMITS"
+	SidecarCPULimits                  = "SIDECAR_CPU_LIMITS"
+	SidecarMemoryLimits               = "SIDECAR_MEMORY_LIMITS"
 	EnvLogLevelKey                    = "LOGLEVEL"
 	EnvPersistentLogKey               = "PERSISTENT_LOG"
 	EnvNodePublishMethodKey           = "NODEPUBLISH_METHOD"
@@ -162,11 +165,19 @@ const (
 
 	// Optional ConfigMap default values
 	DriverCPULimitsDefaultValue          = "600m"
+	DriverMemoryLimitsDefaultValue       = "600Mi"
+	SidecarCPULimitsDefaultValue         = "300m"
+	SidecarMemoryLimitsDefaultValue      = "800Mi"
 	EnvLogLevelDefaultValue              = "INFO"
 	EnvPersistentLogDefaultValue         = "DISABLED"
 	EnvNodePublishMethodDefaultValue     = "BINDMOUNT"
 	EnvVolumeStatsCapabilityDefaultValue = "ENABLED"
 	EnvHostNetworkDefaultValue           = "ENABLED"
+
+	// Driver and Sidecar Containers Resources limits
+	PodsCPULimitsLowerValue      = 20    //20 is 20m
+	PodsCPULimitsFloatLowerValue = 0.020 // 0.020 is equivalent to 20m
+	PodsMemoryLimitsLowerValue   = 20    // 20 is 20Mi
 )
 
 var CSIOptionalConfigMapKeys = []string{

--- a/operator/controllers/config/constants.go
+++ b/operator/controllers/config/constants.go
@@ -145,6 +145,7 @@ const (
 
 	// Optional ConfigMap keys
 	DaemonSetUpgradeMaxUnavailableKey = "DRIVER_UPGRADE_MAXUNAVAILABLE"
+	DriverCPULimits                   = "DRIVER_CPU_LIMITS"
 	EnvLogLevelKey                    = "LOGLEVEL"
 	EnvPersistentLogKey               = "PERSISTENT_LOG"
 	EnvNodePublishMethodKey           = "NODEPUBLISH_METHOD"
@@ -160,6 +161,7 @@ const (
 	EnvDiscoverCGFilesetKeyPrefixed     = EnvVarPrefix + EnvDiscoverCGFilesetKey
 
 	// Optional ConfigMap default values
+	DriverCPULimitsDefaultValue          = "600m"
 	EnvLogLevelDefaultValue              = "INFO"
 	EnvPersistentLogDefaultValue         = "DISABLED"
 	EnvNodePublishMethodDefaultValue     = "BINDMOUNT"
@@ -168,7 +170,8 @@ const (
 )
 
 var CSIOptionalConfigMapKeys = []string{EnvLogLevelKeyPrefixed, EnvPersistentLogKeyPrefixed,
-	EnvNodePublishMethodKeyPrefixed, EnvVolumeStatsCapabilityKeyPrefixed, DaemonSetUpgradeMaxUnavailableKey, EnvDiscoverCGFilesetKeyPrefixed, HostNetworkKey}
+	EnvNodePublishMethodKeyPrefixed, EnvVolumeStatsCapabilityKeyPrefixed, DaemonSetUpgradeMaxUnavailableKey,
+	EnvDiscoverCGFilesetKeyPrefixed, HostNetworkKey, DriverCPULimits}
 var EnvLogLevelValues = []string{"TRACE", "DEBUG", "INFO", "WARNING", "ERROR", "FATAL"}
 var EnvNodePublishMethodValues = []string{"SYMLINK", "BINDMOUNT"}
 var EnvPersistentLogValues = []string{"ENABLED", "DISABLED"}

--- a/operator/controllers/config/constants.go
+++ b/operator/controllers/config/constants.go
@@ -169,9 +169,15 @@ const (
 	EnvHostNetworkDefaultValue           = "ENABLED"
 )
 
-var CSIOptionalConfigMapKeys = []string{EnvLogLevelKeyPrefixed, EnvPersistentLogKeyPrefixed,
-	EnvNodePublishMethodKeyPrefixed, EnvVolumeStatsCapabilityKeyPrefixed, DaemonSetUpgradeMaxUnavailableKey,
-	EnvDiscoverCGFilesetKeyPrefixed, HostNetworkKey, DriverCPULimits}
+var CSIOptionalConfigMapKeys = []string{
+	EnvLogLevelKeyPrefixed,
+	EnvPersistentLogKeyPrefixed,
+	EnvNodePublishMethodKeyPrefixed,
+	EnvVolumeStatsCapabilityKeyPrefixed,
+	DaemonSetUpgradeMaxUnavailableKey,
+	EnvDiscoverCGFilesetKeyPrefixed,
+	HostNetworkKey,
+	DriverCPULimits}
 var EnvLogLevelValues = []string{"TRACE", "DEBUG", "INFO", "WARNING", "ERROR", "FATAL"}
 var EnvNodePublishMethodValues = []string{"SYMLINK", "BINDMOUNT"}
 var EnvPersistentLogValues = []string{"ENABLED", "DISABLED"}

--- a/operator/controllers/config/constants.go
+++ b/operator/controllers/config/constants.go
@@ -188,7 +188,10 @@ var CSIOptionalConfigMapKeys = []string{
 	DaemonSetUpgradeMaxUnavailableKey,
 	EnvDiscoverCGFilesetKeyPrefixed,
 	HostNetworkKey,
-	DriverCPULimits}
+	DriverCPULimits,
+	DriverMemoryLimits,
+	SidecarCPULimits,
+	SidecarMemoryLimits}
 var EnvLogLevelValues = []string{"TRACE", "DEBUG", "INFO", "WARNING", "ERROR", "FATAL"}
 var EnvNodePublishMethodValues = []string{"SYMLINK", "BINDMOUNT"}
 var EnvPersistentLogValues = []string{"ENABLED", "DISABLED"}

--- a/operator/controllers/csiscaleoperator_controller.go
+++ b/operator/controllers/csiscaleoperator_controller.go
@@ -2411,7 +2411,7 @@ func validateCPULimitsValue(key string, value string, data map[string]string, in
 			logger.Info("Validation of CPU limits Value successful ", "cpuLimits", value)
 			data[key] = value
 		} else {
-			logger.Error(fmt.Errorf("failed to parse [inputCPULimitValue=%s] or wrong value passed %v", value, err), "[ Value must be greater than or equal to %dm OR greater than or equal to %v ) ]", config.PodsCPULimitsLowerValue, config.PodsCPULimitsFloatLowerValue)
+			logger.Error(fmt.Errorf("failed to parse [inputCPULimitValue=%s] or wrong value passed. The value must be greater than or equal to %dm OR greater than or equal to %v, error : %v", value, config.PodsCPULimitsLowerValue, config.PodsCPULimitsFloatLowerValue, err), "CPU limits validation error")
 			invalidEnvValue[key] = value
 		}
 	} else {
@@ -2420,7 +2420,7 @@ func validateCPULimitsValue(key string, value string, data map[string]string, in
 			logger.Info("Validation of CPU limits Value successful ", "cpuLimits", value)
 			data[key] = value
 		} else {
-			logger.Error(fmt.Errorf("failed to parse [inputCPULimitValue=%s] or wrong value passed %v", value, err), "[ Value must be greater than or equal to %dm OR greater than or equal to %v ) ]", config.PodsCPULimitsLowerValue, config.PodsCPULimitsFloatLowerValue)
+			logger.Error(fmt.Errorf("failed to parse [inputCPULimitValue=%s] or wrong value passed. The value must be greater than or equal to %dm OR greater than or equal to %v, error : %v", value, config.PodsCPULimitsLowerValue, config.PodsCPULimitsFloatLowerValue, err), "CPU limits validation error")
 			invalidEnvValue[key] = value
 		}
 	}
@@ -2438,11 +2438,11 @@ func validateMemoryLimitsValue(key string, value string, data map[string]string,
 			logger.Info("Validation of memomry limits Value successful ", "memoryLimits", value)
 			data[key] = value
 		} else {
-			logger.Error(fmt.Errorf("failed to parse [inputMemoryLimitValue=%s] or wrong value passed %v", value, err), "[ Value must be greater than or equal to %dMi ]", config.PodsMemoryLimitsLowerValue)
+			logger.Error(fmt.Errorf("failed to parse [inputMemoryLimitValue=%s] or wrong value passed %v", value, err), "memoryLimitsError", "[ Value must be greater than or equal to %dMi ]", config.PodsMemoryLimitsLowerValue)
 			invalidEnvValue[key] = value
 		}
 	} else {
-		logger.Error(fmt.Errorf("failed to parse [inputMemoryLimitValue=%s] or wrong value passed", value), "[ Value must be greater than or equal to %dMi ]", config.PodsMemoryLimitsLowerValue)
+		logger.Error(fmt.Errorf("failed to parse [inputMemoryLimitValue=%s] or wrong value passed", value), "memoryLimitsError", "[ Value must be greater than or equal to %dMi ]", config.PodsMemoryLimitsLowerValue)
 		invalidEnvValue[key] = value
 	}
 }

--- a/operator/controllers/csiscaleoperator_controller.go
+++ b/operator/controllers/csiscaleoperator_controller.go
@@ -399,7 +399,7 @@ func (r *CSIScaleOperatorReconciler) Reconcile(ctx context.Context, req ctrl.Req
 	if err := r.removeDeprecatedStatefulset(instance, config.GetNameForResource(config.CSIControllerAttacher, instance.Name)); err != nil {
 		return ctrl.Result{}, err
 	}
-	csiControllerSyncer := clustersyncer.GetAttacherSyncer(r.Client, r.Scheme, instance, restartedAtKey, restartedAtValue)
+	csiControllerSyncer := clustersyncer.GetAttacherSyncer(r.Client, r.Scheme, instance, restartedAtKey, restartedAtValue, cmData)
 	if err := syncer.Sync(context.TODO(), csiControllerSyncer, nil); err != nil {
 		message := "Synchronization of " + config.GetNameForResource(config.CSIControllerAttacher, instance.Name) + " Deployment failed for the CSISCaleOperator instance " + instance.Name
 		logger.Error(err, message)
@@ -414,7 +414,7 @@ func (r *CSIScaleOperatorReconciler) Reconcile(ctx context.Context, req ctrl.Req
 	if err := r.removeDeprecatedStatefulset(instance, config.GetNameForResource(config.CSIControllerProvisioner, instance.Name)); err != nil {
 		return ctrl.Result{}, err
 	}
-	csiControllerSyncerProvisioner := clustersyncer.GetProvisionerSyncer(r.Client, r.Scheme, instance, restartedAtKey, restartedAtValue)
+	csiControllerSyncerProvisioner := clustersyncer.GetProvisionerSyncer(r.Client, r.Scheme, instance, restartedAtKey, restartedAtValue, cmData)
 	if err := syncer.Sync(context.TODO(), csiControllerSyncerProvisioner, nil); err != nil {
 		message := "Synchronization of " + config.GetNameForResource(config.CSIControllerProvisioner, instance.Name) + " Deployment failed for the CSISCaleOperator instance " + instance.Name
 		logger.Error(err, message)
@@ -429,7 +429,7 @@ func (r *CSIScaleOperatorReconciler) Reconcile(ctx context.Context, req ctrl.Req
 	if err := r.removeDeprecatedStatefulset(instance, config.GetNameForResource(config.CSIControllerSnapshotter, instance.Name)); err != nil {
 		return ctrl.Result{}, err
 	}
-	csiControllerSyncerSnapshotter := clustersyncer.GetSnapshotterSyncer(r.Client, r.Scheme, instance, restartedAtKey, restartedAtValue)
+	csiControllerSyncerSnapshotter := clustersyncer.GetSnapshotterSyncer(r.Client, r.Scheme, instance, restartedAtKey, restartedAtValue, cmData)
 	if err := syncer.Sync(context.TODO(), csiControllerSyncerSnapshotter, nil); err != nil {
 		message := "Synchronization of " + config.GetNameForResource(config.CSIControllerSnapshotter, instance.Name) + " Deployment failed for the CSISCaleOperator instance " + instance.Name
 		logger.Error(err, message)
@@ -444,7 +444,7 @@ func (r *CSIScaleOperatorReconciler) Reconcile(ctx context.Context, req ctrl.Req
 	if err := r.removeDeprecatedStatefulset(instance, config.GetNameForResource(config.CSIControllerResizer, instance.Name)); err != nil {
 		return ctrl.Result{}, err
 	}
-	csiControllerSyncerResizer := clustersyncer.GetResizerSyncer(r.Client, r.Scheme, instance, restartedAtKey, restartedAtValue)
+	csiControllerSyncerResizer := clustersyncer.GetResizerSyncer(r.Client, r.Scheme, instance, restartedAtKey, restartedAtValue, cmData)
 	if err := syncer.Sync(context.TODO(), csiControllerSyncerResizer, nil); err != nil {
 		message := "Synchronization of " + config.GetNameForResource(config.CSIControllerResizer, instance.Name) + " Deployment failed for the CSISCaleOperator instance " + instance.Name
 		logger.Error(err, message)

--- a/operator/controllers/csiscaleoperator_controller.go
+++ b/operator/controllers/csiscaleoperator_controller.go
@@ -2391,7 +2391,7 @@ func validateHostNetworkValue(inputSlice []string, key, value string, envMap, in
 	}
 }
 
-// Input can be either range of (0.1 - 1.0) OR (1m - 1000m)
+// Input can be either range of (0.001 - 1.0) OR (1m - 1000m)
 func validateCPULimitsValue(key string, value string, data map[string]string, invalidEnvValue map[string]string) {
 	logger := csiLog.WithName("validateCPULimitsValue")
 	logger.Info("Validating CPU limits Value input ", "cpuLimits", value)
@@ -2403,16 +2403,16 @@ func validateCPULimitsValue(key string, value string, data map[string]string, in
 			logger.Info("Validation of CPU limits Value successful ", "cpuLimits", value)
 			data[key] = value
 		} else {
-			logger.Error(fmt.Errorf("failed to parse [inputCPULimitValue=%s] or wrong value passed %v", value, err), "[ Value must be either in (1m to 1000m) OR (0.1 to 1.0) ]")
+			logger.Error(fmt.Errorf("failed to parse [inputCPULimitValue=%s] or wrong value passed %v", value, err), "[ Value must be either in (1m to 1000m) OR (0.001 to 1.0) ]")
 			invalidEnvValue[key] = value
 		}
 	} else {
 		intFloatValue, err := strconv.ParseFloat(value, 64)
-		if err == nil && (intFloatValue >= 0.1 && intFloatValue <= 1.0) {
+		if err == nil && (intFloatValue >= 0.001 && intFloatValue <= 1.0) {
 			logger.Info("Validation of CPU limits Value successful ", "cpuLimits", value)
 			data[key] = value
 		} else {
-			logger.Error(fmt.Errorf("failed to parse [inputCPULimitValue=%s] or wrong value passed %v", value, err), "[ Value must be either in (1m to 1000m) OR (0.1 to 1.0) ]")
+			logger.Error(fmt.Errorf("failed to parse [inputCPULimitValue=%s] or wrong value passed %v", value, err), "[ Value must be either in (1m to 1000m) OR (0.001 to 1.0) ]")
 			invalidEnvValue[key] = value
 		}
 	}

--- a/operator/controllers/csiscaleoperator_controller.go
+++ b/operator/controllers/csiscaleoperator_controller.go
@@ -770,13 +770,7 @@ func (r *CSIScaleOperatorReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	//Do not restart driver pods when the configmap contains invalid Envs.
 	shouldRequeueOnCreateOrDelete := func(cfgmapData map[string]string) bool {
 		for key := range cfgmapData {
-			if strings.HasPrefix(strings.ToUpper(key), config.EnvVarPrefix) ||
-				strings.ToUpper(key) == config.DaemonSetUpgradeMaxUnavailableKey ||
-				strings.ToUpper(key) == config.HostNetworkKey ||
-				strings.ToUpper(key) == config.DriverCPULimits ||
-				strings.ToUpper(key) == config.DriverMemoryLimits ||
-				strings.ToUpper(key) == config.SidecarCPULimits ||
-				strings.ToUpper(key) == config.SidecarMemoryLimits {
+			if containsStringInSlice(config.CSIOptionalConfigMapKeys, strings.ToUpper(key)) {
 				return true
 			}
 		}
@@ -790,22 +784,10 @@ func (r *CSIScaleOperatorReconciler) SetupWithManager(mgr ctrl.Manager) error {
 		for key, newVal := range newCfgMapData {
 			//Allow restart of driver pods when a new valid env var is found or the value of existing valid env var is updated
 			if oldVal, ok := oldCfgMapData[key]; !ok {
-				if (strings.HasPrefix(strings.ToUpper(key), config.EnvVarPrefix)) ||
-					strings.ToUpper(key) == config.DaemonSetUpgradeMaxUnavailableKey ||
-					strings.ToUpper(key) == config.HostNetworkKey ||
-					strings.ToUpper(key) == config.DriverCPULimits ||
-					strings.ToUpper(key) == config.DriverMemoryLimits ||
-					strings.ToUpper(key) == config.SidecarCPULimits ||
-					strings.ToUpper(key) == config.SidecarMemoryLimits {
+				if containsStringInSlice(config.CSIOptionalConfigMapKeys, strings.ToUpper(key)) {
 					return true
 				}
-			} else if oldVal != newVal && (strings.HasPrefix(strings.ToUpper(key), config.EnvVarPrefix) ||
-				strings.ToUpper(key) == config.DaemonSetUpgradeMaxUnavailableKey) ||
-				strings.ToUpper(key) == config.HostNetworkKey ||
-				strings.ToUpper(key) == config.DriverCPULimits ||
-				strings.ToUpper(key) == config.DriverMemoryLimits ||
-				strings.ToUpper(key) == config.SidecarCPULimits ||
-				strings.ToUpper(key) == config.SidecarMemoryLimits {
+			} else if oldVal != newVal && containsStringInSlice(config.CSIOptionalConfigMapKeys, strings.ToUpper(key)) {
 				return true
 			}
 		}
@@ -814,13 +796,7 @@ func (r *CSIScaleOperatorReconciler) SetupWithManager(mgr ctrl.Manager) error {
 			//look for deleted valid env vars of the old configmap in the new configmap
 			//if deleted restart driver pods
 			if _, ok := newCfgMapData[key]; !ok {
-				if (strings.HasPrefix(strings.ToUpper(key), config.EnvVarPrefix)) ||
-					(strings.ToUpper(key) == config.DaemonSetUpgradeMaxUnavailableKey) ||
-					strings.ToUpper(key) == config.HostNetworkKey ||
-					strings.ToUpper(key) == config.DriverCPULimits ||
-					strings.ToUpper(key) == config.DriverMemoryLimits ||
-					strings.ToUpper(key) == config.SidecarCPULimits ||
-					strings.ToUpper(key) == config.SidecarMemoryLimits {
+				if containsStringInSlice(config.CSIOptionalConfigMapKeys, strings.ToUpper(key)) {
 					return true
 				}
 			}

--- a/operator/controllers/syncer/csi_node.go
+++ b/operator/controllers/syncer/csi_node.go
@@ -105,7 +105,7 @@ func GetCSIDaemonsetSyncer(c client.Client, scheme *runtime.Scheme, driver *csis
 	cmEnvVars = []corev1.EnvVar{}
 	var keys []string
 	for k := range envVars {
-		if !(k == config.DaemonSetUpgradeMaxUnavailableKey || k == config.HostNetworkKey) {
+		if !(k == config.DaemonSetUpgradeMaxUnavailableKey || k == config.HostNetworkKey || k == config.DriverCPULimits || k == config.DriverMemoryLimits || k == config.SidecarCPULimits || k == config.SidecarMemoryLimits) {
 			keys = append(keys, k)
 		}
 	}

--- a/operator/controllers/syncer/csi_syncer.go
+++ b/operator/controllers/syncer/csi_syncer.go
@@ -89,7 +89,7 @@ func CSIConfigmapSyncer(c client.Client, scheme *runtime.Scheme, driver *csiscal
 
 // GetAttacherSyncer returns a new kubernetes.Object syncer for k8s deployment object for CSI attacher service.
 func GetAttacherSyncer(c client.Client, scheme *runtime.Scheme, driver *csiscaleoperator.CSIScaleOperator,
-	restartedAtKey string, restartedAtValue string, envVars map[string]string) syncer.Interface {
+	restartedAtKey string, restartedAtValue string, cpuLimits string, memoryLimits string) syncer.Interface {
 
 	logger := csiLog.WithName("GetAttacherSyncer")
 	logger.Info("Creating a syncer object for the attacher deployment.")
@@ -108,9 +108,6 @@ func GetAttacherSyncer(c client.Client, scheme *runtime.Scheme, driver *csiscale
 		obj:    obj,
 	}
 
-	cpuLimits := envVars[config.SidecarCPULimits]
-	memoryLimits := envVars[config.SidecarMemoryLimits]
-
 	return syncer.NewObjectSyncer(config.CSIController.String(), driver.Unwrap(), obj, c, func() error {
 		return sync.SyncAttacherFn(restartedAtKey, restartedAtValue, cpuLimits, memoryLimits)
 	})
@@ -118,7 +115,7 @@ func GetAttacherSyncer(c client.Client, scheme *runtime.Scheme, driver *csiscale
 
 // GetProvisionerSyncer returns a new kubernetes.Object syncer for k8s deployment object for CSI provisioner service.
 func GetProvisionerSyncer(c client.Client, scheme *runtime.Scheme, driver *csiscaleoperator.CSIScaleOperator,
-	restartedAtKey string, restartedAtValue string, envVars map[string]string) syncer.Interface {
+	restartedAtKey string, restartedAtValue string, cpuLimits string, memoryLimits string) syncer.Interface {
 
 	logger := csiLog.WithName("GetProvisionerSyncer")
 	logger.Info("Creating a syncer object for the provisioner deployment.")
@@ -137,9 +134,6 @@ func GetProvisionerSyncer(c client.Client, scheme *runtime.Scheme, driver *csisc
 		obj:    obj,
 	}
 
-	cpuLimits := envVars[config.SidecarCPULimits]
-	memoryLimits := envVars[config.SidecarMemoryLimits]
-
 	return syncer.NewObjectSyncer(config.CSIController.String(), driver.Unwrap(), obj, c, func() error {
 		return sync.SyncProvisionerFn(restartedAtKey, restartedAtValue, cpuLimits, memoryLimits)
 	})
@@ -147,7 +141,7 @@ func GetProvisionerSyncer(c client.Client, scheme *runtime.Scheme, driver *csisc
 
 // GetSnapshotterSyncer returns a new kubernetes.Object syncer for k8s deployment object for CSI snapshotter service.
 func GetSnapshotterSyncer(c client.Client, scheme *runtime.Scheme, driver *csiscaleoperator.CSIScaleOperator,
-	restartedAtKey string, restartedAtValue string, envVars map[string]string) syncer.Interface {
+	restartedAtKey string, restartedAtValue string, cpuLimits string, memoryLimits string) syncer.Interface {
 
 	logger := csiLog.WithName("GetSnapshotterSyncer")
 	logger.Info("Creating a syncer object for the snapshotter deployment.")
@@ -166,9 +160,6 @@ func GetSnapshotterSyncer(c client.Client, scheme *runtime.Scheme, driver *csisc
 		obj:    obj,
 	}
 
-	cpuLimits := envVars[config.SidecarCPULimits]
-	memoryLimits := envVars[config.SidecarMemoryLimits]
-
 	return syncer.NewObjectSyncer(config.CSIController.String(), driver.Unwrap(), obj, c, func() error {
 		return sync.SyncSnapshotterFn(restartedAtKey, restartedAtValue, cpuLimits, memoryLimits)
 	})
@@ -176,7 +167,7 @@ func GetSnapshotterSyncer(c client.Client, scheme *runtime.Scheme, driver *csisc
 
 // GetResizerSyncer returns a new kubernetes.Object syncer for k8s deployment object for CSI resizer service.
 func GetResizerSyncer(c client.Client, scheme *runtime.Scheme, driver *csiscaleoperator.CSIScaleOperator,
-	restartedAtKey string, restartedAtValue string, envVars map[string]string) syncer.Interface {
+	restartedAtKey string, restartedAtValue string, cpuLimits string, memoryLimits string) syncer.Interface {
 
 	logger := csiLog.WithName("GetResizerSyncer")
 	logger.Info("Creating a syncer object for the resizer deployment.")
@@ -194,9 +185,6 @@ func GetResizerSyncer(c client.Client, scheme *runtime.Scheme, driver *csiscaleo
 		driver: driver,
 		obj:    obj,
 	}
-
-	cpuLimits := envVars[config.SidecarCPULimits]
-	memoryLimits := envVars[config.SidecarMemoryLimits]
 
 	return syncer.NewObjectSyncer(config.CSIController.String(), driver.Unwrap(), obj, c, func() error {
 		return sync.SyncResizerFn(restartedAtKey, restartedAtValue, cpuLimits, memoryLimits)

--- a/operator/controllers/syncer/csi_syncer.go
+++ b/operator/controllers/syncer/csi_syncer.go
@@ -89,7 +89,7 @@ func CSIConfigmapSyncer(c client.Client, scheme *runtime.Scheme, driver *csiscal
 
 // GetAttacherSyncer returns a new kubernetes.Object syncer for k8s deployment object for CSI attacher service.
 func GetAttacherSyncer(c client.Client, scheme *runtime.Scheme, driver *csiscaleoperator.CSIScaleOperator,
-	restartedAtKey string, restartedAtValue string) syncer.Interface {
+	restartedAtKey string, restartedAtValue string, envVars map[string]string) syncer.Interface {
 
 	logger := csiLog.WithName("GetAttacherSyncer")
 	logger.Info("Creating a syncer object for the attacher deployment.")
@@ -108,14 +108,17 @@ func GetAttacherSyncer(c client.Client, scheme *runtime.Scheme, driver *csiscale
 		obj:    obj,
 	}
 
+	cpuLimits := envVars[config.SidecarCPULimits]
+	memoryLimits := envVars[config.SidecarMemoryLimits]
+
 	return syncer.NewObjectSyncer(config.CSIController.String(), driver.Unwrap(), obj, c, func() error {
-		return sync.SyncAttacherFn(restartedAtKey, restartedAtValue)
+		return sync.SyncAttacherFn(restartedAtKey, restartedAtValue, cpuLimits, memoryLimits)
 	})
 }
 
 // GetProvisionerSyncer returns a new kubernetes.Object syncer for k8s deployment object for CSI provisioner service.
 func GetProvisionerSyncer(c client.Client, scheme *runtime.Scheme, driver *csiscaleoperator.CSIScaleOperator,
-	restartedAtKey string, restartedAtValue string) syncer.Interface {
+	restartedAtKey string, restartedAtValue string, envVars map[string]string) syncer.Interface {
 
 	logger := csiLog.WithName("GetProvisionerSyncer")
 	logger.Info("Creating a syncer object for the provisioner deployment.")
@@ -134,14 +137,17 @@ func GetProvisionerSyncer(c client.Client, scheme *runtime.Scheme, driver *csisc
 		obj:    obj,
 	}
 
+	cpuLimits := envVars[config.SidecarCPULimits]
+	memoryLimits := envVars[config.SidecarMemoryLimits]
+
 	return syncer.NewObjectSyncer(config.CSIController.String(), driver.Unwrap(), obj, c, func() error {
-		return sync.SyncProvisionerFn(restartedAtKey, restartedAtValue)
+		return sync.SyncProvisionerFn(restartedAtKey, restartedAtValue, cpuLimits, memoryLimits)
 	})
 }
 
 // GetSnapshotterSyncer returns a new kubernetes.Object syncer for k8s deployment object for CSI snapshotter service.
 func GetSnapshotterSyncer(c client.Client, scheme *runtime.Scheme, driver *csiscaleoperator.CSIScaleOperator,
-	restartedAtKey string, restartedAtValue string) syncer.Interface {
+	restartedAtKey string, restartedAtValue string, envVars map[string]string) syncer.Interface {
 
 	logger := csiLog.WithName("GetSnapshotterSyncer")
 	logger.Info("Creating a syncer object for the snapshotter deployment.")
@@ -160,14 +166,17 @@ func GetSnapshotterSyncer(c client.Client, scheme *runtime.Scheme, driver *csisc
 		obj:    obj,
 	}
 
+	cpuLimits := envVars[config.SidecarCPULimits]
+	memoryLimits := envVars[config.SidecarMemoryLimits]
+
 	return syncer.NewObjectSyncer(config.CSIController.String(), driver.Unwrap(), obj, c, func() error {
-		return sync.SyncSnapshotterFn(restartedAtKey, restartedAtValue)
+		return sync.SyncSnapshotterFn(restartedAtKey, restartedAtValue, cpuLimits, memoryLimits)
 	})
 }
 
 // GetResizerSyncer returns a new kubernetes.Object syncer for k8s deployment object for CSI resizer service.
 func GetResizerSyncer(c client.Client, scheme *runtime.Scheme, driver *csiscaleoperator.CSIScaleOperator,
-	restartedAtKey string, restartedAtValue string) syncer.Interface {
+	restartedAtKey string, restartedAtValue string, envVars map[string]string) syncer.Interface {
 
 	logger := csiLog.WithName("GetResizerSyncer")
 	logger.Info("Creating a syncer object for the resizer deployment.")
@@ -186,8 +195,11 @@ func GetResizerSyncer(c client.Client, scheme *runtime.Scheme, driver *csiscaleo
 		obj:    obj,
 	}
 
+	cpuLimits := envVars[config.SidecarCPULimits]
+	memoryLimits := envVars[config.SidecarMemoryLimits]
+
 	return syncer.NewObjectSyncer(config.CSIController.String(), driver.Unwrap(), obj, c, func() error {
-		return sync.SyncResizerFn(restartedAtKey, restartedAtValue)
+		return sync.SyncResizerFn(restartedAtKey, restartedAtValue, cpuLimits, memoryLimits)
 	})
 }
 
@@ -213,7 +225,7 @@ func (s *csiControllerSyncer) SyncConfigMapFn() error {
 }
 
 // SyncAttacherFn is a function which mutates the existing attacher deployment object into it's desired state.
-func (s *csiControllerSyncer) SyncAttacherFn(restartedAtKey string, restartedAtValue string) error {
+func (s *csiControllerSyncer) SyncAttacherFn(restartedAtKey string, restartedAtValue string, cpuLimits string, memoryLimits string) error {
 
 	logger := csiLog.WithName("SyncAttacherFn")
 	logger.Info("Mutating the attacher deployment object into it's desired state.")
@@ -243,7 +255,7 @@ func (s *csiControllerSyncer) SyncAttacherFn(restartedAtKey string, restartedAtV
 	out.Spec.Template.Spec.Tolerations = []corev1.Toleration{}
 	out.Spec.Template.Spec.ImagePullSecrets = []corev1.LocalObjectReference{}
 
-	err := mergo.Merge(&out.Spec.Template.Spec, s.ensureAttacherPodSpec(secrets), mergo.WithOverride)
+	err := mergo.Merge(&out.Spec.Template.Spec, s.ensureAttacherPodSpec(secrets, cpuLimits, memoryLimits), mergo.WithOverride)
 	if err != nil {
 		return err
 	}
@@ -252,7 +264,7 @@ func (s *csiControllerSyncer) SyncAttacherFn(restartedAtKey string, restartedAtV
 }
 
 // SyncProvisionerFn is a function which mutates the existing provisioner deployment object into it's desired state.
-func (s *csiControllerSyncer) SyncProvisionerFn(restartedAtKey string, restartedAtValue string) error {
+func (s *csiControllerSyncer) SyncProvisionerFn(restartedAtKey string, restartedAtValue string, cpuLimits string, memoryLimits string) error {
 
 	logger := csiLog.WithName("SyncProvisionerFn")
 	logger.Info("Mutating the provisioner deployment object into it's desired state.")
@@ -280,7 +292,7 @@ func (s *csiControllerSyncer) SyncProvisionerFn(restartedAtKey string, restarted
 	out.Spec.Template.Spec.Tolerations = []corev1.Toleration{}
 	out.Spec.Template.Spec.ImagePullSecrets = []corev1.LocalObjectReference{}
 
-	err := mergo.Merge(&out.Spec.Template.Spec, s.ensureProvisionerPodSpec(secrets), mergo.WithOverride)
+	err := mergo.Merge(&out.Spec.Template.Spec, s.ensureProvisionerPodSpec(secrets, cpuLimits, memoryLimits), mergo.WithOverride)
 	if err != nil {
 		return err
 	}
@@ -289,7 +301,7 @@ func (s *csiControllerSyncer) SyncProvisionerFn(restartedAtKey string, restarted
 }
 
 // SyncSnapshotterFn is a function which mutates the existing snapshotter deployment object into it's desired state.
-func (s *csiControllerSyncer) SyncSnapshotterFn(restartedAtKey string, restartedAtValue string) error {
+func (s *csiControllerSyncer) SyncSnapshotterFn(restartedAtKey string, restartedAtValue string, cpuLimits string, memoryLimits string) error {
 
 	logger := csiLog.WithName("SyncSnapshotterFn")
 	logger.Info("Mutating the snapshotter deployment object into it's desired state.")
@@ -317,7 +329,7 @@ func (s *csiControllerSyncer) SyncSnapshotterFn(restartedAtKey string, restarted
 	out.Spec.Template.Spec.Tolerations = []corev1.Toleration{}
 	out.Spec.Template.Spec.ImagePullSecrets = []corev1.LocalObjectReference{}
 
-	err := mergo.Merge(&out.Spec.Template.Spec, s.ensureSnapshotterPodSpec(secrets), mergo.WithOverride)
+	err := mergo.Merge(&out.Spec.Template.Spec, s.ensureSnapshotterPodSpec(secrets, cpuLimits, memoryLimits), mergo.WithOverride)
 	if err != nil {
 		return err
 	}
@@ -326,7 +338,7 @@ func (s *csiControllerSyncer) SyncSnapshotterFn(restartedAtKey string, restarted
 }
 
 // SyncResizerFn is a function which mutates the existing resizer deployment object into it's desired state.
-func (s *csiControllerSyncer) SyncResizerFn(restartedAtKey string, restartedAtValue string) error {
+func (s *csiControllerSyncer) SyncResizerFn(restartedAtKey string, restartedAtValue string, cpuLimits string, memoryLimits string) error {
 
 	logger := csiLog.WithName("SyncResizerFn")
 	logger.Info("Mutating the resizer deployment object into it's desired state.")
@@ -354,7 +366,7 @@ func (s *csiControllerSyncer) SyncResizerFn(restartedAtKey string, restartedAtVa
 	out.Spec.Template.Spec.Tolerations = []corev1.Toleration{}
 	out.Spec.Template.Spec.ImagePullSecrets = []corev1.LocalObjectReference{}
 
-	err := mergo.Merge(&out.Spec.Template.Spec, s.ensureResizerPodSpec(secrets), mergo.WithOverride)
+	err := mergo.Merge(&out.Spec.Template.Spec, s.ensureResizerPodSpec(secrets, cpuLimits, memoryLimits), mergo.WithOverride)
 	if err != nil {
 		return err
 	}
@@ -402,14 +414,14 @@ func (s *csiControllerSyncer) SyncFn() error {
 
 // ensureAttacherPodSpec returns an object of type corev1.PodSpec.
 // PodSpec contains description of the attacher pod.
-func (s *csiControllerSyncer) ensureAttacherPodSpec(secrets []corev1.LocalObjectReference) corev1.PodSpec {
+func (s *csiControllerSyncer) ensureAttacherPodSpec(secrets []corev1.LocalObjectReference, cpuLimits string, memoryLimits string) corev1.PodSpec {
 
 	logger := csiLog.WithName("ensureAttacherPodSpec")
 	logger.Info("Generating pod description for the attacher pod.")
 
 	tolerations := s.driver.Spec.Tolerations
 	pod := corev1.PodSpec{
-		Containers:         s.ensureAttacherContainersSpec(),
+		Containers:         s.ensureAttacherContainersSpec(cpuLimits, memoryLimits),
 		Volumes:            s.ensureVolumes(),
 		Tolerations:        s.ensurePodTolerations(tolerations),
 		Affinity:           s.driver.GetAffinity(config.Attacher.String()),
@@ -425,7 +437,7 @@ func (s *csiControllerSyncer) ensureAttacherPodSpec(secrets []corev1.LocalObject
 
 // ensureProvisionerPodSpec returns an object of type corev1.PodSpec.
 // PodSpec contains description of the provisioner pod.
-func (s *csiControllerSyncer) ensureProvisionerPodSpec(secrets []corev1.LocalObjectReference) corev1.PodSpec {
+func (s *csiControllerSyncer) ensureProvisionerPodSpec(secrets []corev1.LocalObjectReference, cpuLimits string, memoryLimits string) corev1.PodSpec {
 
 	logger := csiLog.WithName("ensureProvisionerPodSpec")
 	logger.Info("Generating pod description for the provisioner pod.")
@@ -433,7 +445,7 @@ func (s *csiControllerSyncer) ensureProvisionerPodSpec(secrets []corev1.LocalObj
 	tolerations := s.driver.Spec.Tolerations
 	// fsGroup := config.ControllerUserID
 	pod := corev1.PodSpec{
-		Containers:         s.ensureProvisionerContainersSpec(),
+		Containers:         s.ensureProvisionerContainersSpec(cpuLimits, memoryLimits),
 		Volumes:            s.ensureVolumes(),
 		Tolerations:        s.ensurePodTolerations(tolerations),
 		Affinity:           s.driver.GetAffinity(config.Provisioner.String()),
@@ -448,7 +460,7 @@ func (s *csiControllerSyncer) ensureProvisionerPodSpec(secrets []corev1.LocalObj
 
 // ensureSnapshotterPodSpec returns an object of type corev1.PodSpec.
 // PodSpec contains description of the provisioner pod.
-func (s *csiControllerSyncer) ensureSnapshotterPodSpec(secrets []corev1.LocalObjectReference) corev1.PodSpec {
+func (s *csiControllerSyncer) ensureSnapshotterPodSpec(secrets []corev1.LocalObjectReference, cpuLimits string, memoryLimits string) corev1.PodSpec {
 
 	logger := csiLog.WithName("ensureSnapshotterPodSpec")
 	logger.Info("Generating pod description for the snapshotter pod.")
@@ -456,7 +468,7 @@ func (s *csiControllerSyncer) ensureSnapshotterPodSpec(secrets []corev1.LocalObj
 	tolerations := s.driver.Spec.Tolerations
 	// fsGroup := config.ControllerUserID
 	pod := corev1.PodSpec{
-		Containers:         s.ensureSnapshotterContainersSpec(),
+		Containers:         s.ensureSnapshotterContainersSpec(cpuLimits, memoryLimits),
 		Volumes:            s.ensureVolumes(),
 		Tolerations:        s.ensurePodTolerations(tolerations),
 		Affinity:           s.driver.GetAffinity(config.Snapshotter.String()),
@@ -471,7 +483,7 @@ func (s *csiControllerSyncer) ensureSnapshotterPodSpec(secrets []corev1.LocalObj
 
 // ensureResizerPodSpec returns an object of type corev1.PodSpec.
 // PodSpec contains description of the provisioner pod.
-func (s *csiControllerSyncer) ensureResizerPodSpec(secrets []corev1.LocalObjectReference) corev1.PodSpec {
+func (s *csiControllerSyncer) ensureResizerPodSpec(secrets []corev1.LocalObjectReference, cpuLimits string, memoryLimits string) corev1.PodSpec {
 
 	logger := csiLog.WithName("ensureResizerPodSpec")
 	logger.Info("Generating pod description for the resizer pod.")
@@ -479,7 +491,7 @@ func (s *csiControllerSyncer) ensureResizerPodSpec(secrets []corev1.LocalObjectR
 	tolerations := s.driver.Spec.Tolerations
 	// fsGroup := config.ControllerUserID
 	pod := corev1.PodSpec{
-		Containers:         s.ensureResizerContainersSpec(),
+		Containers:         s.ensureResizerContainersSpec(cpuLimits, memoryLimits),
 		Volumes:            s.ensureVolumes(),
 		Tolerations:        s.ensurePodTolerations(tolerations),
 		Affinity:           s.driver.GetAffinity(config.Resizer.String()),
@@ -518,7 +530,7 @@ func (s *csiControllerSyncer) ensurePodSpec() corev1.PodSpec {
 
 // ensureAttacherContainersSpec returns an object of type corev1.Container.
 // Container object contains description for the container within the attacher pod.
-func (s *csiControllerSyncer) ensureAttacherContainersSpec() []corev1.Container {
+func (s *csiControllerSyncer) ensureAttacherContainersSpec(cpuLimits string, memoryLimits string) []corev1.Container {
 
 	logger := csiLog.WithName("ensureAttacherContainersSpec")
 	logger.Info("Generating container description for the attacher pod.", "attacherContainerName", attacherContainerName)
@@ -531,6 +543,7 @@ func (s *csiControllerSyncer) ensureAttacherContainersSpec() []corev1.Container 
 			"--leader-election-renew-deadline=$(LEADER_ELECTION_RENEW_DEADLINE)",
 			"--leader-election-retry-period=$(LEADER_ELECTION_RETRY_PERIOD)",
 			"--http-endpoint=:" + fmt.Sprint(config.LeaderLivenessPort)},
+		cpuLimits, memoryLimits,
 	)
 	attacher.ImagePullPolicy = config.CSIAttacherImagePullPolicy
 
@@ -541,7 +554,7 @@ func (s *csiControllerSyncer) ensureAttacherContainersSpec() []corev1.Container 
 
 // ensureProvisionerContainersSpec returns an object of type corev1.Container.
 // Container object contains description for the container within the provisioner pod.
-func (s *csiControllerSyncer) ensureProvisionerContainersSpec() []corev1.Container {
+func (s *csiControllerSyncer) ensureProvisionerContainersSpec(cpuLimits string, memoryLimits string) []corev1.Container {
 
 	logger := csiLog.WithName("ensureProvisionerContainersSpec")
 	logger.Info("Generating container description for the provisioner pod.", "provisionerContainerName", provisionerContainerName)
@@ -555,6 +568,7 @@ func (s *csiControllerSyncer) ensureProvisionerContainersSpec() []corev1.Contain
 			"--leader-election-renew-deadline=$(LEADER_ELECTION_RENEW_DEADLINE)",
 			"--leader-election-retry-period=$(LEADER_ELECTION_RETRY_PERIOD)",
 			"--http-endpoint=:" + fmt.Sprint(config.LeaderLivenessPort)},
+		cpuLimits, memoryLimits,
 	)
 	provisioner.ImagePullPolicy = config.CSIProvisionerImagePullPolicy
 	return []corev1.Container{
@@ -564,7 +578,7 @@ func (s *csiControllerSyncer) ensureProvisionerContainersSpec() []corev1.Contain
 
 // ensureSnapshotterContainersSpec returns an object of type corev1.Container.
 // Container object contains description for the container within the snapshotter pod.
-func (s *csiControllerSyncer) ensureSnapshotterContainersSpec() []corev1.Container {
+func (s *csiControllerSyncer) ensureSnapshotterContainersSpec(cpuLimits string, memoryLimits string) []corev1.Container {
 
 	logger := csiLog.WithName("ensureSnapshotterContainersSpec")
 	logger.Info("Generating container description for the snapshotter pod.", "snapshotterContainerName", snapshotterContainerName)
@@ -577,6 +591,7 @@ func (s *csiControllerSyncer) ensureSnapshotterContainersSpec() []corev1.Contain
 			"--leader-election-renew-deadline=$(LEADER_ELECTION_RENEW_DEADLINE)",
 			"--leader-election-retry-period=$(LEADER_ELECTION_RETRY_PERIOD)",
 			"--http-endpoint=:" + fmt.Sprint(config.LeaderLivenessPort)},
+		cpuLimits, memoryLimits,
 	)
 	snapshotter.ImagePullPolicy = config.CSISnapshotterImagePullPolicy
 	return []corev1.Container{
@@ -586,7 +601,7 @@ func (s *csiControllerSyncer) ensureSnapshotterContainersSpec() []corev1.Contain
 
 // ensureResizerContainersSpec returns an object of type corev1.Container.
 // Container object contains description for the container within the resizer pod.
-func (s *csiControllerSyncer) ensureResizerContainersSpec() []corev1.Container {
+func (s *csiControllerSyncer) ensureResizerContainersSpec(cpuLimits string, memoryLimits string) []corev1.Container {
 
 	logger := csiLog.WithName("ensureResizerContainersSpec")
 	logger.Info("Generating container description for the resizer pod.", "resizerContainerName", resizerContainerName)
@@ -598,6 +613,7 @@ func (s *csiControllerSyncer) ensureResizerContainersSpec() []corev1.Container {
 			"--leader-election-renew-deadline=$(LEADER_ELECTION_RENEW_DEADLINE)",
 			"--leader-election-retry-period=$(LEADER_ELECTION_RETRY_PERIOD)",
 			"--http-endpoint=:" + fmt.Sprint(config.LeaderLivenessPort)},
+		cpuLimits, memoryLimits,
 	)
 	resizer.ImagePullPolicy = config.CSIResizerImagePullPolicy
 	return []corev1.Container{
@@ -654,8 +670,8 @@ func (s *csiControllerSyncer) ensureContainersSpec() []corev1.Container {
 */
 
 // Helper function that calls ensureResources method with the resources needed for sidecar containers.
-func ensureSidecarResources() corev1.ResourceRequirements {
-	return ensureResources("20m", "300m", "20Mi", "800Mi", "1Gi", "5Gi")
+func ensureSidecarResources(cpuLimits string, memoryLimits string) corev1.ResourceRequirements {
+	return ensureResources("20m", cpuLimits, "20Mi", memoryLimits, "1Gi", "5Gi")
 }
 
 // Helper function that calls ensureResources method with the resources needed for driver containers.
@@ -704,7 +720,7 @@ func ensureNodeAffinity() *corev1.NodeAffinity {
 */
 
 // ensureContainer generates k8s container object.
-func (s *csiControllerSyncer) ensureContainer(name, image string, args []string) corev1.Container {
+func (s *csiControllerSyncer) ensureContainer(name, image string, args []string, cpuLimits string, memoryLimits string) corev1.Container {
 
 	logger := csiLog.WithName("ensureContainer")
 	logger.Info("Container information: ", "Name", name, "Image", image)
@@ -718,7 +734,7 @@ func (s *csiControllerSyncer) ensureContainer(name, image string, args []string)
 		VolumeMounts:  s.getVolumeMountsFor(name),
 		Ports:         s.driver.GetContainerPort(),
 		LivenessProbe: s.driver.GetLivenessProbe(),
-		Resources:     ensureSidecarResources(),
+		Resources:     ensureSidecarResources(cpuLimits, memoryLimits),
 	}
 	container.SecurityContext = ensureContainerSecurityContext(false, false, true)
 	fillSecurityContextCapabilities(container.SecurityContext)

--- a/operator/controllers/syncer/csi_syncer.go
+++ b/operator/controllers/syncer/csi_syncer.go
@@ -659,8 +659,8 @@ func ensureSidecarResources() corev1.ResourceRequirements {
 }
 
 // Helper function that calls ensureResources method with the resources needed for driver containers.
-func ensureDriverResources(cpuLimits string) corev1.ResourceRequirements {
-	return ensureResources("20m", cpuLimits, "20Mi", "600Mi", "1Gi", "10Gi")
+func ensureDriverResources(cpuLimits string, memoryLimits string) corev1.ResourceRequirements {
+	return ensureResources("20m", cpuLimits, "20Mi", memoryLimits, "1Gi", "10Gi")
 }
 
 // ensureResources generates k8s resourceRequirements object.


### PR DESCRIPTION
* Make CPU and Memory limits configurable for CSI driver containers and all the sidecar containers. 
* To configure CPU limits use the optional configmap with a key `DRIVER_CPU_LIMITS` , e.g. `DRIVER_CPU_LIMITS: 800m`
* Default CPU limit is `600m`

Default Limits are:

> DriverCPULimitsDefaultValue          = "600m"
	DriverMemoryLimitsDefaultValue       = "600Mi"
	SidecarCPULimitsDefaultValue         = "300m"
	SidecarMemoryLimitsDefaultValue      = "800Mi"

 
Please check the type of change your PR introduces:
- [ ] Bugfix
- [x] Feature Enhancement
- [ ] Test Automation 
- [ ] Code Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Community Operator listing 
- [ ] Other (please describe): 


## What is the current behavior?
CPU limits of the driver container is to `600m`. Other resources limits are the default values. 

## What is the new behavior?
CPU limits and Memory limits of the all the containers are configurable. 
There is a minimum value must be required to set. For CPU limit, minimum is 20m and for memory, minimum value is 20Mi.
Below is the details of the spec after successfully set.

`  name: ibm-spectrum-scale-csi
    resources:
      limits:
        cpu: 700m
        ephemeral-storage: 10Gi
        memory: 600Mi`

e.g. data in the optionalCM will look like:

> DRIVER_CPU_LIMITS: "0.01"
> DRIVER_CPU_LIMITS: "0.1"
> DRIVER_CPU_LIMITS: 110m

## How risky is this change?
- [ ] Small, isolated change
- [x] Medium, requires regression testing
- [ ] Large, requires functional and regression testing 

