### PR TITLE
support single namespace migration

### DIFF
--- a/operator/controllers/csiscaleoperator_controller.go
+++ b/operator/controllers/csiscaleoperator_controller.go
@@ -357,8 +357,8 @@ func (r *CSIScaleOperatorReconciler) Reconcile(ctx context.Context, req ctrl.Req
 		if !clusterConfigTypeExists || !cnsaOperatorPresenceExists {
 			logger.Info("Checking the clusterType and presence of CNSA")
 			var cnsaOperatorNamespace string
-			if req.Namespace == config.CNSAScaleNamespace {
-				cnsaOperatorNamespace = req.Namespace
+			if os.Getenv("SINGLE_NAMESPACE_DEPLOYMENT") == "true" {
+				cnsaOperatorNamespace = config.CNSAScaleNamespace
 			} else {
 				cnsaOperatorNamespace = config.CNSAOperatorNamespace
 			}


### PR DESCRIPTION
## Pull request checklist

Story: [Changes to support CNSA single-namespace migration in CSI controller](https://github.ibm.com/IBMSpectrumScale/scale-core/issues/9921)


The changes are intended to support CNSA single-namespace migration, where all resources will be deployed in the ibm-spectrum-scale namespace.
When the environment variable `SINGLE_NAMESPACE_DEPLOYMENT` is set to true, the code will check for the presence of the CNSA operator within the `ibm-spectrum-scale` namespace.
These updates are necessary because, during the upgrade process, there are temporarily two CSOs — one in the `ibm-spectrum-scale-csi` namespace (which will be removed after migration completes). As a result, the CSO controller may fail to access the `ibm-spectrum-scale` namespace during its early startup phase, requiring this adjustment.

<!-- Add your one liner release notes here -->
<!-- eg... -->
<!--   - Major functionality adds -->
<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->
<!--   - are you changing our ScaleCluster CR file? -->
```release-notes

```

## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [ ] Bugfix
- [x] Feature Enhancement
- [ ] Test Automation 
- [ ] Code Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Community Operator listing 
- [ ] Other (please describe): 


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying -->
-

## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->
-

## How risky is this change?
- [ ] Small, isolated change
- [x] Medium, requires regression testing
- [ ] Large, requires functional and regression testing 

