### PR TITLE
uid,gid support for afm volume

### DIFF
--- a/driver/csiplugin/connectors/resources.go
+++ b/driver/csiplugin/connectors/resources.go
@@ -649,6 +649,9 @@ type CreateS3CacheFilesetRequest struct {
 	VerifyKeys       bool   `json:"verifyKeys,omitempty"`
 	MakeActive       bool   `json:"makeActive,omitempty"`
 	TempDir          string `json:"tmpDir,omitempty"`
+	Uid		string  `json:"uid,omitempty"`
+	Gid		string  `json:"gid,omitempty"`
+	Permission	string  `json:"permission,omitempty"`
 }
 
 type SetBucketKeysRequest struct {

--- a/driver/csiplugin/connectors/rest_v2.go
+++ b/driver/csiplugin/connectors/rest_v2.go
@@ -768,6 +768,18 @@ func (s *SpectrumRestV2) CreateS3CacheFileset(ctx context.Context, filesystemNam
 	filesetreq.VerifyKeys = true
 	filesetreq.MakeActive = true
 
+	if opts[UserSpecifiedUid] != ""{
+		filesetreq.Uid = opts[UserSpecifiedUid].(string)
+	}
+
+	if opts[UserSpecifiedGid] != ""{
+		filesetreq.Gid = opts[UserSpecifiedGid].(string)
+	}
+
+	if opts[UserSpecifiedPermissions] != ""{
+		filesetreq.Permission = opts[UserSpecifiedPermissions].(string)
+	}
+
 	klog.V(4).Infof("[%s] rest_v2 CreateS3CacheFileset. filesetreq: %v", loggerID, filesetreq)
 
 	createFilesetURL := fmt.Sprintf("scalemgmt/v2/filesystems/%s/filesets/cos", filesystemName)

--- a/driver/csiplugin/controllerserver.go
+++ b/driver/csiplugin/controllerserver.go
@@ -514,6 +514,17 @@ func (cs *ScaleControllerServer) createFilesetVol(ctx context.Context, scVol *sc
 				return "", status.Error(codes.Internal, fmt.Sprintf("failed to set bucket keys for volume %s, error: %v", volName, keyerr))
 			}
 
+			// Set uid,gid for cache fileset if specified in storageclass
+			if scVol.VolUid != "" {
+				opt[connectors.UserSpecifiedUid] = scVol.VolUid
+			}
+			if scVol.VolGid != "" {
+				opt[connectors.UserSpecifiedGid] = scVol.VolGid
+			}
+			if scVol.Shared{
+				opt[connectors.UserSpecifiedPermissions] = AFMCacheSharedPermission
+			}
+
 			// Create a cache fileset
 			if cacheFsetErr := scVol.Connector.CreateS3CacheFileset(ctx, scVol.VolBackendFs, volName, scVol.CacheMode, opt, bucketInfo, exportMapName, parsedURL); cacheFsetErr != nil {
 				klog.Errorf("[%s] volume:[%v] - failed to create cache fileset [%v] in filesystem [%v]. Error: %v", loggerId, volName, volName, scVol.VolBackendFs, cacheFsetErr.Error())

--- a/driver/csiplugin/gpfs_util.go
+++ b/driver/csiplugin/gpfs_util.go
@@ -39,6 +39,7 @@ const (
 	sharedPermissions    = "777"
 	defaultVolNamePrefix = "pvc"
 	VolNamePrefixEnvKey  = "VOLUME_NAME_PREFIX"
+	AFMCacheSharedPermission = "0777"
 )
 
 // AFM caching constants


### PR DESCRIPTION
uid,gid,shared support for afm cache volume. Permission 777 is set when shared parameter is set as true in storage class.


Please check the type of change your PR introduces:
- [ ] Bugfix
- [x] Feature Enhancement
- [ ] Test Automation 
- [ ] Code Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Community Operator listing 
- [ ] Other (please describe): 


## How risky is this change?
- [x] Small, isolated change
- [ ] Medium, requires regression testing
- [ ] Large, requires functional and regression testing 

