### PR TITLE
lock down ubi9-minimal for CSI v2.14.0

### DIFF
--- a/driver/build/Dockerfile
+++ b/driver/build/Dockerfile
@@ -20,7 +20,7 @@ ENV REVISION $commit
 RUN CGO_ENABLED=0 GOOS=$TARGETOS GOARCH=$TARGETARCH go build -a -ldflags "-X 'main.gitCommit=${REVISION}' -extldflags '-static'" -o _output/ibm-spectrum-scale-csi ./cmd/ibm-spectrum-scale-csi
 # RUN chmod +x,u+s _output/ibm-spectrum-scale-csi
 
-FROM registry.access.redhat.com/ubi9-minimal:9.5
+FROM registry.access.redhat.com/ubi9-minimal:9.5-1742914212
 ARG version=2.14.0
 ARG commit
 ARG build_date


### PR DESCRIPTION
## Pull request checklist

Today we have entered mustfix phase for CNSA 5.2.3.0, which means we need to lock down the UBI images we will be using for this release.

Latest `ubi9-minimal` tag available as of today is [9.5-1742914212](https://catalog.redhat.com/software/containers/ubi9/ubi-minimal/615bd9b4075b022acc111bf5?image=67e2cfe11bae27c089d0d26c&gti-tabs=registry-tokens&container-tabs=gti)

Please check the type of change your PR introduces:
- [ ] Bugfix
- [ ] Feature Enhancement
- [ ] Test Automation 
- [ ] Code Refactoring (no functional changes, no api changes)
- [X] Build related changes
- [ ] Community Operator listing 
- [ ] Other (please describe): 

## How risky is this change?
- [X] Small, isolated change
- [ ] Medium, requires regression testing
- [ ] Large, requires functional and regression testing 

