### PR TITLE
[release-2.10] Changes for CSI 2.10.10 and UBI update

### DIFF
--- a/cloudpak/stable/ibm-spectrum-scale-csi-operator-bundle/case/ibm-spectrum-scale-csi-operator/case.yaml
+++ b/cloudpak/stable/ibm-spectrum-scale-csi-operator-bundle/case/ibm-spectrum-scale-csi-operator/case.yaml
@@ -1,7 +1,7 @@
 name: ibm-spectrum-scale-csi-operator
 specVersion: 1.0.0
-version: 2.10.9
-appVersion: 2.10.9
+version: 2.10.10
+appVersion: 2.10.10
 description: "Represents a deployment of the IBM CSI Storage Scale driver."
 displayName: "IBM CSI Storage Scale Driver CASE"
 displayDescription: "Represents a deployment of the IBM CSI Storage Scale driver."

--- a/cloudpak/stable/ibm-spectrum-scale-csi-operator-bundle/case/ibm-spectrum-scale-csi-operator/inventory/ibmCSIScaleOperator/resources.yaml
+++ b/cloudpak/stable/ibm-spectrum-scale-csi-operator-bundle/case/ibm-spectrum-scale-csi-operator/inventory/ibmCSIScaleOperator/resources.yaml
@@ -9,7 +9,7 @@ resources:
     - metadata:
         name: ibm_spectrum_scale_csi_driver
       image: cp/spectrum/scale/csi/ibm-spectrum-scale-csi-driver
-      tag: v2.10.9
+      tag: v2.10.10
       digest: sha256:57b4ee494ca48342d1ffaf22a166286202b0406b88316e4dcbe87212df6ca8f0
       mediaType: application/vnd.docker.distribution.manifest.list.v2
       registries:
@@ -20,19 +20,19 @@ resources:
         platform:
           architecture: amd64
           os: linux
-        tag: v2.10.9-amd64
+        tag: v2.10.10-amd64
       - digest: sha256:4bcdd8eccc13908d8b6c9c21b4ffed63177c53b410d7d50a2bd036ff8398ef46
         mediaType: application/vnd.docker.distribution.manifest.v2
         platform:
           architecture: ppc64le
           os: linux
-        tag: v2.10.9-ppc64le
+        tag: v2.10.10-ppc64le
       - digest: sha256:17d0601ca92224d38abc78a6a5771827ef130a49379270e536b3ca26cc9fc89f
         mediaType: application/vnd.docker.distribution.manifest.v2
         platform:
           architecture: s390x
           os: linux
-        tag: v2.10.9-s390x
+        tag: v2.10.10-s390x
 
     - metadata:
         name: csi_snapshotter

--- a/cloudpak/stable/ibm-spectrum-scale-csi-operator-bundle/case/ibm-spectrum-scale-csi-operator/inventory/ibmCSIScaleOperatorSetup/resources.yaml
+++ b/cloudpak/stable/ibm-spectrum-scale-csi-operator-bundle/case/ibm-spectrum-scale-csi-operator/inventory/ibmCSIScaleOperatorSetup/resources.yaml
@@ -9,7 +9,7 @@ resources:
     - metadata:
         name: ibm_spectrum_scale_csi_operator
       image: cpopen/ibm-spectrum-scale-csi-operator
-      tag: v2.10.9
+      tag: v2.10.10
       digest: sha256:e3d2f9fb68b2d7cd1faf84002bb73626da10bed5d81f91945a592d41893e2fda
       mediaType: application/vnd.docker.distribution.manifest.list.v2
       registries:
@@ -20,19 +20,19 @@ resources:
         platform:
           architecture: amd64
           os: linux
-        tag: v2.10.9-amd64
+        tag: v2.10.10-amd64
       - digest: sha256:4d2ddb810b219aa0caf3e581d1c811dea6deefc1c491f09ff3d68b33b7875434
         mediaType: application/vnd.docker.distribution.manifest.v2
         platform:
           architecture: ppc64le
           os: linux
-        tag: v2.10.9-ppc64le
+        tag: v2.10.10-ppc64le
       - digest: sha256:e299883ecd8932ca2b245246f91f7111c35de1dd0469f0daae2c7e71ee9ea7a1
         mediaType: application/vnd.docker.distribution.manifest.v2
         platform:
           architecture: s390x
           os: linux
-        tag: v2.10.9-s390x
+        tag: v2.10.10-s390x
     files:
     - mediaType: application/vnd.case.resource.k8s.v1+yaml
       ref: cluster/deploy/crds/csi_v1_csiscaleoperator.yaml

--- a/driver/build/Dockerfile
+++ b/driver/build/Dockerfile
@@ -20,7 +20,7 @@ ENV REVISION $commit
 RUN CGO_ENABLED=0 GOOS=$TARGETOS GOARCH=$TARGETARCH go build -a -ldflags "-X 'main.gitCommit=${REVISION}' -extldflags '-static'" -o _output/ibm-spectrum-scale-csi ./cmd/ibm-spectrum-scale-csi
 # RUN chmod +x,u+s _output/ibm-spectrum-scale-csi
 
-FROM registry.access.redhat.com/ubi9-minimal:9.6-1749489516
+FROM registry.access.redhat.com/ubi9-minimal:9.6-1754584681
 ARG version=2.10.10
 ARG commit
 ARG build_date

--- a/driver/build/Dockerfile
+++ b/driver/build/Dockerfile
@@ -21,7 +21,7 @@ RUN CGO_ENABLED=0 GOOS=$TARGETOS GOARCH=$TARGETARCH go build -a -ldflags "-X 'ma
 # RUN chmod +x,u+s _output/ibm-spectrum-scale-csi
 
 FROM registry.access.redhat.com/ubi9-minimal:9.6-1749489516
-ARG version=2.10.9
+ARG version=2.10.10
 ARG commit
 ARG build_date
 

--- a/driver/cmd/ibm-spectrum-scale-csi/main.go
+++ b/driver/cmd/ibm-spectrum-scale-csi/main.go
@@ -41,7 +41,7 @@ var (
 	driverName     = flag.String("drivername", "spectrumscale.csi.ibm.com", "name of the driver")
 	nodeID         = flag.String("nodeid", "", "node id")
 	kubeletRootDir = flag.String("kubeletRootDirPath", "/var/lib/kubelet", "kubelet root directory path")
-	vendorVersion  = "2.10.9"
+	vendorVersion  = "2.10.10"
 )
 
 func main() {

--- a/generated/installer/ibm-spectrum-scale-csi-operator-dev.yaml
+++ b/generated/installer/ibm-spectrum-scale-csi-operator-dev.yaml
@@ -10,7 +10,7 @@ metadata:
     product: ibm-spectrum-scale-csi
     release: ibm-spectrum-scale-csi-operator
   annotations:
-    productVersion: 2.10.9
+    productVersion: 2.10.10
 spec:
   replicas: 1
   selector:
@@ -28,7 +28,7 @@ spec:
       annotations:
         productID: ibm-spectrum-scale-csi-operator
         productName: IBM Spectrum Scale CSI Operator
-        productVersion: 2.10.9
+        productVersion: 2.10.10
     spec:
       serviceAccountName: ibm-spectrum-scale-csi-operator
       containers:

--- a/generated/installer/ibm-spectrum-scale-csi-operator-ocp-rhel.yaml
+++ b/generated/installer/ibm-spectrum-scale-csi-operator-ocp-rhel.yaml
@@ -10,7 +10,7 @@ metadata:
     product: ibm-spectrum-scale-csi
     release: ibm-spectrum-scale-csi-operator
   annotations:
-    productVersion: 2.10.9
+    productVersion: 2.10.10
 spec:
   replicas: 1
   selector:
@@ -28,7 +28,7 @@ spec:
       annotations:
         productID: ibm-spectrum-scale-csi-operator
         productName: IBM Spectrum Scale CSI Operator
-        productVersion: 2.10.9
+        productVersion: 2.10.10
     spec:
       serviceAccountName: ibm-spectrum-scale-csi-operator
       containers:

--- a/generated/installer/ibm-spectrum-scale-csi-operator-ocp-rhel.yaml
+++ b/generated/installer/ibm-spectrum-scale-csi-operator-ocp-rhel.yaml
@@ -33,7 +33,7 @@ spec:
       serviceAccountName: ibm-spectrum-scale-csi-operator
       containers:
       - name: operator
-        image: quay.io/ibm-spectrum-scale/ibm-spectrum-scale-csi-operator@sha256:02d23a0c1854f4ab4cd777d007c0c5ed285d9bb4f65dcaa39dd87b9f797b7df9
+        image: quay.io/ibm-spectrum-scale-dev/ibm-spectrum-scale-csi-operator@sha256:02d23a0c1854f4ab4cd777d007c0c5ed285d9bb4f65dcaa39dd87b9f797b7df9
         args:
         - --leaderElection=true
         env:
@@ -44,7 +44,7 @@ spec:
             fieldRef:
               fieldPath: metadata.namespace
         - name: CSI_DRIVER_IMAGE
-          value: quay.io/ibm-spectrum-scale/ibm-spectrum-scale-csi-driver@sha256:1c4c26446f8756fd8b4957b8fff3540c46808cca4884c460216b58bf42f7d2ce
+          value: quay.io/ibm-spectrum-scale-dev/ibm-spectrum-scale-csi-driver@sha256:1c4c26446f8756fd8b4957b8fff3540c46808cca4884c460216b58bf42f7d2ce
         resources:
           limits:
             cpu: 600m

--- a/generated/installer/ibm-spectrum-scale-csi-operator.yaml
+++ b/generated/installer/ibm-spectrum-scale-csi-operator.yaml
@@ -10,7 +10,7 @@ metadata:
     product: ibm-spectrum-scale-csi
     release: ibm-spectrum-scale-csi-operator
   annotations:
-    productVersion: 2.10.9
+    productVersion: 2.10.10
 spec:
   replicas: 1
   selector:
@@ -28,7 +28,7 @@ spec:
       annotations:
         productID: ibm-spectrum-scale-csi-operator
         productName: IBM Spectrum Scale CSI Operator
-        productVersion: 2.10.9
+        productVersion: 2.10.10
     spec:
       serviceAccountName: ibm-spectrum-scale-csi-operator
       containers:

--- a/generated/installer/ibm-spectrum-scale-csi-operator.yaml
+++ b/generated/installer/ibm-spectrum-scale-csi-operator.yaml
@@ -33,7 +33,7 @@ spec:
       serviceAccountName: ibm-spectrum-scale-csi-operator
       containers:
       - name: operator
-        image: quay.io/ibm-spectrum-scale/ibm-spectrum-scale-csi-operator@sha256:02d23a0c1854f4ab4cd777d007c0c5ed285d9bb4f65dcaa39dd87b9f797b7df9
+        image: quay.io/ibm-spectrum-scale-dev/ibm-spectrum-scale-csi-operator@sha256:02d23a0c1854f4ab4cd777d007c0c5ed285d9bb4f65dcaa39dd87b9f797b7df9
         args:
         - --leaderElection=true
         env:
@@ -44,7 +44,7 @@ spec:
             fieldRef:
               fieldPath: metadata.namespace
         - name: CSI_DRIVER_IMAGE
-          value: quay.io/ibm-spectrum-scale/ibm-spectrum-scale-csi-driver@sha256:1c4c26446f8756fd8b4957b8fff3540c46808cca4884c460216b58bf42f7d2ce
+          value: quay.io/ibm-spectrum-scale-dev/ibm-spectrum-scale-csi-driver@sha256:1c4c26446f8756fd8b4957b8fff3540c46808cca4884c460216b58bf42f7d2ce
         resources:
           limits:
             cpu: 600m

--- a/operator/Makefile
+++ b/operator/Makefile
@@ -3,7 +3,7 @@
 # To re-generate a bundle for another specific version without changing the standard setup, you can:
 # - use the VERSION as arg of the bundle target (e.g make bundle VERSION=0.0.2)
 # - use environment variables to overwrite this value (e.g export VERSION=0.0.2)
-VERSION ?= 2.10.9
+VERSION ?= 2.10.10
 
 # CHANNELS define the bundle channels used in the bundle.
 # Add a new line here if you would like to change its default config. (E.g CHANNELS = "preview,fast,stable")

--- a/operator/build/Dockerfile
+++ b/operator/build/Dockerfile
@@ -33,7 +33,7 @@ RUN CGO_ENABLED=0 go build -ldflags="-X 'main.gitCommit=${REVISION}'" -a -o mana
 # Refer to https://github.com/GoogleContainerTools/distroless for more details
 FROM gcr.io/distroless/static:nonroot
 WORKDIR /
-ARG version=2.10.9
+ARG version=2.10.10
 ARG commit
 ARG build_date
 

--- a/operator/config/manager/kustomization.yaml
+++ b/operator/config/manager/kustomization.yaml
@@ -3,4 +3,4 @@ resources:
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 commonAnnotations:
-  productVersion: 2.10.9
+  productVersion: 2.10.10

--- a/operator/config/manager/manager.yaml
+++ b/operator/config/manager/manager.yaml
@@ -20,7 +20,7 @@ spec:
       annotations:
         productID: ibm-spectrum-scale-csi-operator
         productName: IBM Spectrum Scale CSI Operator
-        productVersion: 2.10.9
+        productVersion: 2.10.10
       labels:
         app.kubernetes.io/instance: ibm-spectrum-scale-csi-operator
         app.kubernetes.io/managed-by: ibm-spectrum-scale-csi-operator

--- a/operator/controllers/config/constants.go
+++ b/operator/controllers/config/constants.go
@@ -71,8 +71,8 @@ const (
 	ENVKubeVersion  = "KUBE_VERSION"
 	ENVCGPrefix     = "CSI_CG_PREFIX"
 	ENVSymDirPath   = "SYMLINK_DIR_PATH"
-	DriverVersion   = "2.10.9"
-	OperatorVersion = "2.10.9"
+	DriverVersion   = "2.10.10"
+	OperatorVersion = "2.10.10"
 
 	// Number of replica pods for CSI Sidecar deployment
 	ReplicaCount = int32(2)
@@ -88,7 +88,7 @@ const (
 	IBMSystem390 = "s390x"
 
 	//  Default images for containers
-	CSIDriverPluginImage = "quay.io/ibm-spectrum-scale-dev/ibm-spectrum-scale-csi-driver:v2.10.9"
+	CSIDriverPluginImage = "quay.io/ibm-spectrum-scale-dev/ibm-spectrum-scale-csi-driver:v2.10.10"
 	//  registry.k8s.io/sig-storage/csi-node-driver-registrar:v2.8.0
 	CSINodeDriverRegistrarImage = "registry.k8s.io/sig-storage/csi-node-driver-registrar@sha256:f6717ce72a2615c7fbc746b4068f788e78579c54c43b8716e5ce650d97af2df1" // #nosec G101 false positive
 	//  registry.k8s.io/sig-storage/livenessprobe:v2.10.0

--- a/tools/ansible/common/dev-env.yaml
+++ b/tools/ansible/common/dev-env.yaml
@@ -2,7 +2,7 @@
 - name: Set environment facts
   set_fact:
     OPERATOR_SDK_VER: "v1.15.0"
-    OPERATOR_VERSION: "2.10.9"
+    OPERATOR_VERSION: "2.10.10"
     GO_VERSION:       "go1.20"
 
 # Something is wrong with this bit.

--- a/tools/ansible/common/runtime-env.yaml
+++ b/tools/ansible/common/runtime-env.yaml
@@ -2,7 +2,7 @@
 - name: Set environment facts
   set_fact:
     OPERATOR_SDK_VER: "v1.15.0"
-    OPERATOR_VERSION: "2.10.9"
+    OPERATOR_VERSION: "2.10.10"
 
 #- name: Ensure 'python3' is installed
 #  package:


### PR DESCRIPTION
## Pull request checklist

Getting ready for next CNSA release **5.1.9.12**

- CSI version change to `2.10.10`
- Update quay path references to dev (`quay.io/ibm-spectrum-scale-dev`)
- UBI-minimal lockdown to `9.6-1754584681`

## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [ ] Bugfix
- [ ] Feature Enhancement
- [ ] Test Automation 
- [ ] Code Refactoring (no functional changes, no api changes)
- [X] Build related changes
- [ ] Community Operator listing 
- [ ] Other (please describe): 

## How risky is this change?
- [X] Small, isolated change
- [ ] Medium, requires regression testing
- [ ] Large, requires functional and regression testing 