### PR TITLE
Fix for #7175 

### DIFF
--- a/driver/build/Dockerfile
+++ b/driver/build/Dockerfile
@@ -17,7 +17,6 @@ ARG commit
 
 ENV REVISION $commit
 
-
 RUN CGO_ENABLED=0 GOOS=$TARGETOS GOARCH=$TARGETARCH go build -a -ldflags "-X 'main.gitCommit=${REVISION}' -extldflags '-static'" -o _output/ibm-spectrum-scale-csi ./cmd/ibm-spectrum-scale-csi
 # RUN chmod +x,u+s _output/ibm-spectrum-scale-csi
 

--- a/driver/build/Dockerfile
+++ b/driver/build/Dockerfile
@@ -17,7 +17,7 @@ ARG commit
 
 ENV REVISION $commit
 
-RUN CGO_ENABLED=0 GOOS=$TARGETOS GOARCH=$TARGETARCH go build -a -ldflags "-X 'main.gitCommit=${REVISION}' -extldflags '-static'" -o _output/ibm-spectrum-scale-csi ./cmd/ibm-spectrum-scale-csi
+RUN CGO_ENABLED=0 GOOS="linux" GOARCH="amd64" go build -a -ldflags "-X 'main.gitCommit=${REVISION}' -extldflags '-static'" -o _output/ibm-spectrum-scale-csi ./cmd/ibm-spectrum-scale-csi
 # RUN chmod +x,u+s _output/ibm-spectrum-scale-csi
 
 FROM registry.access.redhat.com/ubi9-minimal:9.5-1742914212

--- a/driver/build/Dockerfile
+++ b/driver/build/Dockerfile
@@ -17,7 +17,8 @@ ARG commit
 
 ENV REVISION $commit
 
-RUN CGO_ENABLED=0 GOOS="linux" GOARCH="amd64" go build -a -ldflags "-X 'main.gitCommit=${REVISION}' -extldflags '-static'" -o _output/ibm-spectrum-scale-csi ./cmd/ibm-spectrum-scale-csi
+
+RUN CGO_ENABLED=0 GOOS=$TARGETOS GOARCH=$TARGETARCH go build -a -ldflags "-X 'main.gitCommit=${REVISION}' -extldflags '-static'" -o _output/ibm-spectrum-scale-csi ./cmd/ibm-spectrum-scale-csi
 # RUN chmod +x,u+s _output/ibm-spectrum-scale-csi
 
 FROM registry.access.redhat.com/ubi9-minimal:9.5-1742914212

--- a/driver/csiplugin/controllerserver.go
+++ b/driver/csiplugin/controllerserver.go
@@ -3009,14 +3009,14 @@ func (cs *ScaleControllerServer) ControllerPublishVolume(ctx context.Context, re
 
 		klog.V(4).Infof("[%s] ControllerPublishVolume : filesystem:[%s] or fsNameRemote:[%s] is mounted on these nodes %v", loggerId, fsName, fsNameRemote, fsRemoteMountDetails.NodesMounted)
 
-		// check whether FS is mounted on all the gateway nodes or not
+		// check whether FS is mounted on any one  gateway nodes or not
 		isFsMountedOnGateway = isSubset(gatewayNodeNames, fsRemoteMountDetails.NodesMounted)
 
-		//sucess when FS is mounted primary , volumeFS and on all the gatewayNodes for "cache" volume
+		//sucess when FS is mounted primary , volumeFS and on any one gatewayNode for "cache" volume
 		if isFsMounted && ispFsMounted && isFsMountedOnGateway {
-			klog.V(4).Infof("[%s] ControllerPublishVolume : filesystem %s is mounted on %s and on gatewayNodes %v so returning success", loggerId, fsName, scalenodeID, gatewayNodeNames)
+			klog.V(4).Infof("[%s] ControllerPublishVolume : filesystem %s is mounted on %s and on gatewayNode %v so returning success", loggerId, fsName, scalenodeID, gatewayNodeNames)
 			if fsName != primaryfsName {
-				klog.V(4).Infof("[%s] ControllerPublishVolume when not a primaryfs : filesystem %s is mounted on %s and on gatewayNodes %v so returning success", loggerId, primaryfsName, scalenodeID, gatewayNodeNames)
+				klog.V(4).Infof("[%s] ControllerPublishVolume when not a primaryfs : filesystem %s is mounted on %s and on gatewayNode %v so returning success", loggerId, primaryfsName, scalenodeID, gatewayNodeNames)
 			}
 			return &csi.ControllerPublishVolumeResponse{}, nil
 		}
@@ -3030,9 +3030,9 @@ func (cs *ScaleControllerServer) ControllerPublishVolume(ctx context.Context, re
 	}
 
 	if skipMountUnmount == "yes" {
-		//error when FS is not mounted on all the gatewayNodes for "cache" volume
+		//error when FS is not mounted on any one  the gatewayNode for "cache" volume
 		if volumeIDMembers.StorageClassType == STORAGECLASS_CACHE && !isFsMountedOnGateway {
-			message := fmt.Sprintf("[%s] ControllerPublishVolume : filesystem %s is not mounted on all the gatewayNodes %v", loggerId, fsName, gatewayNodeNames)
+			message := fmt.Sprintf("[%s] ControllerPublishVolume : filesystem %s is not mounted on any of the gatewayNodes %v", loggerId, fsName, gatewayNodeNames)
 			klog.Errorf(message)
 			return nil, status.Error(codes.Internal, message)
 		}

--- a/driver/csiplugin/gpfs_util.go
+++ b/driver/csiplugin/gpfs_util.go
@@ -709,15 +709,27 @@ func getVolIDMembers(vID string) (scaleVolId, error) {
 	return scaleVolId{}, status.Error(codes.Internal, fmt.Sprintf("Invalid Volume Id : [%v]", vID))
 }
 
+// checking the fs is mounted on any 1 gateway node
 func isSubset(subset []string, superset []string) bool {
-	checkset := make(map[string]bool)
+	// checkset := make(map[string]bool)
+	//
+	//	for _, element := range subset {
+	//		checkset[element] = true
+	//	}
+	//
+	//	for _, value := range superset {
+	//		if checkset[value] {
+	//			delete(checkset, value)
+	//		}
+	//	}
+	//
+	// return len(checkset) == 0 //this implies that set is subset of superset
 	for _, element := range subset {
-		checkset[element] = true
-	}
-	for _, value := range superset {
-		if checkset[value] {
-			delete(checkset, value)
+		for _, value := range superset {
+			if element == value {
+				return true
+			}
 		}
 	}
-	return len(checkset) == 0 //this implies that set is subset of superset
+	return false
 }

--- a/driver/csiplugin/gpfs_util.go
+++ b/driver/csiplugin/gpfs_util.go
@@ -709,21 +709,9 @@ func getVolIDMembers(vID string) (scaleVolId, error) {
 	return scaleVolId{}, status.Error(codes.Internal, fmt.Sprintf("Invalid Volume Id : [%v]", vID))
 }
 
-// checking the fs is mounted on any 1 gateway node
+// checking the fs is mounted on any 1 gateway node or not
 func isSubset(subset []string, superset []string) bool {
-	// checkset := make(map[string]bool)
-	//
-	//	for _, element := range subset {
-	//		checkset[element] = true
-	//	}
-	//
-	//	for _, value := range superset {
-	//		if checkset[value] {
-	//			delete(checkset, value)
-	//		}
-	//	}
-	//
-	// return len(checkset) == 0 //this implies that set is subset of superset
+
 	for _, element := range subset {
 		for _, value := range superset {
 			if element == value {


### PR DESCRIPTION
## Pull request checklist

-This PR is going to handle the issue related to  : [attach volume should be successful even if the filesystem is mounted on 1 gateway node](https://github.ibm.com/IBMSpectrumScale/scale-core/issues/7175)

<!-- Add your one liner release notes here -->
<!-- eg... -->
<!--   - Major functionality adds -->
<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->
<!--   - are you changing our ScaleCluster CR file? -->
```release-notes

```

## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [x] Bugfix
- [ ] Feature Enhancement
- [ ] Test Automation 
- [ ] Code Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Community Operator listing 
- [ ] Other (please describe): 


## What is the current behavior?
<!--Currently -->
- There was a strict check that filesystem should be mounted on all gateway node to create afm fileset 

## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->
- The afm fileset should get created even when the filesystem is mounted on any 1 gateway node

## How risky is this change?
- [ ] Small, isolated change
- [x] Medium, requires regression testing
- [ ] Large, requires functional and regression testing 

