### PR TITLE
unlock UBI minimal version for CSI driver

### DIFF
--- a/driver/build/Dockerfile
+++ b/driver/build/Dockerfile
@@ -20,7 +20,7 @@ ENV REVISION $commit
 RUN CGO_ENABLED=0 GOOS=$TARGETOS GOARCH=$TARGETARCH go build -a -ldflags "-X 'main.gitCommit=${REVISION}' -extldflags '-static'" -o _output/ibm-spectrum-scale-csi ./cmd/ibm-spectrum-scale-csi
 # RUN chmod +x,u+s _output/ibm-spectrum-scale-csi
 
-FROM registry.access.redhat.com/ubi9-minimal:9.4-949.1717074713
+FROM registry.access.redhat.com/ubi9-minimal:9.4
 ARG version=2.13.0
 ARG commit
 ARG build_date


### PR DESCRIPTION
## Pull request checklist

We are currently building CSI driver with **UBI 9.4-949.1717074713** which is 3 months old. We want to be pulling the latest UBI tag available. Eventually when we get to DCUT phase, we'll want to cut a `release-2.13` branch and lock it down with the latest UBI tag available at that point in time. This way we can keep the UBI image in this `dev` branch alone and always pulling the latest UBI levels 😄 

## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [ ] Bugfix
- [ ] Feature Enhancement
- [ ] Test Automation 
- [ ] Code Refactoring (no functional changes, no api changes)
- [X] Build related changes
- [ ] Community Operator listing 
- [ ] Other (please describe): 

## How risky is this change?
- [X] Small, isolated change
- [ ] Medium, requires regression testing
- [ ] Large, requires functional and regression testing 

