### PR TITLE
updated fileset comment with namespace and pvcname

### DIFF
--- a/driver/csiplugin/connectors/connectors.go
+++ b/driver/csiplugin/connectors/connectors.go
@@ -55,7 +55,7 @@ type SpectrumScaleConnector interface {
 	UnlinkFileset(ctx context.Context, filesystemName string, filesetName string, force bool) error
 	//ListFilesets(filesystemName string) ([]resources.Volume, error)
 	ListFileset(ctx context.Context, filesystemName string, filesetName string) (Fileset_v2, error)
-	ListCSIIndependentFilesets(ctx context.Context, filesystemName string) ([]Fileset_v2, error)
+	ListCSIIndependentFilesets(ctx context.Context, filesystemName string, pvcName string, namespace string) ([]Fileset_v2, error)
 	GetFilesetsInodeSpace(ctx context.Context, filesystemName string, inodeSpace int) ([]Fileset_v2, error)
 	IsFilesetLinked(ctx context.Context, filesystemName string, filesetName string) (bool, error)
 	FilesetRefreshTask(ctx context.Context) error
@@ -126,17 +126,19 @@ const (
 	UserSpecifiedShared           string = "shared"
 	AFMModeSecondary              string = "secondary"
 	FilesetComment                string = "Fileset created by IBM Container Storage Interface driver"
+	FilesetCommentKey             string = "FilesetComment"
+	FilesetCommentValue           string = FilesetComment + " for PVC [ %s ] in the namespace [ %s ]"
 	UserSpecifiedCacheMode        string = "cacheMode"
 	UserSpecifiedVolumeType       string = "volumeType"
 	UserSpecifiedVolNamePrefix    string = "volNamePrefix"
 
 	// AFM tuning parameters to modify cache fileset
 	AfmReadSparseThreshold     string = "afmReadSparseThreshold"
-	AfmNumFlushThreads         string = "afmNumFlushThreads"        
-	AfmPrefetchThreshold       string = "afmPrefetchThreshold"       
-	AfmObjectFastReaddir       string = "afmObjectFastReaddir"       
+	AfmNumFlushThreads         string = "afmNumFlushThreads"
+	AfmPrefetchThreshold       string = "afmPrefetchThreshold"
+	AfmObjectFastReaddir       string = "afmObjectFastReaddir"
 	AfmFileOpenRefreshInterval string = "afmFileOpenRefreshInterval"
-	AfmNumReadThreads          string = "afmNumReadThreads"          
+	AfmNumReadThreads          string = "afmNumReadThreads"
 
 	// default value for AFM tuning parameters
 	AfmNumFlushThreadsDefault         = 4

--- a/driver/csiplugin/connectors/rest_v2.go
+++ b/driver/csiplugin/connectors/rest_v2.go
@@ -848,8 +848,8 @@ func (s *SpectrumRestV2) CreateS3CacheFileset(ctx context.Context, filesystemNam
 	if opts[UserSpecifiedPermissions] != nil {
 		filesetreq.Permission = opts[UserSpecifiedPermissions].(string)
 	}
-	if opts[UserSpecifiedVolDirPath] != nil{
-		filesetreq.Dir = fmt.Sprintf("%s/%s",opts[UserSpecifiedVolDirPath],filesetName)
+	if opts[UserSpecifiedVolDirPath] != nil {
+		filesetreq.Dir = fmt.Sprintf("%s/%s", opts[UserSpecifiedVolDirPath], filesetName)
 	}
 
 	klog.V(4).Infof("[%s] rest_v2 CreateS3CacheFileset. filesetreq: %v", loggerID, filesetreq)
@@ -1102,11 +1102,10 @@ func (s *SpectrumRestV2) CheckFilesetWithAFMTarget(ctx context.Context, filesyst
 func (s *SpectrumRestV2) ListCSIIndependentFilesets(ctx context.Context, filesystemName string, pvcName string, namespace string) ([]Fileset_v2, error) {
 	loggerID := utils.GetLoggerId(ctx)
 	klog.V(4).Infof("[%s] rest_v2 ListCSIIndependentFilesets. filesystem: %s . pvcName %s, namespace %s", loggerID, filesystemName, pvcName, namespace)
-	filesetComment := fmt.Sprintf(FilesetCommentValue, pvcName, namespace)
 
-	encodedFilesetComment := strings.ReplaceAll(filesetComment, " ", "%20")
+	encodedFilesetComment := strings.ReplaceAll(FilesetComment, " ", "%20")
 	url := fmt.Sprintf("scalemgmt/v2/filesystems/%s/filesets", filesystemName)
-	filter := fmt.Sprintf("filter=config.isInodeSpaceOwner=true,config.comment=%s", encodedFilesetComment)
+	filter := fmt.Sprintf("filter=config.isInodeSpaceOwner=true,config.comment='''%s.*'''", encodedFilesetComment)
 	getFilesetURL := url + "?" + filter
 	klog.V(6).Infof("[%s] getFilesetURL [%v] ", loggerID, getFilesetURL)
 	getFilesetResponse := GetFilesetResponse_v2{}

--- a/driver/csiplugin/connectors/rest_v2.go
+++ b/driver/csiplugin/connectors/rest_v2.go
@@ -528,48 +528,48 @@ func (s *SpectrumRestV2) UpdateFileset(ctx context.Context, filesystemName strin
 		filesetreq.MaxNumInodes = inodeLimit.(string)
 		//filesetreq.AllocInodes = "1024"
 	}
-	comment, commentSpecified := opts[FilesetComment]
+	comment, commentSpecified := opts[FilesetCommentKey]
 	if commentSpecified {
 		filesetreq.Comment = fmt.Sprintf("%v", comment)
 	}
 
 	if volType == cachevolume && setAfmAttributes {
-        	afmReadSparseThresholdValue, afmReadSparseThresholdFound := opts[AfmReadSparseThreshold]
-                if afmReadSparseThresholdFound {
-                	filesetreq.AfmReadSparseThreshold = afmReadSparseThresholdValue.(string)
-                } else {
-                        filesetreq.AfmReadSparseThreshold = AfmReadSparseThresholdDefault
-                }
+		afmReadSparseThresholdValue, afmReadSparseThresholdFound := opts[AfmReadSparseThreshold]
+		if afmReadSparseThresholdFound {
+			filesetreq.AfmReadSparseThreshold = afmReadSparseThresholdValue.(string)
+		} else {
+			filesetreq.AfmReadSparseThreshold = AfmReadSparseThresholdDefault
+		}
 
-                afmNumFlushThreadsValue, afmNumFlushThreadsFound := opts[AfmNumFlushThreads]
-                if afmNumFlushThreadsFound {
-                        filesetreq.AfmNumFlushThreads = afmNumFlushThreadsValue.(int)
-                } else {
-                        filesetreq.AfmNumFlushThreads = AfmNumFlushThreadsDefault
-                }
+		afmNumFlushThreadsValue, afmNumFlushThreadsFound := opts[AfmNumFlushThreads]
+		if afmNumFlushThreadsFound {
+			filesetreq.AfmNumFlushThreads = afmNumFlushThreadsValue.(int)
+		} else {
+			filesetreq.AfmNumFlushThreads = AfmNumFlushThreadsDefault
+		}
 
-                afmPrefetchThresholdValue, afmPrefetchThresholdFound := opts[AfmPrefetchThreshold]
-                if afmPrefetchThresholdFound {
-                        filesetreq.AfmPrefetchThreshold = afmPrefetchThresholdValue.(int)
-                } else {
-                        filesetreq.AfmPrefetchThreshold = AfmPrefetchThresholdDefault
-                }
+		afmPrefetchThresholdValue, afmPrefetchThresholdFound := opts[AfmPrefetchThreshold]
+		if afmPrefetchThresholdFound {
+			filesetreq.AfmPrefetchThreshold = afmPrefetchThresholdValue.(int)
+		} else {
+			filesetreq.AfmPrefetchThreshold = AfmPrefetchThresholdDefault
+		}
 
-                afmObjectFastReaddirValue, afmObjectFastReaddirFound := opts[AfmObjectFastReaddir]
-                if afmObjectFastReaddirFound {
-                        filesetreq.AfmObjectFastReaddir = afmObjectFastReaddirValue.(string)
-                } else {
-                        filesetreq.AfmObjectFastReaddir = AfmObjectFastReaddirDefault
-                }
+		afmObjectFastReaddirValue, afmObjectFastReaddirFound := opts[AfmObjectFastReaddir]
+		if afmObjectFastReaddirFound {
+			filesetreq.AfmObjectFastReaddir = afmObjectFastReaddirValue.(string)
+		} else {
+			filesetreq.AfmObjectFastReaddir = AfmObjectFastReaddirDefault
+		}
 
-                afmFileOpenRefreshIntervalValue, afmFileOpenRefreshIntervalFound := opts[AfmFileOpenRefreshInterval]
-                if afmFileOpenRefreshIntervalFound {
+		afmFileOpenRefreshIntervalValue, afmFileOpenRefreshIntervalFound := opts[AfmFileOpenRefreshInterval]
+		if afmFileOpenRefreshIntervalFound {
 			filesetreq.AfmFileOpenRefreshInterval = afmFileOpenRefreshIntervalValue.(string)
-                } else {
-                        filesetreq.AfmFileOpenRefreshInterval = AfmFileOpenRefreshIntervalDefault
-                }
+		} else {
+			filesetreq.AfmFileOpenRefreshInterval = AfmFileOpenRefreshIntervalDefault
+		}
 
-       }
+	}
 
 	updateFilesetURL := fmt.Sprintf("scalemgmt/v2/filesystems/%s/filesets/%s", filesystemName, filesetName)
 	updateFilesetResponse := GenericResponse{}
@@ -619,7 +619,13 @@ func (s *SpectrumRestV2) CreateFileset(ctx context.Context, filesystemName strin
 
 	filesetreq := CreateFilesetRequest{}
 	filesetreq.FilesetName = filesetName
-	filesetreq.Comment = FilesetComment
+
+	comment, commentSpecified := opts[FilesetCommentKey]
+	if commentSpecified {
+		filesetreq.Comment = fmt.Sprintf("%v", comment)
+	} else {
+		filesetreq.Comment = FilesetComment
+	}
 
 	filesetType, filesetTypeSpecified := opts[UserSpecifiedFilesetType]
 	inodeLimit, inodeLimitSpecified := opts[UserSpecifiedInodeLimit]
@@ -807,15 +813,15 @@ func (s *SpectrumRestV2) CreateS3CacheFileset(ctx context.Context, filesystemNam
 	filesetreq.VerifyKeys = true
 	filesetreq.MakeActive = true
 
-	if opts[UserSpecifiedUid] != nil{
+	if opts[UserSpecifiedUid] != nil {
 		filesetreq.Uid = opts[UserSpecifiedUid].(string)
 	}
 
-	if opts[UserSpecifiedGid] != nil{
+	if opts[UserSpecifiedGid] != nil {
 		filesetreq.Gid = opts[UserSpecifiedGid].(string)
 	}
 
-	if opts[UserSpecifiedPermissions] != nil{
+	if opts[UserSpecifiedPermissions] != nil {
 		filesetreq.Permission = opts[UserSpecifiedPermissions].(string)
 	}
 
@@ -1066,11 +1072,12 @@ func (s *SpectrumRestV2) CheckFilesetWithAFMTarget(ctx context.Context, filesyst
 	return "", nil
 }
 
-func (s *SpectrumRestV2) ListCSIIndependentFilesets(ctx context.Context, filesystemName string) ([]Fileset_v2, error) {
+func (s *SpectrumRestV2) ListCSIIndependentFilesets(ctx context.Context, filesystemName string, pvcName string, namespace string) ([]Fileset_v2, error) {
 	loggerID := utils.GetLoggerId(ctx)
-	klog.V(4).Infof("[%s] rest_v2 ListCSIIndependentFilesets. filesystem: %s", loggerID, filesystemName)
+	klog.V(4).Infof("[%s] rest_v2 ListCSIIndependentFilesets. filesystem: %s . pvcName %s, namespace %s", loggerID, filesystemName, pvcName, namespace)
+	filesetComment := fmt.Sprintf(FilesetCommentValue, pvcName, namespace)
 
-	encodedFilesetComment := strings.ReplaceAll(FilesetComment, " ", "%20")
+	encodedFilesetComment := strings.ReplaceAll(filesetComment, " ", "%20")
 	url := fmt.Sprintf("scalemgmt/v2/filesystems/%s/filesets", filesystemName)
 	filter := fmt.Sprintf("filter=config.isInodeSpaceOwner=true,config.comment=%s", encodedFilesetComment)
 	getFilesetURL := url + "?" + filter

--- a/driver/csiplugin/controllerserver.go
+++ b/driver/csiplugin/controllerserver.go
@@ -297,6 +297,7 @@ func (cs *ScaleControllerServer) validateCG(ctx context.Context, scVol *scaleVol
 		return "", err
 	}
 
+	klog.V(4).Infof("[%s] Validate CG response fsetlist [%v]", loggerId, fsetlist)
 	var flist []string
 	pvcns := scVol.ConsistencyGroup[cgPrefixLen:]
 
@@ -577,7 +578,7 @@ func (cs *ScaleControllerServer) createFilesetVol(ctx context.Context, scVol *sc
 
 	} else {
 		// fileset is present. Confirm if creator is IBM Storage Scale CSI driver and fileset type is correct.
-		if strings.Contains(filesetInfo.Config.Comment, connectors.FilesetComment) {
+		if !strings.Contains(filesetInfo.Config.Comment, connectors.FilesetComment) {
 			if scVol.VolumeType == cacheVolume {
 				if err := handleUpdateComment(ctx, scVol, setAfmAttributes, afmTuningParams); err != nil {
 					return "", err

--- a/driver/csiplugin/controllerserver.go
+++ b/driver/csiplugin/controllerserver.go
@@ -292,7 +292,7 @@ func (cs *ScaleControllerServer) validateCG(ctx context.Context, scVol *scaleVol
 	loggerId := utils.GetLoggerId(ctx)
 	klog.V(4).Infof("[%s] Validate CG for volume [%v]", loggerId, scVol)
 
-	fsetlist, err := scVol.Connector.ListCSIIndependentFilesets(ctx, scVol.VolBackendFs)
+	fsetlist, err := scVol.Connector.ListCSIIndependentFilesets(ctx, scVol.VolBackendFs, scVol.PVCName, scVol.Namespace)
 	if err != nil {
 		return "", err
 	}
@@ -543,6 +543,7 @@ func (cs *ScaleControllerServer) createFilesetVol(ctx context.Context, scVol *sc
 			}
 		} else {
 			// This means fileset is not present, create it
+			opt[connectors.FilesetCommentKey] = fmt.Sprintf(connectors.FilesetCommentValue, scVol.PVCName, scVol.Namespace)
 			fseterr = scVol.Connector.CreateFileset(ctx, scVol.VolBackendFs, volName, opt)
 		}
 
@@ -561,7 +562,7 @@ func (cs *ScaleControllerServer) createFilesetVol(ctx context.Context, scVol *sc
 
 	} else {
 		// fileset is present. Confirm if creator is IBM Storage Scale CSI driver and fileset type is correct.
-		if filesetInfo.Config.Comment != connectors.FilesetComment {
+		if strings.Contains(filesetInfo.Config.Comment, connectors.FilesetComment) {
 			if scVol.VolumeType == cacheVolume {
 				if err := handleUpdateComment(ctx, scVol, setAfmAttributes, afmTuningParams); err != nil {
 					return "", err
@@ -687,7 +688,7 @@ func updateComment(ctx context.Context, scVol *scaleVolume, setAfmAttributes boo
 	if setAfmAttributes {
 		updateOpts = afmTuningParams
 	}
-	updateOpts[connectors.FilesetComment] = connectors.FilesetComment
+	updateOpts[connectors.FilesetCommentKey] = fmt.Sprintf(connectors.FilesetCommentValue, scVol.PVCName, scVol.Namespace)
 	return scVol.Connector.UpdateFileset(ctx, scVol.VolBackendFs, scVol.StorageClassType, scVol.VolName, updateOpts, setAfmAttributes)
 }
 
@@ -2164,7 +2165,7 @@ func (cs *ScaleControllerServer) DeleteCGFileset(ctx context.Context, Filesystem
 	}
 
 	// Check if fileset was created by IBM Storage Scale CSI Driver
-	if filesetDetails.Config.Comment == connectors.FilesetComment {
+	if strings.Contains(filesetDetails.Config.Comment, connectors.FilesetComment) {
 		// before deletion of fileset get its inodeSpace.
 		// this will help to identify if there are one or more dependent filesets for same inodeSpace
 		// which is shared with independent fileset
@@ -2368,7 +2369,7 @@ func (cs *ScaleControllerServer) DeleteVolume(newctx context.Context, req *csi.D
 		if err != nil {
 			klog.Errorf("[%s]  unable to list fileset [%v] in filesystem [%v]. Error: %v", loggerId, FilesetName, FilesystemName, err)
 			return nil, status.Error(codes.Internal, fmt.Sprintf("unable to list fileset [%v] in filesystem [%v]. Error: %v", FilesetName, FilesystemName, err))
-		} else if !reflect.ValueOf(filesetInfo).IsZero() && filesetInfo.Config.Comment != connectors.FilesetComment {
+		} else if !reflect.ValueOf(filesetInfo).IsZero() && !strings.Contains(filesetInfo.Config.Comment, connectors.FilesetComment) {
 			klog.Infof("Fileset [%v] is not created by IBM Container Storage Interface driver, skipping the fileset delete", FilesetName)
 			return &csi.DeleteVolumeResponse{}, nil
 		}
@@ -2981,7 +2982,7 @@ func (cs *ScaleControllerServer) CreateSnapshot(newctx context.Context, req *csi
 		// storageclass_type;volumeType;clusterId;FSUUID;consistency_group;filesetName;snapshotName;metaSnapshotName
 		snapID = fmt.Sprintf("%s;%s;%s;%s;%s;%s;%s;%s", volumeIDMembers.StorageClassType, volumeIDMembers.VolType, volumeIDMembers.ClusterId, volumeIDMembers.FsUUID, filesetName, filesetResp.FilesetName, snapName, req.GetName())
 	} else {
-		if filesetResp.Config.Comment == connectors.FilesetComment &&
+		if strings.Contains(filesetResp.Config.Comment, connectors.FilesetComment) &&
 			(cs.Driver.primary.PrimaryFset != filesetName || cs.Driver.primary.PrimaryFs != filesystemName) {
 			// Dynamically created PVC, here path is the xxx-data directory within the fileset where all volume data resides
 			// storageclass_type;volumeType;clusterId;FSUUID;consistency_group;filesetName;snapshotName;metaSnapshotName;path

--- a/driver/csiplugin/gpfs_util.go
+++ b/driver/csiplugin/gpfs_util.go
@@ -32,13 +32,13 @@ import (
 )
 
 const (
-	dependentFileset     = "dependent"
-	independentFileset   = "independent"
-	scversion1           = "1"
-	scversion2           = "2"
-	sharedPermissions    = "777"
-	defaultVolNamePrefix = "pvc"
-	VolNamePrefixEnvKey  = "VOLUME_NAME_PREFIX"
+	dependentFileset         = "dependent"
+	independentFileset       = "independent"
+	scversion1               = "1"
+	scversion2               = "2"
+	sharedPermissions        = "777"
+	defaultVolNamePrefix     = "pvc"
+	VolNamePrefixEnvKey      = "VOLUME_NAME_PREFIX"
 	AFMCacheSharedPermission = "0777"
 )
 
@@ -99,6 +99,8 @@ type scaleVolume struct {
 	VolumeType         string                            `json:"volumeType"`
 	CacheMode          string                            `json:"cacheMode"`
 	VolNamePrefix      string                            `json:"volNamePrefix"`
+	PVCName            string                            `json:"pvcName"`
+	Namespace          string                            `json:"namespace"`
 }
 
 type scaleVolId struct {
@@ -182,10 +184,18 @@ func getScaleVolumeOptions(ctx context.Context, volOptions map[string]string) (*
 	scaleVol.StorageClassType = ""
 	scaleVol.Compression = ""
 	scaleVol.Tier = ""
+	scaleVol.PVCName = ""
 
 	if isSCTypeSpecified && storageClassType == "" {
 		isSCTypeSpecified = false
 	}
+	if volOptions["csi.storage.k8s.io/pvc/name"] != "" {
+		scaleVol.PVCName = volOptions["csi.storage.k8s.io/pvc/name"]
+	}
+	if volOptions["csi.storage.k8s.io/pvc/namespace"] != "" {
+		scaleVol.Namespace = volOptions["csi.storage.k8s.io/pvc/namespace"]
+	}
+
 	isSCAdvanced := false
 	if isSCTypeSpecified {
 		if storageClassType != scversion1 && storageClassType != scversion2 {


### PR DESCRIPTION
The feature request for this PR [Fileset created by csi needs to have namespace and pvc-name with comment](https://github.ibm.com/IBMSpectrumScale/scale-core/issues/8336)

## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [ ] Bugfix
- [x] Feature Enhancement
- [ ] Test Automation 
- [ ] Code Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Community Operator listing 
- [ ] Other (please describe): 


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying -->
- The current feature add a standard comment for the filesets created by csi as 

> "Fileset created by IBM Container Storage Interface driver"

## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->
- After this new changes, the fileset comment will have deatils of namepsace and pvcName in the standard comment for the filesets. 
e.g.
> "Fileset created by IBM Container Storage Interface driver for PVC [ scale-fset-pvc ] in the namespace [ ibm-spectrum-scale-csi-driver ]"

## How risky is this change?
- [ ] Small, isolated change
- [x] Medium, requires regression testing
- [ ] Large, requires functional and regression testing 

