### PR TITLE
Fix for race condition during shallow copy deletion

### DIFF
--- a/driver/csiplugin/controllerserver.go
+++ b/driver/csiplugin/controllerserver.go
@@ -2105,8 +2105,13 @@ func (cs *ScaleControllerServer) DeleteShallowCopyRefPath (ctx context.Context, 
 	if isShallowCopyRefPathDeleted{
 		statInfo, err := conn.StatDirectory(ctx, FilesystemName, ShallowCopyRefPath)
     		if err != nil{
-      			klog.Errorf("[%s] unable to stat directory using FS [%s] at path [%s]. Error [%v]", loggerId, FilesystemName, ShallowCopyRefPath, err)
-      			return err
+			if strings.Contains(err.Error(), "EFSSG0264C") ||
+			   strings.Contains(err.Error(), "does not exist") {
+				klog.Infof("[%s] snapshot path [%s] is already deleted", loggerId, ShallowCopyRefPath)
+			} else {
+      				klog.Errorf("[%s] unable to stat directory using FS [%s] at path [%s]. Error [%v]", loggerId, FilesystemName, ShallowCopyRefPath, err)
+      				return err
+			}
     		}else{
       			nlink,err := parseStatDirInfo(statInfo)
       			if err != nil{

--- a/driver/csiplugin/controllerserver.go
+++ b/driver/csiplugin/controllerserver.go
@@ -2108,6 +2108,7 @@ func (cs *ScaleControllerServer) DeleteShallowCopyRefPath (ctx context.Context, 
 			if strings.Contains(err.Error(), "EFSSG0264C") ||
 			   strings.Contains(err.Error(), "does not exist") {
 				klog.Infof("[%s] snapshot path [%s] is already deleted", loggerId, ShallowCopyRefPath)
+				return nil
 			} else {
       				klog.Errorf("[%s] unable to stat directory using FS [%s] at path [%s]. Error [%v]", loggerId, FilesystemName, ShallowCopyRefPath, err)
       				return err


### PR DESCRIPTION
## Pull request checklist



Please check the type of change your PR introduces:
- [ x] Bugfix
- [ ] Feature Enhancement
- [ ] Test Automation 
- [ ] Code Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Community Operator listing 
- [ ] Other (please describe): 


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying -->
- Race condition happens when shallow copy deletion and snapshot deletion happens in parallel

## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->
- Race condition doesn't happen when shallow copy deletion and snapshot deletion happens in parallel. Also when snapshot directory is deleted manually then also shallow copy deletion would get successful which was not happening previously.

## How risky is this change?
- [ ] Small, isolated change
- [ x] Medium, requires regression testing
- [ ] Large, requires functional and regression testing 

