### PR TITLE
Go version insync with cnsa for csi-operator

### DIFF
--- a/operator/go.mod
+++ b/operator/go.mod
@@ -1,9 +1,9 @@
 module github.com/IBM/ibm-spectrum-scale-csi/operator
 
-go 1.22.12
+go 1.22.0
 
 require (
-	github.com/IBM/ibm-spectrum-scale-csi/driver v0.0.0-20250325063409-0b2b91be5630
+	github.com/IBM/ibm-spectrum-scale-csi/driver v0.0.0-20250618121823-ad038bf4e64d
 	github.com/google/uuid v1.6.0
 	github.com/imdario/mergo v0.3.16
 	github.com/onsi/ginkgo v1.16.5

--- a/operator/go.sum
+++ b/operator/go.sum
@@ -1,5 +1,5 @@
-github.com/IBM/ibm-spectrum-scale-csi/driver v0.0.0-20250325063409-0b2b91be5630 h1:ImK+XB5MtkU07cNio5L70bxjvEOCtGScX2CJVwoC2OM=
-github.com/IBM/ibm-spectrum-scale-csi/driver v0.0.0-20250325063409-0b2b91be5630/go.mod h1:1QX0sRgNrWA3thlpqj6sK4hy0DjzXYZ7AdjtIbRHe68=
+github.com/IBM/ibm-spectrum-scale-csi/driver v0.0.0-20250618121823-ad038bf4e64d h1:DK63Ge7dHYuhqwW1NbujJKXNrvvpVBb81ji/hwKE/ew=
+github.com/IBM/ibm-spectrum-scale-csi/driver v0.0.0-20250618121823-ad038bf4e64d/go.mod h1:mxJP29rpUFdDDVejygq+y9FHn0pUWzVibdxMRiAb/K0=
 github.com/beorn7/perks v1.0.1 h1:VlbKKnNfV8bJzeqoa4cOKqO6bYr3WgKZxO8Z16+hsOM=
 github.com/beorn7/perks v1.0.1/go.mod h1:G2ZrVWU2WbWT9wwq4/hrbKbnv/1ERSJQ0ibhJ6rlkpw=
 github.com/cespare/xxhash/v2 v2.3.0 h1:UL815xU9SqsFlibzuggzjXhog7bL6oX9BbNZnL2UFvs=


### PR DESCRIPTION
## Pull request checklist

<!-- Add your one liner release notes here -->
<!-- eg... -->
<!--   - Major functionality adds -->
<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->
<!--   - are you changing our ScaleCluster CR file? -->
```release-notes

```

## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [ ] Bugfix
- [ ] Feature Enhancement
- [ ] Test Automation 
- [ ] Code Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Community Operator listing 
- [x] Other (please describe): 


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying -->
- CSI go version has been upgraded to 1.22.12 which is a latest with 1.22.
## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->
- We are making the go version in sync with cnsa to get compatible with it to reduce upgradation of other places as cnsa ci/cd and cnsa dependencies.

## How risky is this change?
- [x] Small, isolated change
- [ ] Medium, requires regression testing
- [ ] Large, requires functional and regression testing 

