### PR TITLE
adding functionality for fixes for CNSADeployment=true in developer environment and single ns deployment

### DIFF
--- a/operator/controllers/csiscaleoperator_controller.go
+++ b/operator/controllers/csiscaleoperator_controller.go
@@ -41,7 +41,9 @@ import (
 	"k8s.io/apimachinery/pkg/api/meta"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/tools/record"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -353,32 +355,19 @@ func (r *CSIScaleOperatorReconciler) Reconcile(ctx context.Context, req ctrl.Req
 	// _, cnsaOperatorPresenceExists := clusterTypeData[config.ENVClusterCNSAPresenceCheck]
 	// If the setup is a cnsa dev setup, then we are not going to set any clusterTypeData as cnsa operator is not present in the cluster and platform is also local.
 	inClusterScaleGui := os.Getenv("incluster_gui_host")
-	logger.Info("inClusterScaleGui value", "inClusterScaleGui", inClusterScaleGui)
+	logger.V(6).Info("inClusterScaleGui value", "inClusterScaleGui", inClusterScaleGui)
 
 	// if !clusterConfigTypeExists || !cnsaOperatorPresenceExists {
-	logger.Info("Checking the clusterType and presence of CNSA")
-	var cnsaOperatorNamespace string
-	if req.Namespace == config.CNSAScaleNamespace {
-		cnsaOperatorNamespace = req.Namespace
-	} else {
-		cnsaOperatorNamespace = config.CNSAOperatorNamespace
-	}
-	err = getClusterTypeAndCNSAOperatorPresence(ctx, cnsaOperatorNamespace)
+	logger.V(4).Info("Checking the clusterType and presence of CNSA")
+	err = getClusterTypeAndCNSAOperatorPresence(ctx, inClusterScaleGui, r)
 	if err != nil {
 		logger.Error(err, "Failed to check cluster platform and cnsa presence")
 		return ctrl.Result{}, err
 	}
+	// }
+	logger.V(4).Info("clusterTypeData values", "clusterTypeData", clusterTypeData)
+	logger.V(4).Info("CSI environment variables are found successfully", "CSIConfig", r.CSIEnvConfig)
 
-	if inClusterScaleGui != "" {
-		// If in-cluster GUI is enabled i.e. dev env for cnsa, we need to set the appropriate environment variables
-
-		clusterTypeData[config.ENVClusterCNSAPresenceCheck] = "True"
-	}
-	logger.Info("clusterTypeData values", "clusterTypeData", clusterTypeData)
-	logger.Info("CSI environment variables are found successfully", "CSIConfig", r.CSIEnvConfig)
-	/*	// Get CSI env images from the ClusterManagerConfig for cnsa
-		r.GetCSIConfig(ctx)
-	*/
 	// Synchronizing optional configMap
 	cm, err := r.getConfigMap(ctx, instance, config.EnvVarConfigMap)
 	if err != nil && !errors.IsNotFound(err) {
@@ -388,10 +377,10 @@ func (r *CSIScaleOperatorReconciler) Reconcile(ctx context.Context, req ctrl.Req
 		cmData = map[string]string{}
 		cmDataCopy = map[string]string{}
 		//this means cm is deleted, so set defaults
-		logger.Info("Optional ConfigMap is not found", "ConfigMap", config.EnvVarConfigMap)
+		logger.V(4).Info("Optional ConfigMap is not found", "ConfigMap", config.EnvVarConfigMap)
 		// setting default values if values are empty
 		setDefaultDriverEnvValues(ctx, cmData)
-		logger.Info("Final optional configmap values ", "when the optional configmap is absent", cmData)
+		logger.V(4).Info("Final optional configmap values ", "when the optional configmap is absent", cmData)
 	} else {
 		isValidationNeeded := false
 		// for the first iteration or if there is change in cm data, then validation is required
@@ -403,14 +392,14 @@ func (r *CSIScaleOperatorReconciler) Reconcile(ctx context.Context, req ctrl.Req
 		if isValidationNeeded {
 			if err == nil && len(cm.Data) != 0 {
 				cmData = r.parseConfigMap(ctx, instance, cm)
-				logger.Info("Final optional configmap values ", "when the optional configmap is present", cmData)
+				logger.V(4).Info("Final optional configmap values ", "when the optional configmap is present", cmData)
 
 			} else {
 				cmData = map[string]string{}
 				logger.Info("Optional ConfigMap is either not found or is empty, skipped parsing it", "ConfigMap", config.EnvVarConfigMap)
 				// setting default values if values are empty
 				setDefaultDriverEnvValues(ctx, cmData)
-				logger.Info("Final optional configmap values ", "when the optional configmap is absent", cmData)
+				logger.V(4).Info("Final optional configmap values ", "when the optional configmap is absent", cmData)
 			}
 		}
 	}
@@ -423,7 +412,7 @@ func (r *CSIScaleOperatorReconciler) Reconcile(ctx context.Context, req ctrl.Req
 		cmData[config.ENVClusterCNSAPresenceCheck] = clusterTypeData[config.ENVClusterCNSAPresenceCheck]
 	}
 
-	logger.Info("Final optional configmap values", "when the sent to syncer is ", cmData)
+	logger.V(4).Info("Final optional configmap values", "when the sent to syncer is ", cmData)
 
 	// Synchronizing node/driver daemonset
 	CGPrefix := r.GetConsistencyGroupPrefix(ctx, instance)
@@ -2528,58 +2517,96 @@ func isGUIUnauthorized(err error) bool {
 
 // getClusterTypeAndCNSAOperatorPresence fetches CNSA operator deployment from the cluster
 // and sets two parameters in the clusterTypeData map which is being set later in environment of the driver
-func getClusterTypeAndCNSAOperatorPresence(ctx context.Context, namespace string) (err error) {
+func getClusterTypeAndCNSAOperatorPresence(ctx context.Context, inClusterScaleGui string, r *CSIScaleOperatorReconciler) (err error) {
 
 	// Checking the presence of CNSA operator into the cluster
 	logger := csiLog.FromContext(ctx).WithName("getClusterTypeAndCNSAOperatorPresence")
-	logger.Info("Reading resources from the cluster in the", "Namespace", namespace)
 
 	// Default env/cluster type setup
 	clusterTypeData[config.ENVClusterConfigurationType] = config.ENVClusterTypeKubernetes
 	clusterTypeData[config.ENVClusterCNSAPresenceCheck] = "False"
 
-	inClusterConfig, err := rest.InClusterConfig()
-	if err != nil {
-		logger.Error(err, "Failed to set inclusterconfig instance")
-		return err
-	}
-	// creates the clientset
-	clientset, err := kubernetes.NewForConfig(inClusterConfig)
-	if err != nil {
-		logger.Error(err, "Failed to set clientset with config")
-		return err
-	}
+	if inClusterScaleGui != "" {
+		// When inClusterScaleGui is set, it means CNSA dev setup is being used
+		logger.V(4).Info("Cluster is having CNSA deployment in dev setup")
+		clusterTypeData[config.ENVClusterCNSAPresenceCheck] = "True"
+	} else {
 
-	// get deployments in a ibm-spectrum-scale-operator namespace
-	deployments, err := clientset.AppsV1().Deployments(namespace).List(context.TODO(), metav1.ListOptions{})
-	if err != nil {
-		logger.Error(err, "Failed to list of all deployments from the ibm-spectrum-scale-operator namespace")
-		return err
-	}
+		namespaces := []string{config.CNSAScaleNamespace, config.CNSAOperatorNamespace}
 
-	for _, deployment := range deployments.Items {
-		if strings.Contains(deployment.GetName(), config.CNSAOperatorDeploymentName) {
-			logger.Info("Cluster is having CNSA deployment")
-			clusterTypeData[config.ENVClusterCNSAPresenceCheck] = "True"
-			break
+		inClusterConfig, err := rest.InClusterConfig()
+		if err != nil {
+			logger.Error(err, "Failed to set inclusterconfig instance")
+			return err
 		}
-	}
 
-	// Checking if the platform is OpenShift
-	apiList, err := clientset.ServerGroups()
+		// create the clientset
+		clientset, err := kubernetes.NewForConfig(inClusterConfig)
+		if err != nil {
+			logger.Error(err, "Failed to set clientset with config")
+			return err
+		}
+
+		found := false
+		for _, ns := range namespaces {
+			deployments, err := clientset.AppsV1().Deployments(ns).List(context.TODO(), metav1.ListOptions{})
+			if err != nil {
+				// skip if namespace doesn’t exist or is forbidden
+				if errors.IsNotFound(err) || errors.IsForbidden(err) {
+					logger.V(4).Info("Skipping namespace (not found/forbidden)", "namespace", ns)
+					continue
+				}
+				logger.Error(err, "Failed to list CNSA operator deployment in the namespace", "namespace", ns)
+				return err
+			}
+
+			for _, deployment := range deployments.Items {
+				if strings.Contains(deployment.GetName(), config.CNSAOperatorDeploymentName) {
+					logger.V(4).Info("CNSA deployment found", "namespace", ns, "deployment", deployment.GetName())
+					clusterTypeData[config.ENVClusterCNSAPresenceCheck] = "True"
+					found = true
+					break
+				}
+			}
+
+			if found { // found CNSA deployment, no need to check in other namespaces
+				break
+			}
+		}
+
+		if !found {
+			logger.V(4).Info("CNSA deployment not found in any target namespace", "namespaces", namespaces)
+		}
+
+	}
+	// Checking if the cluster is OpenShift or not
+	isOpenShift, err := IsOpenShift(ctx, r.Client)
 	if err != nil {
-		logger.Error(err, "Failed to get ServerGroups while getting openshift platform type")
 		return err
 	}
-
-	apiGroups := apiList.Groups
-	for i := 0; i < len(apiGroups); i++ {
-		if apiGroups[i].Name == "route.openshift.io" {
-			logger.Info("Found apiGroup having route.openshift.io :", "apiGroup", apiGroups[i])
-			logger.Info("Platform is a Openshift")
-			clusterTypeData[config.ENVClusterConfigurationType] = config.ENVClusterTypeOpenshift
-			break
-		}
+	if isOpenShift {
+		clusterTypeData[config.ENVClusterConfigurationType] = config.ENVClusterTypeOpenshift
 	}
 	return nil
+}
+
+// IsOpenShift returns (true, nil) if OpenShift API resources are available.
+// Returns (false, nil) if not an OpenShift cluster.
+// Returns (false, err) for unexpected errors (e.g. network, auth issues).
+func IsOpenShift(ctx context.Context, c client.Client) (bool, error) {
+	dns := &unstructured.Unstructured{}
+	dns.SetGroupVersionKind(schema.GroupVersionKind{
+		Group:   "config.openshift.io",
+		Version: "v1",
+		Kind:    "DNS",
+	})
+	err := c.Get(ctx, client.ObjectKey{Name: "cluster"}, dns)
+	if err != nil {
+		if errors.IsNotFound(err) || meta.IsNoMatchError(err) {
+			return false, nil
+		}
+		return false, fmt.Errorf("Error while checking for Cluster Type OpenShift: %v", err)
+	}
+	// OpenShift
+	return true, nil
 }

--- a/operator/controllers/csiscaleoperator_controller.go
+++ b/operator/controllers/csiscaleoperator_controller.go
@@ -349,31 +349,32 @@ func (r *CSIScaleOperatorReconciler) Reconcile(ctx context.Context, req ctrl.Req
 	// 6. Driver daemonset
 
 	// Calling the function to get platform type and check whether CNSA is present or not in the cluster
-	_, clusterConfigTypeExists := clusterTypeData[config.ENVClusterConfigurationType]
-	_, cnsaOperatorPresenceExists := clusterTypeData[config.ENVClusterCNSAPresenceCheck]
+	// _, clusterConfigTypeExists := clusterTypeData[config.ENVClusterConfigurationType]
+	// _, cnsaOperatorPresenceExists := clusterTypeData[config.ENVClusterCNSAPresenceCheck]
 	// If the setup is a cnsa dev setup, then we are not going to set any clusterTypeData as cnsa operator is not present in the cluster and platform is also local.
 	inClusterScaleGui := os.Getenv("incluster_gui_host")
 	logger.Info("inClusterScaleGui value", "inClusterScaleGui", inClusterScaleGui)
-	if inClusterScaleGui == "" {
-		if !clusterConfigTypeExists || !cnsaOperatorPresenceExists {
-			logger.Info("Checking the clusterType and presence of CNSA")
-			var cnsaOperatorNamespace string
-			if req.Namespace == config.CNSAScaleNamespace {
-				cnsaOperatorNamespace = req.Namespace
-			} else {
-				cnsaOperatorNamespace = config.CNSAOperatorNamespace
-			}
-			err := getClusterTypeAndCNSAOperatorPresence(ctx, cnsaOperatorNamespace)
-			if err != nil {
-				logger.Error(err, "Failed to check cluster platform and cnsa presence")
-				return ctrl.Result{}, err
-			}
-		}
-	} else if inClusterScaleGui != "" {
-		// If in-cluster GUI is enabled, we need to set the appropriate environment variables
-		clusterTypeData[config.ENVClusterConfigurationType] = config.ENVClusterTypeOpenshift
+
+	// if !clusterConfigTypeExists || !cnsaOperatorPresenceExists {
+	logger.Info("Checking the clusterType and presence of CNSA")
+	var cnsaOperatorNamespace string
+	if req.Namespace == config.CNSAScaleNamespace {
+		cnsaOperatorNamespace = req.Namespace
+	} else {
+		cnsaOperatorNamespace = config.CNSAOperatorNamespace
+	}
+	err = getClusterTypeAndCNSAOperatorPresence(ctx, cnsaOperatorNamespace)
+	if err != nil {
+		logger.Error(err, "Failed to check cluster platform and cnsa presence")
+		return ctrl.Result{}, err
+	}
+
+	if inClusterScaleGui != "" {
+		// If in-cluster GUI is enabled i.e. dev env for cnsa, we need to set the appropriate environment variables
+
 		clusterTypeData[config.ENVClusterCNSAPresenceCheck] = "True"
 	}
+	logger.Info("clusterTypeData values", "clusterTypeData", clusterTypeData)
 	logger.Info("CSI environment variables are found successfully", "CSIConfig", r.CSIEnvConfig)
 	/*	// Get CSI env images from the ClusterManagerConfig for cnsa
 		r.GetCSIConfig(ctx)

--- a/operator/controllers/csiscaleoperator_controller.go
+++ b/operator/controllers/csiscaleoperator_controller.go
@@ -353,6 +353,7 @@ func (r *CSIScaleOperatorReconciler) Reconcile(ctx context.Context, req ctrl.Req
 	_, cnsaOperatorPresenceExists := clusterTypeData[config.ENVClusterCNSAPresenceCheck]
 	// If the setup is a cnsa dev setup, then we are not going to set any clusterTypeData as cnsa operator is not present in the cluster and platform is also local.
 	inClusterScaleGui := os.Getenv("incluster_gui_host")
+	logger.Info("inClusterScaleGui value", "inClusterScaleGui", inClusterScaleGui)
 	if inClusterScaleGui == "" {
 		if !clusterConfigTypeExists || !cnsaOperatorPresenceExists {
 			logger.Info("Checking the clusterType and presence of CNSA")
@@ -368,6 +369,10 @@ func (r *CSIScaleOperatorReconciler) Reconcile(ctx context.Context, req ctrl.Req
 				return ctrl.Result{}, err
 			}
 		}
+	} else if inClusterScaleGui != "" {
+		// If in-cluster GUI is enabled, we need to set the appropriate environment variables
+		clusterTypeData[config.ENVClusterConfigurationType] = config.ENVClusterTypeOpenshift
+		clusterTypeData[config.ENVClusterCNSAPresenceCheck] = "True"
 	}
 	logger.Info("CSI environment variables are found successfully", "CSIConfig", r.CSIEnvConfig)
 	/*	// Get CSI env images from the ClusterManagerConfig for cnsa

--- a/operator/controllers/csiscaleoperator_controller.go
+++ b/operator/controllers/csiscaleoperator_controller.go
@@ -365,7 +365,7 @@ func (r *CSIScaleOperatorReconciler) Reconcile(ctx context.Context, req ctrl.Req
 		return ctrl.Result{}, err
 	}
 	// }
-	logger.V(4).Info("clusterTypeData values", "clusterTypeData", clusterTypeData)
+	logger.Info("clusterTypeData values", "clusterTypeData", clusterTypeData)
 	logger.V(4).Info("CSI environment variables are found successfully", "CSIConfig", r.CSIEnvConfig)
 
 	// Synchronizing optional configMap
@@ -392,14 +392,14 @@ func (r *CSIScaleOperatorReconciler) Reconcile(ctx context.Context, req ctrl.Req
 		if isValidationNeeded {
 			if err == nil && len(cm.Data) != 0 {
 				cmData = r.parseConfigMap(ctx, instance, cm)
-				logger.V(4).Info("Final optional configmap values ", "when the optional configmap is present", cmData)
+				logger.Info("Final optional configmap values ", "when the optional configmap is present", cmData)
 
 			} else {
 				cmData = map[string]string{}
 				logger.Info("Optional ConfigMap is either not found or is empty, skipped parsing it", "ConfigMap", config.EnvVarConfigMap)
 				// setting default values if values are empty
 				setDefaultDriverEnvValues(ctx, cmData)
-				logger.V(4).Info("Final optional configmap values ", "when the optional configmap is absent", cmData)
+				logger.Info("Final optional configmap values ", "when the optional configmap is absent", cmData)
 			}
 		}
 	}
@@ -412,7 +412,7 @@ func (r *CSIScaleOperatorReconciler) Reconcile(ctx context.Context, req ctrl.Req
 		cmData[config.ENVClusterCNSAPresenceCheck] = clusterTypeData[config.ENVClusterCNSAPresenceCheck]
 	}
 
-	logger.V(4).Info("Final optional configmap values", "when the sent to syncer is ", cmData)
+	logger.Info("Final optional configmap values", "when the sent to syncer is ", cmData)
 
 	// Synchronizing node/driver daemonset
 	CGPrefix := r.GetConsistencyGroupPrefix(ctx, instance)
@@ -2562,7 +2562,7 @@ func getClusterTypeAndCNSAOperatorPresence(ctx context.Context, inClusterScaleGu
 
 			for _, deployment := range deployments.Items {
 				if strings.Contains(deployment.GetName(), config.CNSAOperatorDeploymentName) {
-					logger.V(4).Info("CNSA deployment found", "namespace", ns, "deployment", deployment.GetName())
+					logger.Info("CNSA deployment found", "namespace", ns, "deployment", deployment.GetName())
 					clusterTypeData[config.ENVClusterCNSAPresenceCheck] = "True"
 					found = true
 					break
@@ -2575,7 +2575,7 @@ func getClusterTypeAndCNSAOperatorPresence(ctx context.Context, inClusterScaleGu
 		}
 
 		if !found {
-			logger.V(4).Info("CNSA deployment not found in any target namespace", "namespaces", namespaces)
+			logger.Info("CNSA deployment not found in any target namespace", "namespaces", namespaces)
 		}
 
 	}


### PR DESCRIPTION
## Pull request checklist

Fixes both issues.
Story: [Changes to support CNSA single-namespace migration in CSI controller](https://github.ibm.com/IBMSpectrumScale/scale-core/issues/9921)
Issue: [CSI Driver missing env variable CNSADeployment=true in developer environment](https://github.ibm.com/IBMSpectrumScale/scale-core/issues/9901)
<!-- Add your one liner release notes here -->
<!-- eg... -->
<!--   - Major functionality adds -->
<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->
<!--   - are you changing our ScaleCluster CR file? -->
```release-notes
For Story: [Changes to support CNSA single-namespace migration in CSI controller](https://github.ibm.com/IBMSpectrumScale/scale-core/issues/9921)

The changes are intended to support CNSA single-namespace migration, where all resources will be deployed in the ibm-spectrum-scale namespace.
When the environment variable SINGLE_NAMESPACE_DEPLOYMENT is set to true, the code will check for the presence of the CNSA operator within the ibm-spectrum-scale namespace.
These updates are necessary because, during the upgrade process, there are temporarily two CSOs — one in the ibm-spectrum-scale-csi namespace (which will be removed after migration completes). As a result, the CSO controller may fail to access the ibm-spectrum-scale namespace during its early startup phase, requiring this adjustment.
```
```
Issue: [CSI Driver missing env variable CNSADeployment=true in developer environment](https://github.ibm.com/IBMSpectrumScale/scale-core/issues/9901)
In a development environment (means when running CNSA operator in VSCode), the CSI driver fails to mount a CSI PV in an application pod. The application pod shows the following error:

  Warning  FailedMount             6s (x5 over 15s)  kubelet                  MountVolume.SetUp failed for volume "pvc-2b4fd619-1689-4d1c-a9f9-68a32320e74e" : rpc error: code = Unknown desc = checkGpfsType: the path [/mnt/shared-fs/32784d88-c953-456a-9658-aa4f8dd56cb0-test/pvc-2b4fd619-1689-4d1c-a9f9-68a32320e74e] is not a valid gpfs path
The problem is related to environment variable CNSADeployment=true not set in the CSI Driver pods:
```
## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [ ] Bugfix
- [x] Feature Enhancement
- [ ] Test Automation 
- [ ] Code Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Community Operator listing 
- [ ] Other (please describe): 


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying -->
-

## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->
-

## How risky is this change?
- [ ] Small, isolated change
- [x] Medium, requires regression testing
- [ ] Large, requires functional and regression testing 

