### PR TITLE
Fix for primary fset link

### DIFF
--- a/operator/controllers/csiscaleoperator_controller.go
+++ b/operator/controllers/csiscaleoperator_controller.go
@@ -2212,10 +2212,10 @@ func (r *CSIScaleOperatorReconciler) createPrimaryFileset(instance *csiscaleoper
 		message := fmt.Sprintf("Failed to list fileset in filesystem %s", fsNameOnOwningCluster)
 		logger.Error(err, message)
 		SetStatusAndRaiseEvent(instance, r.Recorder, corev1.EventTypeWarning, string(config.StatusConditionSuccess),
-                                        metav1.ConditionFalse, string(csiv1.GetFilesetFailed), message,
-                )
-                return "", err
-	} else if reflect.ValueOf(fsetResponse).IsZero(){
+			metav1.ConditionFalse, string(csiv1.GetFilesetFailed), message,
+		)
+		return "", err
+	} else if reflect.ValueOf(fsetResponse).IsZero() {
 		logger.Info("Primary fileset not found, so creating it", "fileseName", filesetName)
 		opts := make(map[string]interface{})
 		if inodeLimit != "" {
@@ -2232,24 +2232,39 @@ func (r *CSIScaleOperatorReconciler) createPrimaryFileset(instance *csiscaleoper
 			return "", err
 		}
 		logger.Info("Primary fileset is created successfully", "filesetName", filesetName)
-	} else {
-		linkPath := fsetResponse.Config.Path
-		if linkPath == "" || linkPath == "--" {
-			logger.Info("Primary fileset not linked. Linking it", "filesetName", filesetName)
-			err = sc.LinkFileset(context.TODO(), fsNameOnOwningCluster, filesetName, newLinkPath)
-			if err != nil {
-				message := fmt.Sprintf("Failed to link the primary fileset %s to the linkpath %s on the filesystem %s", filesetName, newLinkPath, fsNameOnOwningCluster)
-				logger.Error(err, message)
-				SetStatusAndRaiseEvent(instance, r.Recorder, corev1.EventTypeWarning, string(config.StatusConditionSuccess),
-					metav1.ConditionFalse, string(csiv1.LinkFilesetFailed), message,
-				)
-				return "", err
-			} else {
-				logger.Info("Linked primary fileset", "filesetName", filesetName, "linkpath", newLinkPath)
-			}
-		} else {
-			logger.Info("Primary fileset exists and linked", "filesetName", filesetName, "linkpath", linkPath)
+
+		fsetResponse, err = sc.ListFileset(context.TODO(), fsNameOnOwningCluster, filesetName)
+		if err != nil {
+			// fileset got created but listing failed, return without cleanup
+			message := fmt.Sprintf("unable to list newly created primary fileset [%v] in filesystem [%v]. Error: %v", filesetName, fsNameOnOwningCluster, err)
+			logger.Error(err, message)
+			return "", err
 		}
+	} else {
+		if fsetResponse.Config.Comment != connectors.FilesetComment {
+			message := fmt.Sprintf("Primary fileset [%s] is not created by IBM Storage Scale CSI driver. Cannot use it.", filesetName)
+			err := fmt.Errorf("%s", message)
+			logger.Error(err, "")
+			return "", err
+		}
+	}
+
+	linkPath := fsetResponse.Config.Path
+	if linkPath == "" || linkPath == "--" {
+		logger.Info("Primary fileset not linked. Linking it", "filesetName", filesetName)
+		err = sc.LinkFileset(context.TODO(), fsNameOnOwningCluster, filesetName, newLinkPath)
+		if err != nil {
+			message := fmt.Sprintf("Failed to link the primary fileset %s to the linkpath %s on the filesystem %s", filesetName, newLinkPath, fsNameOnOwningCluster)
+			logger.Error(err, message)
+			SetStatusAndRaiseEvent(instance, r.Recorder, corev1.EventTypeWarning, string(config.StatusConditionSuccess),
+				metav1.ConditionFalse, string(csiv1.LinkFilesetFailed), message,
+			)
+			return "", err
+		} else {
+			logger.Info("Linked primary fileset", "filesetName", filesetName, "linkpath", newLinkPath)
+		}
+	} else {
+		logger.Info("Primary fileset exists and linked", "filesetName", filesetName, "linkpath", linkPath)
 	}
 	return newLinkPath, nil
 }

--- a/operator/controllers/csiscaleoperator_controller.go
+++ b/operator/controllers/csiscaleoperator_controller.go
@@ -2241,7 +2241,7 @@ func (r *CSIScaleOperatorReconciler) createPrimaryFileset(instance *csiscaleoper
 			return "", err
 		}
 	} else {
-		if fsetResponse.Config.Comment != connectors.FilesetComment {
+		if !strings.Contains(fsetResponse.Config.Comment, connectors.FilesetComment) {
 			message := fmt.Sprintf("Primary fileset [%s] is not created by IBM Storage Scale CSI driver. Cannot use it.", filesetName)
 			err := fmt.Errorf("%s", message)
 			logger.Error(err, "")

--- a/operator/go.mod
+++ b/operator/go.mod
@@ -3,7 +3,7 @@ module github.com/IBM/ibm-spectrum-scale-csi/operator
 go 1.22.12
 
 require (
-	github.com/IBM/ibm-spectrum-scale-csi/driver v0.0.0-20250225143912-5fbde7905a8b
+	github.com/IBM/ibm-spectrum-scale-csi/driver v0.0.0-20250325063409-0b2b91be5630
 	github.com/google/uuid v1.6.0
 	github.com/imdario/mergo v0.3.16
 	github.com/onsi/ginkgo v1.16.5

--- a/operator/go.sum
+++ b/operator/go.sum
@@ -1,5 +1,7 @@
 github.com/IBM/ibm-spectrum-scale-csi/driver v0.0.0-20250225143912-5fbde7905a8b h1:o+y/OfU3x8vQH1nIFXUm4bIxd9q/j/+/iS0MeMZy1kM=
 github.com/IBM/ibm-spectrum-scale-csi/driver v0.0.0-20250225143912-5fbde7905a8b/go.mod h1:1QX0sRgNrWA3thlpqj6sK4hy0DjzXYZ7AdjtIbRHe68=
+github.com/IBM/ibm-spectrum-scale-csi/driver v0.0.0-20250325063409-0b2b91be5630 h1:ImK+XB5MtkU07cNio5L70bxjvEOCtGScX2CJVwoC2OM=
+github.com/IBM/ibm-spectrum-scale-csi/driver v0.0.0-20250325063409-0b2b91be5630/go.mod h1:1QX0sRgNrWA3thlpqj6sK4hy0DjzXYZ7AdjtIbRHe68=
 github.com/beorn7/perks v1.0.1 h1:VlbKKnNfV8bJzeqoa4cOKqO6bYr3WgKZxO8Z16+hsOM=
 github.com/beorn7/perks v1.0.1/go.mod h1:G2ZrVWU2WbWT9wwq4/hrbKbnv/1ERSJQ0ibhJ6rlkpw=
 github.com/cespare/xxhash/v2 v2.3.0 h1:UL815xU9SqsFlibzuggzjXhog7bL6oX9BbNZnL2UFvs=

--- a/operator/go.sum
+++ b/operator/go.sum
@@ -1,5 +1,3 @@
-github.com/IBM/ibm-spectrum-scale-csi/driver v0.0.0-20250225143912-5fbde7905a8b h1:o+y/OfU3x8vQH1nIFXUm4bIxd9q/j/+/iS0MeMZy1kM=
-github.com/IBM/ibm-spectrum-scale-csi/driver v0.0.0-20250225143912-5fbde7905a8b/go.mod h1:1QX0sRgNrWA3thlpqj6sK4hy0DjzXYZ7AdjtIbRHe68=
 github.com/IBM/ibm-spectrum-scale-csi/driver v0.0.0-20250325063409-0b2b91be5630 h1:ImK+XB5MtkU07cNio5L70bxjvEOCtGScX2CJVwoC2OM=
 github.com/IBM/ibm-spectrum-scale-csi/driver v0.0.0-20250325063409-0b2b91be5630/go.mod h1:1QX0sRgNrWA3thlpqj6sK4hy0DjzXYZ7AdjtIbRHe68=
 github.com/beorn7/perks v1.0.1 h1:VlbKKnNfV8bJzeqoa4cOKqO6bYr3WgKZxO8Z16+hsOM=


### PR DESCRIPTION
If primary fileset is already created by CSI but not linked then we could see the issue in creating pvc. CSI doesn't the primary fileset. Fix has been provided to link the fileset which is created by CSI.

## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [x] Bugfix
- [ ] Feature Enhancement
- [ ] Test Automation 
- [ ] Code Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Community Operator listing 
- [ ] Other (please describe): 


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying -->
- pvc creation fails due to primary fset unlink status

## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->
- pvc creation succeeds as CSI links the primary fileset which is already created by it and which is in unlink status.

## How risky is this change?
- [ ] Small, isolated change
- [x] Medium, requires regression testing
- [ ] Large, requires functional and regression testing 

