### PR TITLE
[release-2.14] Update CSI driver to UBI 9.6 to match CNSA 5.2.3.1

### DIFF
--- a/driver/build/Dockerfile
+++ b/driver/build/Dockerfile
@@ -20,7 +20,7 @@ ENV REVISION $commit
 RUN CGO_ENABLED=0 GOOS=$TARGETOS GOARCH=$TARGETARCH go build -a -ldflags "-X 'main.gitCommit=${REVISION}' -extldflags '-static'" -o _output/ibm-spectrum-scale-csi ./cmd/ibm-spectrum-scale-csi
 # RUN chmod +x,u+s _output/ibm-spectrum-scale-csi
 
-FROM registry.access.redhat.com/ubi9-minimal:9.5-1745855087
+FROM registry.access.redhat.com/ubi9-minimal:9.6-1747218906
 ARG version=2.14.1
 ARG commit
 ARG build_date


### PR DESCRIPTION
## Pull request checklist

Updating ubi-minimal image to [9.6-1747218906](https://catalog.redhat.com/software/containers/ubi9/ubi-minimal/615bd9b4075b022acc111bf5?image=6824a0343e24a4f5ddfc6206&gti-tabs=registry-tokens&container-tabs=overview) for CSI driver in order to match the level for CNSA 5.2.3.1
## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [ ] Bugfix
- [ ] Feature Enhancement
- [ ] Test Automation 
- [ ] Code Refactoring (no functional changes, no api changes)
- [X] Build related changes
- [ ] Community Operator listing 
- [ ] Other (please describe): 

## How risky is this change?
- [X] Small, isolated change
- [ ] Medium, requires regression testing
- [ ] Large, requires functional and regression testing 