### PR TITLE
[release-2.10] changes for 2.10.8 and UBI update

### DIFF
--- a/cloudpak/stable/ibm-spectrum-scale-csi-operator-bundle/case/ibm-spectrum-scale-csi-operator/case.yaml
+++ b/cloudpak/stable/ibm-spectrum-scale-csi-operator-bundle/case/ibm-spectrum-scale-csi-operator/case.yaml
@@ -1,7 +1,7 @@
 name: ibm-spectrum-scale-csi-operator
 specVersion: 1.0.0
-version: 2.10.7
-appVersion: 2.10.7
+version: 2.10.8
+appVersion: 2.10.8
 description: "Represents a deployment of the IBM CSI Storage Scale driver."
 displayName: "IBM CSI Storage Scale Driver CASE"
 displayDescription: "Represents a deployment of the IBM CSI Storage Scale driver."

--- a/cloudpak/stable/ibm-spectrum-scale-csi-operator-bundle/case/ibm-spectrum-scale-csi-operator/inventory/ibmCSIScaleOperator/resources.yaml
+++ b/cloudpak/stable/ibm-spectrum-scale-csi-operator-bundle/case/ibm-spectrum-scale-csi-operator/inventory/ibmCSIScaleOperator/resources.yaml
@@ -9,7 +9,7 @@ resources:
     - metadata:
         name: ibm_spectrum_scale_csi_driver
       image: cp/spectrum/scale/csi/ibm-spectrum-scale-csi-driver
-      tag: v2.10.7
+      tag: v2.10.8
       digest: sha256:57b4ee494ca48342d1ffaf22a166286202b0406b88316e4dcbe87212df6ca8f0
       mediaType: application/vnd.docker.distribution.manifest.list.v2
       registries:
@@ -20,19 +20,19 @@ resources:
         platform:
           architecture: amd64
           os: linux
-        tag: v2.10.7-amd64
+        tag: v2.10.8-amd64
       - digest: sha256:4bcdd8eccc13908d8b6c9c21b4ffed63177c53b410d7d50a2bd036ff8398ef46
         mediaType: application/vnd.docker.distribution.manifest.v2
         platform:
           architecture: ppc64le
           os: linux
-        tag: v2.10.7-ppc64le
+        tag: v2.10.8-ppc64le
       - digest: sha256:17d0601ca92224d38abc78a6a5771827ef130a49379270e536b3ca26cc9fc89f
         mediaType: application/vnd.docker.distribution.manifest.v2
         platform:
           architecture: s390x
           os: linux
-        tag: v2.10.7-s390x
+        tag: v2.10.8-s390x
 
     - metadata:
         name: csi_snapshotter

--- a/cloudpak/stable/ibm-spectrum-scale-csi-operator-bundle/case/ibm-spectrum-scale-csi-operator/inventory/ibmCSIScaleOperatorSetup/resources.yaml
+++ b/cloudpak/stable/ibm-spectrum-scale-csi-operator-bundle/case/ibm-spectrum-scale-csi-operator/inventory/ibmCSIScaleOperatorSetup/resources.yaml
@@ -9,7 +9,7 @@ resources:
     - metadata:
         name: ibm_spectrum_scale_csi_operator
       image: cpopen/ibm-spectrum-scale-csi-operator
-      tag: v2.10.7
+      tag: v2.10.8
       digest: sha256:e3d2f9fb68b2d7cd1faf84002bb73626da10bed5d81f91945a592d41893e2fda
       mediaType: application/vnd.docker.distribution.manifest.list.v2
       registries:
@@ -20,19 +20,19 @@ resources:
         platform:
           architecture: amd64
           os: linux
-        tag: v2.10.7-amd64
+        tag: v2.10.8-amd64
       - digest: sha256:4d2ddb810b219aa0caf3e581d1c811dea6deefc1c491f09ff3d68b33b7875434
         mediaType: application/vnd.docker.distribution.manifest.v2
         platform:
           architecture: ppc64le
           os: linux
-        tag: v2.10.7-ppc64le
+        tag: v2.10.8-ppc64le
       - digest: sha256:e299883ecd8932ca2b245246f91f7111c35de1dd0469f0daae2c7e71ee9ea7a1
         mediaType: application/vnd.docker.distribution.manifest.v2
         platform:
           architecture: s390x
           os: linux
-        tag: v2.10.7-s390x
+        tag: v2.10.8-s390x
     files:
     - mediaType: application/vnd.case.resource.k8s.v1+yaml
       ref: cluster/deploy/crds/csi_v1_csiscaleoperator.yaml

--- a/driver/build/Dockerfile
+++ b/driver/build/Dockerfile
@@ -20,8 +20,8 @@ ENV REVISION $commit
 RUN CGO_ENABLED=0 GOOS=$TARGETOS GOARCH=$TARGETARCH go build -a -ldflags "-X 'main.gitCommit=${REVISION}' -extldflags '-static'" -o _output/ibm-spectrum-scale-csi ./cmd/ibm-spectrum-scale-csi
 # RUN chmod +x,u+s _output/ibm-spectrum-scale-csi
 
-FROM registry.access.redhat.com/ubi9-minimal:9.5-1739420147
-ARG version=2.10.7
+FROM registry.access.redhat.com/ubi9-minimal:9.5-1742914212
+ARG version=2.10.8
 ARG commit
 ARG build_date
 

--- a/driver/cmd/ibm-spectrum-scale-csi/main.go
+++ b/driver/cmd/ibm-spectrum-scale-csi/main.go
@@ -41,7 +41,7 @@ var (
 	driverName     = flag.String("drivername", "spectrumscale.csi.ibm.com", "name of the driver")
 	nodeID         = flag.String("nodeid", "", "node id")
 	kubeletRootDir = flag.String("kubeletRootDirPath", "/var/lib/kubelet", "kubelet root directory path")
-	vendorVersion  = "2.10.7"
+	vendorVersion  = "2.10.8"
 )
 
 func main() {

--- a/generated/installer/ibm-spectrum-scale-csi-operator-dev.yaml
+++ b/generated/installer/ibm-spectrum-scale-csi-operator-dev.yaml
@@ -10,7 +10,7 @@ metadata:
     product: ibm-spectrum-scale-csi
     release: ibm-spectrum-scale-csi-operator
   annotations:
-    productVersion: 2.10.7
+    productVersion: 2.10.8
 spec:
   replicas: 1
   selector:
@@ -28,7 +28,7 @@ spec:
       annotations:
         productID: ibm-spectrum-scale-csi-operator
         productName: IBM Spectrum Scale CSI Operator
-        productVersion: 2.10.7
+        productVersion: 2.10.8
     spec:
       serviceAccountName: ibm-spectrum-scale-csi-operator
       containers:

--- a/generated/installer/ibm-spectrum-scale-csi-operator-ocp-rhel.yaml
+++ b/generated/installer/ibm-spectrum-scale-csi-operator-ocp-rhel.yaml
@@ -10,7 +10,7 @@ metadata:
     product: ibm-spectrum-scale-csi
     release: ibm-spectrum-scale-csi-operator
   annotations:
-    productVersion: 2.10.7
+    productVersion: 2.10.8
 spec:
   replicas: 1
   selector:
@@ -28,12 +28,12 @@ spec:
       annotations:
         productID: ibm-spectrum-scale-csi-operator
         productName: IBM Spectrum Scale CSI Operator
-        productVersion: 2.10.7
+        productVersion: 2.10.8
     spec:
       serviceAccountName: ibm-spectrum-scale-csi-operator
       containers:
       - name: operator
-        image: quay.io/ibm-spectrum-scale/ibm-spectrum-scale-csi-operator@sha256:fd0bd1a72471d51af65a8eb968ec36706f3761aff678454d42c2bdf1ac04f853
+        image: quay.io/ibm-spectrum-scale-dev/ibm-spectrum-scale-csi-operator@sha256:fd0bd1a72471d51af65a8eb968ec36706f3761aff678454d42c2bdf1ac04f853
         args:
         - --leaderElection=true
         env:
@@ -44,7 +44,7 @@ spec:
             fieldRef:
               fieldPath: metadata.namespace
         - name: CSI_DRIVER_IMAGE
-          value: quay.io/ibm-spectrum-scale/ibm-spectrum-scale-csi-driver@sha256:51af18efe71c1078d7257d199c2566ab7b71367bc302cfdadecbaad8dfec8023
+          value: quay.io/ibm-spectrum-scale-dev/ibm-spectrum-scale-csi-driver@sha256:51af18efe71c1078d7257d199c2566ab7b71367bc302cfdadecbaad8dfec8023
         resources:
           limits:
             cpu: 600m

--- a/generated/installer/ibm-spectrum-scale-csi-operator.yaml
+++ b/generated/installer/ibm-spectrum-scale-csi-operator.yaml
@@ -10,7 +10,7 @@ metadata:
     product: ibm-spectrum-scale-csi
     release: ibm-spectrum-scale-csi-operator
   annotations:
-    productVersion: 2.10.7
+    productVersion: 2.10.8
 spec:
   replicas: 1
   selector:
@@ -28,12 +28,12 @@ spec:
       annotations:
         productID: ibm-spectrum-scale-csi-operator
         productName: IBM Spectrum Scale CSI Operator
-        productVersion: 2.10.7
+        productVersion: 2.10.8
     spec:
       serviceAccountName: ibm-spectrum-scale-csi-operator
       containers:
       - name: operator
-        image: quay.io/ibm-spectrum-scale/ibm-spectrum-scale-csi-operator@sha256:fd0bd1a72471d51af65a8eb968ec36706f3761aff678454d42c2bdf1ac04f853
+        image: quay.io/ibm-spectrum-scale-dev/ibm-spectrum-scale-csi-operator@sha256:fd0bd1a72471d51af65a8eb968ec36706f3761aff678454d42c2bdf1ac04f853
         args:
         - --leaderElection=true
         env:
@@ -44,7 +44,7 @@ spec:
             fieldRef:
               fieldPath: metadata.namespace
         - name: CSI_DRIVER_IMAGE
-          value: quay.io/ibm-spectrum-scale/ibm-spectrum-scale-csi-driver@sha256:51af18efe71c1078d7257d199c2566ab7b71367bc302cfdadecbaad8dfec8023
+          value: quay.io/ibm-spectrum-scale-dev/ibm-spectrum-scale-csi-driver@sha256:51af18efe71c1078d7257d199c2566ab7b71367bc302cfdadecbaad8dfec8023
         resources:
           limits:
             cpu: 600m

--- a/operator/Makefile
+++ b/operator/Makefile
@@ -29,7 +29,7 @@ BUNDLE_METADATA_OPTS ?= $(BUNDLE_CHANNELS) $(BUNDLE_DEFAULT_CHANNEL)
 #
 # For example, running 'make bundle-build bundle-push catalog-build catalog-push' will build and push both
 # ibm.com/ibm-spectrum-scale-csi-bundle:$VERSION and ibm.com/ibm-spectrum-scale-csi-catalog:$VERSION.
-IMAGE_TAG_BASE ?= quay.io/ibm-spectrum-scale-dev/ibm-spectrum-scale-csi-operator
+IMAGE_TAG_BASE ?= quay.io/ibm-spectrum-scale/ibm-spectrum-scale-csi-operator
 
 # BUNDLE_IMG defines the image:tag used for the bundle.
 # You can use it as an arg. (E.g make bundle-build BUNDLE_IMG=<some-registry>/<project-name-bundle>:<tag>)

--- a/operator/Makefile
+++ b/operator/Makefile
@@ -3,7 +3,7 @@
 # To re-generate a bundle for another specific version without changing the standard setup, you can:
 # - use the VERSION as arg of the bundle target (e.g make bundle VERSION=0.0.2)
 # - use environment variables to overwrite this value (e.g export VERSION=0.0.2)
-VERSION ?= 2.10.7
+VERSION ?= 2.10.8
 
 # CHANNELS define the bundle channels used in the bundle.
 # Add a new line here if you would like to change its default config. (E.g CHANNELS = "preview,fast,stable")
@@ -29,7 +29,7 @@ BUNDLE_METADATA_OPTS ?= $(BUNDLE_CHANNELS) $(BUNDLE_DEFAULT_CHANNEL)
 #
 # For example, running 'make bundle-build bundle-push catalog-build catalog-push' will build and push both
 # ibm.com/ibm-spectrum-scale-csi-bundle:$VERSION and ibm.com/ibm-spectrum-scale-csi-catalog:$VERSION.
-IMAGE_TAG_BASE ?= quay.io/ibm-spectrum-scale/ibm-spectrum-scale-csi-operator
+IMAGE_TAG_BASE ?= quay.io/ibm-spectrum-scale-dev/ibm-spectrum-scale-csi-operator
 
 # BUNDLE_IMG defines the image:tag used for the bundle.
 # You can use it as an arg. (E.g make bundle-build BUNDLE_IMG=<some-registry>/<project-name-bundle>:<tag>)

--- a/operator/build/Dockerfile
+++ b/operator/build/Dockerfile
@@ -33,7 +33,7 @@ RUN CGO_ENABLED=0 go build -ldflags="-X 'main.gitCommit=${REVISION}'" -a -o mana
 # Refer to https://github.com/GoogleContainerTools/distroless for more details
 FROM gcr.io/distroless/static:nonroot
 WORKDIR /
-ARG version=2.10.7
+ARG version=2.10.8
 ARG commit
 ARG build_date
 

--- a/operator/config/manager/kustomization.yaml
+++ b/operator/config/manager/kustomization.yaml
@@ -3,4 +3,4 @@ resources:
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 commonAnnotations:
-  productVersion: 2.10.7
+  productVersion: 2.10.8

--- a/operator/config/manager/manager.yaml
+++ b/operator/config/manager/manager.yaml
@@ -20,7 +20,7 @@ spec:
       annotations:
         productID: ibm-spectrum-scale-csi-operator
         productName: IBM Spectrum Scale CSI Operator
-        productVersion: 2.10.7
+        productVersion: 2.10.8
       labels:
         app.kubernetes.io/instance: ibm-spectrum-scale-csi-operator
         app.kubernetes.io/managed-by: ibm-spectrum-scale-csi-operator

--- a/operator/config/manifests/bases/ibm-spectrum-scale-csi-operator.clusterserviceversion.yaml
+++ b/operator/config/manifests/bases/ibm-spectrum-scale-csi-operator.clusterserviceversion.yaml
@@ -6,7 +6,7 @@ metadata:
     capabilities: Basic Install
     categories: Storage
     certified: "false"
-    containerImage: quay.io/ibm-spectrum-scale-dev/ibm-spectrum-scale-csi-operator
+    containerImage: quay.io/ibm-spectrum-scale/ibm-spectrum-scale-csi-operator
     createdAt: Thu May 5 04:42:15 IST 2022
     description: An operator for deploying and managing the IBM Storage Scale CSI
       Driver.

--- a/operator/config/manifests/bases/ibm-spectrum-scale-csi-operator.clusterserviceversion.yaml
+++ b/operator/config/manifests/bases/ibm-spectrum-scale-csi-operator.clusterserviceversion.yaml
@@ -6,7 +6,7 @@ metadata:
     capabilities: Basic Install
     categories: Storage
     certified: "false"
-    containerImage: quay.io/ibm-spectrum-scale/ibm-spectrum-scale-csi-operator
+    containerImage: quay.io/ibm-spectrum-scale-dev/ibm-spectrum-scale-csi-operator
     createdAt: Thu May 5 04:42:15 IST 2022
     description: An operator for deploying and managing the IBM Storage Scale CSI
       Driver.

--- a/operator/config/overlays/default/kustomization.yaml
+++ b/operator/config/overlays/default/kustomization.yaml
@@ -24,9 +24,9 @@ patches:
           spec:
             containers:
               - name: operator
-                image: quay.io/ibm-spectrum-scale/ibm-spectrum-scale-csi-operator@sha256:fd0bd1a72471d51af65a8eb968ec36706f3761aff678454d42c2bdf1ac04f853
+                image: quay.io/ibm-spectrum-scale-dev/dev/ibm-spectrum-scale-csi-operator@sha256:fd0bd1a72471d51af65a8eb968ec36706f3761aff678454d42c2bdf1ac04f853
                 env:
                   - name: METRICS_BIND_ADDRESS
                   - name: WATCH_NAMESPACE
                   - name: CSI_DRIVER_IMAGE
-                    value: quay.io/ibm-spectrum-scale/ibm-spectrum-scale-csi-driver@sha256:51af18efe71c1078d7257d199c2566ab7b71367bc302cfdadecbaad8dfec8023
+                    value: quay.io/ibm-spectrum-scale-dev/dev/ibm-spectrum-scale-csi-driver@sha256:51af18efe71c1078d7257d199c2566ab7b71367bc302cfdadecbaad8dfec8023

--- a/operator/config/overlays/default/kustomization.yaml
+++ b/operator/config/overlays/default/kustomization.yaml
@@ -24,9 +24,9 @@ patches:
           spec:
             containers:
               - name: operator
-                image: quay.io/ibm-spectrum-scale-dev/dev/ibm-spectrum-scale-csi-operator@sha256:fd0bd1a72471d51af65a8eb968ec36706f3761aff678454d42c2bdf1ac04f853
+                image: quay.io/ibm-spectrum-scale-dev/ibm-spectrum-scale-csi-operator@sha256:fd0bd1a72471d51af65a8eb968ec36706f3761aff678454d42c2bdf1ac04f853
                 env:
                   - name: METRICS_BIND_ADDRESS
                   - name: WATCH_NAMESPACE
                   - name: CSI_DRIVER_IMAGE
-                    value: quay.io/ibm-spectrum-scale-dev/dev/ibm-spectrum-scale-csi-driver@sha256:51af18efe71c1078d7257d199c2566ab7b71367bc302cfdadecbaad8dfec8023
+                    value: quay.io/ibm-spectrum-scale-dev/ibm-spectrum-scale-csi-driver@sha256:51af18efe71c1078d7257d199c2566ab7b71367bc302cfdadecbaad8dfec8023

--- a/operator/controllers/config/constants.go
+++ b/operator/controllers/config/constants.go
@@ -88,7 +88,7 @@ const (
 	IBMSystem390 = "s390x"
 
 	//  Default images for containers
-	CSIDriverPluginImage = "quay.io/ibm-spectrum-scale-dev/dev/ibm-spectrum-scale-csi-driver:v2.10.8"
+	CSIDriverPluginImage = "quay.io/ibm-spectrum-scale-dev/ibm-spectrum-scale-csi-driver:v2.10.8"
 	//  registry.k8s.io/sig-storage/csi-node-driver-registrar:v2.8.0
 	CSINodeDriverRegistrarImage = "registry.k8s.io/sig-storage/csi-node-driver-registrar@sha256:f6717ce72a2615c7fbc746b4068f788e78579c54c43b8716e5ce650d97af2df1" // #nosec G101 false positive
 	//  registry.k8s.io/sig-storage/livenessprobe:v2.10.0

--- a/operator/controllers/config/constants.go
+++ b/operator/controllers/config/constants.go
@@ -71,8 +71,8 @@ const (
 	ENVKubeVersion  = "KUBE_VERSION"
 	ENVCGPrefix     = "CSI_CG_PREFIX"
 	ENVSymDirPath   = "SYMLINK_DIR_PATH"
-	DriverVersion   = "2.10.7"
-	OperatorVersion = "2.10.7"
+	DriverVersion   = "2.10.8"
+	OperatorVersion = "2.10.8"
 
 	// Number of replica pods for CSI Sidecar deployment
 	ReplicaCount = int32(2)
@@ -88,7 +88,7 @@ const (
 	IBMSystem390 = "s390x"
 
 	//  Default images for containers
-	CSIDriverPluginImage = "quay.io/ibm-spectrum-scale/ibm-spectrum-scale-csi-driver:v2.10.7"
+	CSIDriverPluginImage = "quay.io/ibm-spectrum-scale-dev/dev/ibm-spectrum-scale-csi-driver:v2.10.8"
 	//  registry.k8s.io/sig-storage/csi-node-driver-registrar:v2.8.0
 	CSINodeDriverRegistrarImage = "registry.k8s.io/sig-storage/csi-node-driver-registrar@sha256:f6717ce72a2615c7fbc746b4068f788e78579c54c43b8716e5ce650d97af2df1" // #nosec G101 false positive
 	//  registry.k8s.io/sig-storage/livenessprobe:v2.10.0

--- a/tools/ansible/common/dev-env.yaml
+++ b/tools/ansible/common/dev-env.yaml
@@ -2,7 +2,7 @@
 - name: Set environment facts
   set_fact:
     OPERATOR_SDK_VER: "v1.15.0"
-    OPERATOR_VERSION: "2.10.7"
+    OPERATOR_VERSION: "2.10.8"
     GO_VERSION:       "go1.20"
 
 # Something is wrong with this bit.

--- a/tools/ansible/common/runtime-env.yaml
+++ b/tools/ansible/common/runtime-env.yaml
@@ -2,7 +2,7 @@
 - name: Set environment facts
   set_fact:
     OPERATOR_SDK_VER: "v1.15.0"
-    OPERATOR_VERSION: "2.10.7"
+    OPERATOR_VERSION: "2.10.8"
 
 #- name: Ensure 'python3' is installed
 #  package:


### PR DESCRIPTION
## Pull request checklist

Getting ready for next CNSA release **5.1.9.10**

- CSI version change to `2.10.8`
- UBI-minimal lockdown to `9.5-1742914212`
- update quay path references to dev (`quay.io/ibm-spectrum-scale-dev`)

## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [ ] Bugfix
- [ ] Feature Enhancement
- [ ] Test Automation 
- [ ] Code Refactoring (no functional changes, no api changes)
- [X] Build related changes
- [ ] Community Operator listing 
- [ ] Other (please describe): 

## How risky is this change?
- [X] Small, isolated change
- [ ] Medium, requires regression testing
- [ ] Large, requires functional and regression testing 

