### PR TITLE
Removing dependencies on the cacert data key and certificate configMap name

### DIFF
--- a/driver/csiplugin/gpfs.go
+++ b/driver/csiplugin/gpfs.go
@@ -248,7 +248,6 @@ func (driver *ScaleDriver) PluginInitialize(ctx context.Context) (map[string]con
 	loggerId := utils.GetLoggerId(ctx)
 	klog.Infof("[%s] Initialize IBM Storage Scale CSI driver", loggerId)
 	scaleConfig := settings.LoadScaleConfigSettings(ctx)
-
 	scaleConnMap := make(map[string]connectors.SpectrumScaleConnector)
 	primaryInfo := settings.Primary{}
 
@@ -278,7 +277,6 @@ func (driver *ScaleDriver) PluginInitialize(ctx context.Context) (map[string]con
 		}
 	}
 
-	klog.Infof("[%s] scaleConfig:[%+v], primaryInfo:[%+v],  scaleConnMap:[%+v]", utils.GetLoggerId(ctx), scaleConfig, primaryInfo, scaleConnMap)
 	klog.Infof("[%s] IBM Storage Scale CSI driver initialized", utils.GetLoggerId(ctx))
 	return scaleConnMap, scaleConfig, primaryInfo, nil
 }

--- a/driver/csiplugin/identityserver.go
+++ b/driver/csiplugin/identityserver.go
@@ -49,12 +49,16 @@ func (is *ScaleIdentityServer) GetPluginCapabilities(ctx context.Context, req *c
 func (is *ScaleIdentityServer) Probe(ctx context.Context, req *csi.ProbeRequest) (*csi.ProbeResponse, error) {
 	loggerId := utils.GetLoggerId(ctx)
 	klog.V(4).Infof("[%s] Probe called with args: %#v", loggerId, req)
-
 	// Node mapping check
 	scalenodeID := getNodeMapping(is.Driver.nodeID)
-	klog.V(6).Infof("[%s] Probe: scalenodeID:%s --known as-- k8snodeName: %s", loggerId, scalenodeID, is.Driver.nodeID)
+	klog.V(4).Infof("[%s] Probe: scalenodeID:%s --known as-- k8snodeName: %s", loggerId, scalenodeID, is.Driver.nodeID)
 	// IsNodeComponentHealthy accepts nodeName as admin node name, daemon node name, etc.
-	ghealthy, err := is.Driver.connmap["primary"].IsNodeComponentHealthy(ctx, scalenodeID, "GPFS")
+	conn, ok := is.Driver.connmap["primary"]
+	if !ok || conn == nil {
+		klog.Errorf("[%s] Probe: primary connection not available", loggerId)
+		return &csi.ProbeResponse{Ready: &wrapperspb.BoolValue{Value: true}}, nil
+	}
+	ghealthy, err := conn.IsNodeComponentHealthy(ctx, scalenodeID, "GPFS")
 	if !ghealthy {
 		// Even gpfs health is unhealthy, success is return because restarting csi driver is not going help fix the issue
 		klog.Errorf("[%s] Probe: IBM Storage Scale on node %v is unhealthy. Error: %v", loggerId, scalenodeID, err)

--- a/driver/csiplugin/settings/scale_config.go
+++ b/driver/csiplugin/settings/scale_config.go
@@ -148,7 +148,7 @@ func HandleSecretsAndCerts(ctx context.Context, cmap *ScaleSettingsConfigMap) er
 
 			// the certificate directory i.e. cacert configMap should contain exactly one cert file with the dynamic name
 			if len(certFile) != 1 {
-				return fmt.Errorf("no cert files found in secret mount path or multiple cert files found in the same cert cm: %v", certFile)
+				return fmt.Errorf("Failed to get the cert data or multiple cert data found in the same cert ConfigMap: %v", certFile)
 			}
 			// only one data file should present in the cert cm, above check
 			certPath = path.Join(certPath, certFile[0].Name())

--- a/operator/controllers/csiscaleoperator_controller.go
+++ b/operator/controllers/csiscaleoperator_controller.go
@@ -1785,7 +1785,7 @@ func (r *CSIScaleOperatorReconciler) checkPrerequisite(ctx context.Context, inst
 	// get list of configMaps from custom resource
 	configMaps := []string{}
 	for _, cluster := range instance.Spec.Clusters {
-		if len(cluster.Cacert) != 0 {
+		if cluster.SecureSslMode && len(cluster.Cacert) != 0 {
 			configMaps = append(configMaps, cluster.Cacert)
 		}
 	}

--- a/operator/controllers/csiscaleoperator_controller.go
+++ b/operator/controllers/csiscaleoperator_controller.go
@@ -1909,7 +1909,15 @@ func (r *CSIScaleOperatorReconciler) newConnector(ctx context.Context, instance 
 			)
 			return nil, err
 		}
-		cacertValue := []byte(configMap.Data[cluster.Cacert])
+		// Check the cert data in the ConfigMap, should contain exactly one cert data cert ConfigMap
+		if len(configMap.Data) != 1 {
+			return nil, fmt.Errorf("Failed to get the cert data in the ConfigMap or multiple cert data found in the same cert ConfigMap: %v", cluster.Cacert)
+		}
+		var cacertValue []byte
+		for _, v := range configMap.Data {
+			cacertValue = []byte(v)
+		}
+		// cacertValue := []byte(configMap.Data[cluster.Cacert])
 		caCertPool := x509.NewCertPool()
 		if ok := caCertPool.AppendCertsFromPEM(cacertValue); !ok {
 			return nil, fmt.Errorf("parsing CA cert %v failed", cluster.Cacert)


### PR DESCRIPTION
Signed-off-by: badri-pathak <badri.pathak@ibm.com>

Handles Story: [[Story] Remove strict dependency on cacert data key and ConfigMap name for the CSI](https://github.ibm.com/IBMSpectrumScale/scale-core/issues/9420)

### PR Checklists: 

PR to handle the issue raise during CNSA upgrade where csi failed to restart due to cacert issue.
[(EWM-349612) TS019318966 NSA Certification issues](https://github.ibm.com/IBMSpectrumScale/scale-core/issues/8962)

There has been temporary solution provided by making sslMode as false(default) in the CNSA to pass.
[Change skip verify CNSA back to original default for cso](https://github.ibm.com/IBMSpectrumScale/scale-core/pull/9005)

## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [ ] Bugfix
- [x] Feature Enhancement
- [ ] Test Automation 
- [ ] Code Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Community Operator listing 
- [ ] Other (please describe): 


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying -->
- When secureSslMode is enabled in the CSO CR, CSI expects the CA certificate to be provided in a strict format.
- The ConfigMap name and the --from-file key must match, and this key must be used as the "cacert" value by the Operator.
<img width="1057" height="72" alt="image" src="https://github.com/user-attachments/assets/f256771d-71d3-476b-8b45-5e253ae4686f" />

Current configMap create command:
```
kubectl create configmap <name of configmap> --from-file=<same value provided as name of configmap>=/path/to/mycertificate.pem -n ibm-spectrum-scale-csi-driver
```
- More details can be found here. [Configurations-Certificates](https://www.ibm.com/docs/en/scalecsi?topic=configurations-certificates)

## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. --> 
- The dependency on matching ConfigMap name, --from-file key, and "cacert" suffix is removed.
- Users can now create the ConfigMap with any key name without being restricted to this specific format.

Create secret command can be:
```
kubectl create configmap storage-cacert-new --from-file=storage-ca=/root/a.pem -n ibm-spectrum-scale-csi-driver
```
- CM name is storage-cacert-new 
- Whereas --from-file=<key>=<value of the file>, where key is storage-ca, i.e. need not to be exact cm name.

## How risky is this change?
- [ ] Small, isolated change
- [x] Medium, requires regression testing
- [ ] Large, requires functional and regression testing 

