### PR TITLE
Fix for vac validation and parameter values

### DIFF
--- a/driver/csiplugin/controllerserver.go
+++ b/driver/csiplugin/controllerserver.go
@@ -761,7 +761,7 @@ func validateVACParams(ctx context.Context, mutableParams map[string]string) (ma
 
 		case connectors.AfmReadSparseThreshold:
 			afmReadSparseThresholdValue, _ := strconv.Atoi(vacValue)
-			if afmReadSparseThresholdValue < 0 && afmReadSparseThresholdValue > 4294967296 {
+			if afmReadSparseThresholdValue < 0 || afmReadSparseThresholdValue > 2147483647 {
 				return nil, status.Error(codes.Internal, fmt.Sprintf("invalid value specified for the parameter[%s]", connectors.AfmReadSparseThreshold))
 			} else {
 				afmTuningParams[vacKey] = vacValue
@@ -769,7 +769,7 @@ func validateVACParams(ctx context.Context, mutableParams map[string]string) (ma
 
 		case connectors.AfmNumFlushThreads:
 			afmNumFlushThreadsValue, _ := strconv.Atoi(vacValue)
-			if afmNumFlushThreadsValue > 1024 {
+			if afmNumFlushThreadsValue < 1 || afmNumFlushThreadsValue > 1024 {
 				return nil, status.Error(codes.Internal, fmt.Sprintf("invalid value specified for the parameter[%s]", connectors.AfmNumFlushThreads))
 			} else {
 				afmTuningParams[vacKey] = afmNumFlushThreadsValue


### PR DESCRIPTION
Fix for vac validation parameters. Addresses below defects.

https://github.ibm.com/IBMSpectrumScale/scale-core/issues/8370
https://github.ibm.com/IBMSpectrumScale/scale-core/issues/8368 



Please check the type of change your PR introduces:
- [x] Bugfix
- [ ] Feature Enhancement
- [ ] Test Automation 
- [ ] Code Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Community Operator listing 
- [ ] Other (please describe): 




## How risky is this change?
- [x] Small, isolated change
- [ ] Medium, requires regression testing
- [ ] Large, requires functional and regression testing 

