### PR TITLE
Fix for primary fileset creation

### DIFF
--- a/operator/controllers/csiscaleoperator_controller.go
+++ b/operator/controllers/csiscaleoperator_controller.go
@@ -2209,6 +2209,13 @@ func (r *CSIScaleOperatorReconciler) createPrimaryFileset(instance *csiscaleoper
 	// create primary fileset if not already created
 	fsetResponse, err := sc.ListFileset(context.TODO(), fsNameOnOwningCluster, filesetName)
 	if err != nil {
+		message := fmt.Sprintf("Failed to list fileset in filesystem %s", fsNameOnOwningCluster)
+		logger.Error(err, message)
+		SetStatusAndRaiseEvent(instance, r.Recorder, corev1.EventTypeWarning, string(config.StatusConditionSuccess),
+                                        metav1.ConditionFalse, string(csiv1.GetFilesetFailed), message,
+                )
+                return "", err
+	} else if reflect.ValueOf(fsetResponse).IsZero(){
 		logger.Info("Primary fileset not found, so creating it", "fileseName", filesetName)
 		opts := make(map[string]interface{})
 		if inodeLimit != "" {


### PR DESCRIPTION
Primary fileset creation fails after CNSA reinstall. GUI sends err as nil and fset response with empty fields. In driver code it is handled as fset repsonse is empty or filled with value 0 then fileset creation is triggered. Same fix has been added in operator code as well.

Addresses Issue: https://github.ibm.com/IBMSpectrumScale/scale-core/issues/8388

## Pull request type


Please check the type of change your PR introduces:
- [x] Bugfix
- [ ] Feature Enhancement
- [ ] Test Automation 
- [ ] Code Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Community Operator listing 
- [ ] Other (please describe): 


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying -->
- Primary fileset creation is not successful after CNSA reinstall

## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->
- Primary fileset creation is successful after CNSA reinstall and other CSI pods are coming up.

## How risky is this change?
- [ ] Small, isolated change
- [x] Medium, requires regression testing
- [ ] Large, requires functional and regression testing 

