### PR TITLE
fixed issue for comments for cg independent fileset

### DIFF
--- a/driver/csiplugin/connectors/connectors.go
+++ b/driver/csiplugin/connectors/connectors.go
@@ -56,7 +56,7 @@ type SpectrumScaleConnector interface {
 	UnlinkFileset(ctx context.Context, filesystemName string, filesetName string, force bool) error
 	//ListFilesets(filesystemName string) ([]resources.Volume, error)
 	ListFileset(ctx context.Context, filesystemName string, filesetName string) (Fileset_v2, error)
-	ListCSIIndependentFilesets(ctx context.Context, filesystemName string, pvcName string, namespace string) ([]Fileset_v2, error)
+	ListCSIIndependentFilesets(ctx context.Context, filesystemName string) ([]Fileset_v2, error)
 	GetFilesetsInodeSpace(ctx context.Context, filesystemName string, inodeSpace int) ([]Fileset_v2, error)
 	IsFilesetLinked(ctx context.Context, filesystemName string, filesetName string) (bool, error)
 	FilesetRefreshTask(ctx context.Context) error

--- a/driver/csiplugin/connectors/rest_v2.go
+++ b/driver/csiplugin/connectors/rest_v2.go
@@ -1099,9 +1099,9 @@ func (s *SpectrumRestV2) CheckFilesetWithAFMTarget(ctx context.Context, filesyst
 	return "", nil
 }
 
-func (s *SpectrumRestV2) ListCSIIndependentFilesets(ctx context.Context, filesystemName string, pvcName string, namespace string) ([]Fileset_v2, error) {
+func (s *SpectrumRestV2) ListCSIIndependentFilesets(ctx context.Context, filesystemName string) ([]Fileset_v2, error) {
 	loggerID := utils.GetLoggerId(ctx)
-	klog.V(4).Infof("[%s] rest_v2 ListCSIIndependentFilesets. filesystem: %s . pvcName %s, namespace %s", loggerID, filesystemName, pvcName, namespace)
+	klog.V(4).Infof("[%s] rest_v2 ListCSIIndependentFilesets. filesystem: %s .", loggerID, filesystemName)
 
 	encodedFilesetComment := strings.ReplaceAll(FilesetComment, " ", "%20")
 	url := fmt.Sprintf("scalemgmt/v2/filesystems/%s/filesets", filesystemName)

--- a/driver/csiplugin/controllerserver.go
+++ b/driver/csiplugin/controllerserver.go
@@ -292,7 +292,7 @@ func (cs *ScaleControllerServer) validateCG(ctx context.Context, scVol *scaleVol
 	loggerId := utils.GetLoggerId(ctx)
 	klog.V(4).Infof("[%s] Validate CG for volume [%v]", loggerId, scVol)
 
-	fsetlist, err := scVol.Connector.ListCSIIndependentFilesets(ctx, scVol.VolBackendFs, scVol.PVCName, scVol.Namespace)
+	fsetlist, err := scVol.Connector.ListCSIIndependentFilesets(ctx, scVol.VolBackendFs)
 	if err != nil {
 		return "", err
 	}
@@ -559,7 +559,12 @@ func (cs *ScaleControllerServer) createFilesetVol(ctx context.Context, scVol *sc
 			}
 		} else {
 			// This means fileset is not present, create it
-			opt[connectors.FilesetCommentKey] = fmt.Sprintf(connectors.FilesetCommentValue, scVol.PVCName, scVol.Namespace)
+			if isCGIndependentFset {
+				opt[connectors.FilesetCommentKey] = fmt.Sprintf(connectors.FilesetCommentValue, volName, scVol.Namespace)
+			} else {
+				opt[connectors.FilesetCommentKey] = fmt.Sprintf(connectors.FilesetCommentValue, scVol.PVCName, scVol.Namespace)
+			}
+
 			fseterr = scVol.Connector.CreateFileset(ctx, scVol.VolBackendFs, volName, opt)
 		}
 


### PR DESCRIPTION
Signed-off-by: badri-pathak <badri.pathak@ibm.com>


This is to handle the issue where Independent fileset comment was wrong, as it took fileset name of the very first cg based fileset. 


## Pull request checklist

<!-- Add your one liner release notes here -->
<!-- eg... -->
<!--   - Major functionality adds -->
<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->
<!--   - are you changing our ScaleCluster CR file? -->
```release-notes

```

## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [x] Bugfix
- [ ] Feature Enhancement
- [ ] Test Automation 
- [ ] Code Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Community Operator listing 
- [ ] Other (please describe): 


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying -->
- The independent fset created during the very first version-2 fset creation was being taken as fsetName during the comment of independentFset also.

## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->
- Every fileset will have their own fileset name in the comment.
<img width="1716" alt="image" src="https://github.com/user-attachments/assets/0bb78e5b-0655-4dd0-bde1-4be64baba03a" />


## How risky is this change?
- [ ] Small, isolated change
- [x] Medium, requires regression testing
- [ ] Large, requires functional and regression testing 

