### PR TITLE
change for issue 8161

### DIFF
--- a/driver/csiplugin/controllerserver.go
+++ b/driver/csiplugin/controllerserver.go
@@ -1686,10 +1686,10 @@ func (cs *ScaleControllerServer) checkCGSupport(assembledScaleversion string) er
 }
 
 func (cs *ScaleControllerServer) checkCacheVolumeSupport(assembledScaleversion string) error {
-	/* Verify IBM Storage Scale Version is not below 5.2.2-0 */
-	versionCheck := checkMinScaleVersionValid(assembledScaleversion, "5220")
+	/* Verify IBM Storage Scale Version is not below 5.2.3-0 */
+	versionCheck := checkMinScaleVersionValid(assembledScaleversion, "5230")
 	if !versionCheck {
-		return status.Error(codes.FailedPrecondition, "the minimum required IBM Storage Scale version for cache volume support with CSI is 5.2.2-0")
+		return status.Error(codes.FailedPrecondition, "the minimum required IBM Storage Scale version for cache volume support with CSI is 5.2.3-0")
 	}
 	return nil
 }


### PR DESCRIPTION
AFM cache volume creation is not supported before scale version 5.2.3. Modified version in existing check to avoid cache volume creation in earlier stage itself.



Please check the type of change your PR introduces:
- [x] Bugfix
- [ ] Feature Enhancement
- [ ] Test Automation 
- [ ] Code Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Community Operator listing 
- [ ] Other (please describe): 




## How risky is this change?
- [x] Small, isolated change
- [ ] Medium, requires regression testing
- [ ] Large, requires functional and regression testing 

