### PR TITLE
Fix for snapshot stuck deletion

### DIFF
--- a/driver/csiplugin/controllerserver.go
+++ b/driver/csiplugin/controllerserver.go
@@ -730,7 +730,7 @@ func (cs *ScaleControllerServer) CreateVolume(ctx context.Context, req *csi.Crea
 	}
 
 	if isSnapSource {
-		err = cs.validateSnapId(ctx, scaleVol, &snapIdMembers, scaleVol, primaryClusterID)
+		err = cs.validateSnapId(ctx, scaleVol, &snapIdMembers, scaleVol, primaryClusterID, assembledScaleversion)
 		if err != nil {
 			klog.Errorf("[%s] volume:[%v] - Error in source snapshot validation [%v]", loggerId, volName, err)
 			return nil,err
@@ -748,7 +748,7 @@ func (cs *ScaleControllerServer) CreateVolume(ctx context.Context, req *csi.Crea
 
 	var shallowCopyTargetPath string
 	if isShallowCopyVolume {
-		err = cs.createSnapshotDir(ctx, &snapIdMembers, scaleVol, isNewVolumeType
+		err = cs.createSnapshotDir(ctx, &snapIdMembers, scaleVol, isNewVolumeType)
 		if err != nil {
 			return nil, err
 		}

--- a/driver/csiplugin/controllerserver.go
+++ b/driver/csiplugin/controllerserver.go
@@ -1645,14 +1645,8 @@ func (cs *ScaleControllerServer) validateShallowCopyVolume(ctx context.Context, 
 			}else{
 				if sourcesnapshot.StorageClassType == STORAGECLASS_CLASSIC {
           				isSamefsetType := false
-          				if newvolume.FilesetType == independentFileset {
-            					if sourcesnapshot.VolType == FILE_INDEPENDENTFILESET_VOLUME{
+          				if (newvolume.FilesetType == independentFileset && sourcesnapshot.VolType == FILE_INDEPENDENTFILESET_VOLUME) || (newvolume.FilesetType == dependentFileset && sourcesnapshot.VolType == FILE_DEPENDENTFILESET_VOLUME) {
               						isSamefsetType = true
-            					}
-          				}else if newvolume.FilesetType == dependentFileset{
-            					if sourcesnapshot.VolType == FILE_DEPENDENTFILESET_VOLUME{
-              						isSamefsetType = true
-             					}
           				}
 
           				if !isSamefsetType {

--- a/driver/csiplugin/controllerserver.go
+++ b/driver/csiplugin/controllerserver.go
@@ -1275,14 +1275,10 @@ func (cs *ScaleControllerServer) copyShallowVolumeContent(ctx context.Context, n
         jobDetails := VolCopyJobDetails{VOLCOPY_JOB_NOT_STARTED, volID}
         response := connectors.GenericResponse{}
 
-        primaryFSMountPoint, err := cs.getPrimaryFSMountPoint(ctx)
-        if err != nil {
-                return err
-        }
         sLinkRelPath := strings.Replace(sourcevolume.Path, fsMntPt, "", 1)
         sLinkRelPath = strings.Trim(sLinkRelPath, "!/")
 
-	if primaryFSMountPoint != fsMntPt && fsDetails.Type == filesystemTypeRemote{
+	if fsDetails.Type == filesystemTypeRemote{
 		remotefsDetails,err := conn.GetFilesystemDetails(ctx, newvolume.VolBackendFs)
 		if err != nil {
 			if strings.Contains(err.Error(), "Invalid value in filesystemName") {

--- a/driver/csiplugin/controllerserver.go
+++ b/driver/csiplugin/controllerserver.go
@@ -749,9 +749,9 @@ func (cs *ScaleControllerServer) CreateVolume(ctx context.Context, req *csi.Crea
                 }
 		
 		if isNewVolumeType{
-                        shallowCopyTargetPath = fmt.Sprintf("%s/%s/.snapshots/%s/%s",scaleVol.PrimaryFSMount,snapIdMembers.ConsistencyGroup, snapIdMembers.SnapName,snapIdMembers.FsetName)
+                        shallowCopyTargetPath = fmt.Sprintf("%s/%s/.snapshots/%s/%s",volFsInfo.Mount.MountPoint,snapIdMembers.ConsistencyGroup, snapIdMembers.SnapName,snapIdMembers.FsetName)
                 }else{
-                        shallowCopyTargetPath = fmt.Sprintf("%s/%s/.snapshots/%s/%s",scaleVol.PrimaryFSMount,snapIdMembers.FsetName,snapIdMembers.SnapName,snapIdMembers.Path)
+                        shallowCopyTargetPath = fmt.Sprintf("%s/%s/.snapshots/%s/%s",volFsInfo.Mount.MountPoint,snapIdMembers.FsetName,snapIdMembers.SnapName,snapIdMembers.Path)
                 }
 
 		volID, volIDErr := cs.generateVolID(ctx, scaleVol, volFsInfo.UUID, isNewVolumeType, isShallowCopyVolume, shallowCopyTargetPath)


### PR DESCRIPTION
When multiple snapshots are taken within snap window for version2 volume then snapshot deletion was getting stuck. This fix resolves this snapshot deletion stuck issue introduced with shallow copy feature.


Please check the type of change your PR introduces:
- [ x] Bugfix
- [ ] Feature Enhancement
- [ ] Test Automation 
- [ ] Code Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Community Operator listing 
- [ ] Other (please describe): 


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying -->
- Snapshot deletion is getting stuck when multiple snapshots are taken within snap window for version2 volume

## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->
- Snapshot deletion works fine if multiple snapshots are taken within snap window for version2 volume

## How risky is this change?
- [ ] Small, isolated change
- [ x] Medium, requires regression testing
- [ ] Large, requires functional and regression testing 

