### PR TITLE
pvc size shouldn't more than scale allowed size

### DIFF
--- a/driver/csiplugin/controllerserver.go
+++ b/driver/csiplugin/controllerserver.go
@@ -3241,11 +3241,6 @@ func (cs *ScaleControllerServer) ControllerExpandVolume(ctx context.Context, req
 		}, nil
 	}
 
-	if uint64(capacity) > maximumPVSize {
-		klog.Errorf("[%s] ControllerExpandVolume - Volume expansion volID:[%v] with requested volSize:[%v] is not allowed beyond max PV size:[%v]", loggerId, volID, uint64(capacity), maximumPVSize)
-		return &csi.ControllerExpandVolumeResponse{NodeExpansionRequired: false}, nil
-	}
-
 	conn, err := cs.getConnFromClusterID(ctx, volumeIDMembers.ClusterId)
 	if err != nil {
 		return nil, err

--- a/driver/csiplugin/controllerserver.go
+++ b/driver/csiplugin/controllerserver.go
@@ -3228,6 +3228,11 @@ func (cs *ScaleControllerServer) ControllerExpandVolume(ctx context.Context, req
 		return nil, status.Error(codes.Internal, fmt.Sprintf("ControllerExpandVolume - volume expansion is not supported for shallow copy volume %s", volID))
 	}
 
+	if uint64(capacity) > maximumPVSize {
+		klog.Errorf("[%s] ControllerExpandVolume - Volume expansion volID:[%v] with requested volSize:[%v] is not allowed beyond max PV size:[%v]", loggerId, volID, uint64(capacity), maximumPVSize)
+		return &csi.ControllerExpandVolumeResponse{NodeExpansionRequired: false}, status.Error(codes.Internal, fmt.Sprintf("ControllerExpandVolume - Volume expansion volID:[%v] with requested volSize:[%v] is not allowed beyond max PV size:[%v]", volID, uint64(capacity), maximumPVSize))
+	}
+
 	// For lightweight return volume expanded as no action is required
 	if !volumeIDMembers.IsFilesetBased {
 		return &csi.ControllerExpandVolumeResponse{

--- a/driver/csiplugin/controllerserver.go
+++ b/driver/csiplugin/controllerserver.go
@@ -1085,7 +1085,7 @@ func (cs *ScaleControllerServer) setScaleVolume(ctx context.Context, req *csi.Cr
 	scaleVol.VolName = volName
 
 	// larger than allowed pv size not allowed
-	if scaleVol.IsFilesetBased && uint64(volSize) > maximumPVSize {
+	if uint64(volSize) > maximumPVSize {
 		return nil, false, "", fmt.Errorf("failed to create volume, request volume size: [%v] in Bytes is greater than the allowed PV max size: [%v]", uint64(volSize), maximumPVSizeForLog)
 	}
 	if scaleVol.IsFilesetBased && uint64(volSize) < smallestVolSize {

--- a/driver/csiplugin/controllerserver.go
+++ b/driver/csiplugin/controllerserver.go
@@ -50,7 +50,7 @@ const (
 	oneGB                 uint64 = 1024 * 1024 * 1024
 	smallestVolSize       uint64 = oneGB                              // 1GB
 	maximumPVSize         uint64 = 931322 * 1024 * 1024 * 1024 * 1024 // 999999999999999K
-	maximumPVSizeForLog          = "953673728GB"
+	maximumPVSizeForLog          = "953673728GiB"
 	defaultSnapWindow            = "30" // default snapWindow for Consistency Group snapshots is 30 minutes
 	cgPrefixLen                  = 37
 	softQuotaPercent             = 70 // This value is % of the hardQuotaLimit e.g. 70%

--- a/driver/csiplugin/controllerserver.go
+++ b/driver/csiplugin/controllerserver.go
@@ -3238,7 +3238,7 @@ func (cs *ScaleControllerServer) ControllerExpandVolume(ctx context.Context, req
 
 	if uint64(capacity) > maximumPVSize {
 		klog.Errorf("[%s] ControllerExpandVolume - Volume expansion volID:[%v] with requested volSize:[%v] is not allowed beyond max PV size:[%v]", loggerId, volID, uint64(capacity), maximumPVSize)
-		return nil, status.Error(codes.Internal, fmt.Sprintf("ControllerExpandVolume - Volume expansion volID:[%v] with  requested volSize:[%v] is not allowed beyond max PV size:[%v]", volID, uint64(capacity), maximumPVSize))
+		return &csi.ControllerExpandVolumeResponse{NodeExpansionRequired: false}, nil
 	}
 
 	conn, err := cs.getConnFromClusterID(ctx, volumeIDMembers.ClusterId)


### PR DESCRIPTION
Signed-off-by: badri-pathak <badri.pathak@ibm.com>

## Pull request checklist

<!-- Add your one liner release notes here -->
<!-- eg... -->
<!--   - Major functionality adds -->
<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->
<!--   - are you changing our ScaleCluster CR file? -->
```release-notes

```

This will address the issue https://github.com/IBM/ibm-spectrum-scale-csi/issues/800

The max size supported by scale is 999999999999999K . The changes won't allow the user to create/resize more this allowed limit.

## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [x] Bugfix
- [ ] Feature Enhancement
- [ ] Test Automation 
- [ ] Code Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Community Operator listing 
- [ ] Other (please describe): 


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying -->
-

## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->
-

## How risky is this change?
- [ ] Small, isolated change
- [ ] Medium, requires regression testing
- [ ] Large, requires functional and regression testing 

