### PR TITLE
fixed for pv deletion issue with provisioner 501

### DIFF
--- a/driver/csiplugin/connectors/rest_v2.go
+++ b/driver/csiplugin/connectors/rest_v2.go
@@ -1419,6 +1419,10 @@ func (s *SpectrumRestV2) DeleteDirectory(ctx context.Context, filesystemName str
 
 	err = s.WaitForJobCompletion(ctx, deleteDirResponse.Status.Code, deleteDirResponse.Jobs[0].JobID)
 	if err != nil {
+		if strings.Contains(err.Error(), "EFSSG0264C") {
+			klog.V(4).Infof("[%s] Since dirName %v was already deleted, so returning success", loggerId, dirName)
+			return nil
+		}
 		return fmt.Errorf("unable to delete dir %v:%v", dirName, err)
 	}
 


### PR DESCRIPTION
## Pull request checklist

[PV remains in terminating state with provisioner sidecar v5.0.1](https://github.com/IBM/ibm-spectrum-scale-csi/issues/1173)
<!-- Add your one liner release notes here -->
<!-- eg... -->
<!--   - Major functionality adds -->
<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->
<!--   - are you changing our ScaleCluster CR file? -->
```release-notes

```

## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [x] Bugfix
- [ ] Feature Enhancement
- [ ] Test Automation 
- [ ] Code Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Community Operator listing 
- [ ] Other (please describe): 


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying -->
-

## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->
-

## How risky is this change?
- [ ] Small, isolated change
- [ ] Medium, requires regression testing
- [ ] Large, requires functional and regression testing 

