### PR TITLE
fixed issue of not to create temp dir for ro mode

### DIFF
--- a/driver/csiplugin/controllerserver.go
+++ b/driver/csiplugin/controllerserver.go
@@ -638,8 +638,8 @@ func (cs *ScaleControllerServer) createFilesetVol(ctx context.Context, scVol *sc
 			return "", status.Error(codes.Internal, err.Error())
 		}
 
-		if scVol.VolumeType == cacheVolume {
-			// Create cacheTempDirName inside the created fileset
+		// Create a cacheTempDir inside the fileset for all the cacheModes except ro and LU modes.
+		if scVol.VolumeType == cacheVolume && !(scVol.CacheMode == afmModeRO || scVol.CacheMode == afmModeLU) {
 			err = cs.createDirectory(ctx, scVol, volName, fmt.Sprintf("%s/%s", targetBasePath, connectors.CacheTempDirName))
 			if err != nil {
 				return "", status.Error(codes.Internal, err.Error())

--- a/driver/csiplugin/controllerserver.go
+++ b/driver/csiplugin/controllerserver.go
@@ -638,8 +638,8 @@ func (cs *ScaleControllerServer) createFilesetVol(ctx context.Context, scVol *sc
 			return "", status.Error(codes.Internal, err.Error())
 		}
 
-		// Create a cacheTempDir inside the fileset for all the cacheModes except ro and LU modes.
-		if scVol.VolumeType == cacheVolume && !(scVol.CacheMode == afmModeRO || scVol.CacheMode == afmModeLU) {
+		// Create a cacheTempDir inside the fileset for all the cacheModes except ro mode.
+		if scVol.VolumeType == cacheVolume && scVol.CacheMode != afmModeRO {
 			err = cs.createDirectory(ctx, scVol, volName, fmt.Sprintf("%s/%s", targetBasePath, connectors.CacheTempDirName))
 			if err != nil {
 				return "", status.Error(codes.Internal, err.Error())


### PR DESCRIPTION
## Pull request checklist

<!-- Add your one liner release notes here -->
<!-- eg... -->
<!--   - Major functionality adds -->
<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->
<!--   - are you changing our ScaleCluster CR file? -->
```release-notes

```

To handle issue [readonly cache volume PVC doesn't get created](https://github.com/IBM/ibm-spectrum-scale-csi/issues/1218)


- The tempdir shouldn't be created when modes are ro  cachemode

## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [x] Bugfix
- [ ] Feature Enhancement
- [ ] Test Automation 
- [ ] Code Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Community Operator listing 
- [ ] Other (please describe): 


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying -->
-

## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->
-

## How risky is this change?
- [ ] Small, isolated change
- [x] Medium, requires regression testing
- [ ] Large, requires functional and regression testing 

