### PR TITLE
Remove scc from cnsa as it is added through operator code

### DIFF
--- a/operator/config/overlays/cnsa/kustomization.yaml
+++ b/operator/config/overlays/cnsa/kustomization.yaml
@@ -7,4 +7,3 @@ namespace: ibm-spectrum-scale-csi
 
 resources:
 - ../../crd/
-- ../../scc/


### PR DESCRIPTION
## Pull request checklist


## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [ ] Bugfix
- [x] Feature Enhancement
- [ ] Test Automation 
- [ ] Code Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Community Operator listing 
- [ ] Other (please describe): 


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying -->
- Earlier SCC was being added using kustomize yamls in install.yaml
 
## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->
- Now the SCC creation and updation are handled through CNSA operator so we need to remove the SCC from Kustomize for CNSA

## How risky is this change?
- [x] Small, isolated change
- [ ] Medium, requires regression testing
- [ ] Large, requires functional and regression testing 

