### PR TITLE
[release-2.14] changes for CSI 2.14.5 and UBI update

### DIFF
--- a/driver/build/Dockerfile
+++ b/driver/build/Dockerfile
@@ -20,8 +20,8 @@ ENV REVISION $commit
 RUN CGO_ENABLED=0 GOOS=$TARGETOS GOARCH=$TARGETARCH go build -a -ldflags "-X 'main.gitCommit=${REVISION}' -extldflags '-static'" -o _output/ibm-spectrum-scale-csi ./cmd/ibm-spectrum-scale-csi
 # RUN chmod +x,u+s _output/ibm-spectrum-scale-csi
 
-FROM registry.access.redhat.com/ubi9-minimal:9.6-1760515502
-ARG version=2.14.4
+FROM registry.access.redhat.com/ubi9-minimal:9.7-1764794109
+ARG version=2.14.5
 ARG commit
 ARG build_date
 

--- a/driver/cmd/ibm-spectrum-scale-csi/main.go
+++ b/driver/cmd/ibm-spectrum-scale-csi/main.go
@@ -42,7 +42,7 @@ var (
 	driverName     = flag.String("drivername", "spectrumscale.csi.ibm.com", "name of the driver")
 	nodeID         = flag.String("nodeid", "", "node id")
 	kubeletRootDir = flag.String("kubeletRootDirPath", "/var/lib/kubelet", "kubelet root directory path")
-	vendorVersion  = "2.14.4"
+	vendorVersion  = "2.14.5"
 )
 
 func main() {

--- a/generated/installer/ibm-spectrum-scale-csi-operator-dev.yaml
+++ b/generated/installer/ibm-spectrum-scale-csi-operator-dev.yaml
@@ -147,7 +147,7 @@ metadata:
     product: ibm-spectrum-scale-csi
     release: ibm-spectrum-scale-csi-operator
   annotations:
-    productVersion: 2.14.4
+    productVersion: 2.14.5
 spec:
   replicas: 1
   selector:
@@ -165,7 +165,7 @@ spec:
       annotations:
         productID: ibm-spectrum-scale-csi-operator
         productName: IBM Spectrum Scale CSI Operator
-        productVersion: 2.14.4
+        productVersion: 2.14.5
     spec:
       serviceAccountName: ibm-spectrum-scale-csi-operator
       containers:

--- a/generated/installer/ibm-spectrum-scale-csi-operator.yaml
+++ b/generated/installer/ibm-spectrum-scale-csi-operator.yaml
@@ -147,7 +147,7 @@ metadata:
     product: ibm-spectrum-scale-csi
     release: ibm-spectrum-scale-csi-operator
   annotations:
-    productVersion: 2.14.4
+    productVersion: 2.14.5
 spec:
   replicas: 1
   selector:
@@ -165,12 +165,12 @@ spec:
       annotations:
         productID: ibm-spectrum-scale-csi-operator
         productName: IBM Spectrum Scale CSI Operator
-        productVersion: 2.14.4
+        productVersion: 2.14.5
     spec:
       serviceAccountName: ibm-spectrum-scale-csi-operator
       containers:
       - name: operator
-        image: quay.io/ibm-spectrum-scale/ibm-spectrum-scale-csi-operator@sha256:2c2e9c630a45da80321bbf1b63e9152e0cb7cc14390ee3879fd736e0a6974464
+        image: quay.io/ibm-spectrum-scale-dev/ibm-spectrum-scale-csi-operator@sha256:2c2e9c630a45da80321bbf1b63e9152e0cb7cc14390ee3879fd736e0a6974464
         args:
         - --leaderElection=true
         env:
@@ -181,7 +181,7 @@ spec:
             fieldRef:
               fieldPath: metadata.namespace
         - name: CSI_DRIVER_IMAGE
-          value: quay.io/ibm-spectrum-scale/ibm-spectrum-scale-csi-driver@sha256:711f9fc45969639da712b0823139549cdbedead0be9453c4243e1a873e7737f1
+          value: quay.io/ibm-spectrum-scale-dev/ibm-spectrum-scale-csi-driver@sha256:711f9fc45969639da712b0823139549cdbedead0be9453c4243e1a873e7737f1
         - name: CSI_SNAPSHOTTER_IMAGE
           value: registry.k8s.io/sig-storage/csi-snapshotter@sha256:5f4bb469fec51147ce157329dab598c758da1b018bad6dad26f0ff469326d769
         - name: CSI_ATTACHER_IMAGE

--- a/operator/Makefile
+++ b/operator/Makefile
@@ -3,7 +3,7 @@
 # To re-generate a bundle for another specific version without changing the standard setup, you can:
 # - use the VERSION as arg of the bundle target (e.g make bundle VERSION=0.0.2)
 # - use environment variables to overwrite this value (e.g export VERSION=0.0.2)
-VERSION ?= 2.14.4
+VERSION ?= 2.14.5
 
 # CHANNELS define the bundle channels used in the bundle.
 # Add a new line here if you would like to change its default config. (E.g CHANNELS = "preview,fast,stable")

--- a/operator/build/Dockerfile
+++ b/operator/build/Dockerfile
@@ -33,7 +33,7 @@ RUN CGO_ENABLED=0 go build -ldflags="-X 'main.gitCommit=${REVISION}'" -a -o mana
 # Refer to https://github.com/GoogleContainerTools/distroless for more details
 FROM gcr.io/distroless/static:nonroot
 WORKDIR /
-ARG version=2.14.4
+ARG version=2.14.5
 ARG commit
 ARG build_date
 

--- a/operator/config/manager/kustomization.yaml
+++ b/operator/config/manager/kustomization.yaml
@@ -3,4 +3,4 @@ resources:
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 commonAnnotations:
-  productVersion: 2.14.4
+  productVersion: 2.14.5

--- a/operator/config/manager/manager.yaml
+++ b/operator/config/manager/manager.yaml
@@ -20,7 +20,7 @@ spec:
       annotations:
         productID: ibm-spectrum-scale-csi-operator
         productName: IBM Spectrum Scale CSI Operator
-        productVersion: 2.14.4
+        productVersion: 2.14.5
       labels:
         app.kubernetes.io/instance: ibm-spectrum-scale-csi-operator
         app.kubernetes.io/managed-by: ibm-spectrum-scale-csi-operator

--- a/operator/config/overlays/default/kustomization.yaml
+++ b/operator/config/overlays/default/kustomization.yaml
@@ -24,9 +24,9 @@ patches:
           spec:
             containers:
               - name: operator
-                image: quay.io/ibm-spectrum-scale/ibm-spectrum-scale-csi-operator@sha256:2c2e9c630a45da80321bbf1b63e9152e0cb7cc14390ee3879fd736e0a6974464
+                image: quay.io/ibm-spectrum-scale-dev/ibm-spectrum-scale-csi-operator@sha256:2c2e9c630a45da80321bbf1b63e9152e0cb7cc14390ee3879fd736e0a6974464
                 env:
                   - name: METRICS_BIND_ADDRESS
                   - name: WATCH_NAMESPACE
                   - name: CSI_DRIVER_IMAGE
-                    value: quay.io/ibm-spectrum-scale/ibm-spectrum-scale-csi-driver@sha256:711f9fc45969639da712b0823139549cdbedead0be9453c4243e1a873e7737f1
+                    value: quay.io/ibm-spectrum-scale-dev/ibm-spectrum-scale-csi-driver@sha256:711f9fc45969639da712b0823139549cdbedead0be9453c4243e1a873e7737f1

--- a/operator/controllers/config/constants.go
+++ b/operator/controllers/config/constants.go
@@ -71,8 +71,8 @@ const (
 	ENVKubeVersion  = "KUBE_VERSION"
 	ENVCGPrefix     = "CSI_CG_PREFIX"
 	ENVSymDirPath   = "SYMLINK_DIR_PATH"
-	DriverVersion   = "2.14.4"
-	OperatorVersion = "2.14.4"
+	DriverVersion   = "2.14.5"
+	OperatorVersion = "2.14.5"
 
 	// Number of replica pods for CSI Sidecar deployment
 	ReplicaCount = int32(2)
@@ -91,7 +91,7 @@ const (
 
 	//  Default images for containers
 
-	CSIDriverPluginImage = "quay.io/ibm-spectrum-scale/ibm-spectrum-scale-csi-driver:v2.14.4"
+	CSIDriverPluginImage = "quay.io/ibm-spectrum-scale/ibm-spectrum-scale-csi-driver:v2.14.5"
 	//  registry.k8s.io/sig-storage/csi-node-driver-registrar:v2.13.0
 	CSINodeDriverRegistrarImage = "registry.k8s.io/sig-storage/csi-node-driver-registrar@sha256:d7138bcc3aa5f267403d45ad4292c95397e421ea17a0035888850f424c7de25d" // #nosec G101 false positive
 	//  registry.k8s.io/sig-storage/livenessprobe:v2.15.0

--- a/tools/ansible/common/dev-env.yaml
+++ b/tools/ansible/common/dev-env.yaml
@@ -2,7 +2,7 @@
 - name: Set environment facts
   set_fact:
     OPERATOR_SDK_VER: "v1.36.1"
-    OPERATOR_VERSION: "2.14.4"
+    OPERATOR_VERSION: "2.14.5"
     GO_VERSION:       "go1.22"
 
 # Something is wrong with this bit.

--- a/tools/ansible/common/runtime-env.yaml
+++ b/tools/ansible/common/runtime-env.yaml
@@ -2,7 +2,7 @@
 - name: Set environment facts
   set_fact:
     OPERATOR_SDK_VER: "v1.36.1"
-    OPERATOR_VERSION: "2.14.4"
+    OPERATOR_VERSION: "2.14.5"
 
 #- name: Ensure 'python3' is installed
 #  package:


### PR DESCRIPTION
## Pull request checklist

Getting ready for next CNSA release **5.2.3.6**

- CSI version change to `2.14.5`
- UBI-minimal lockdown to `9.7-1764794109`
- update quay path references to dev (`quay.io/ibm-spectrum-scale-dev`)

## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [ ] Bugfix
- [ ] Feature Enhancement
- [ ] Test Automation 
- [ ] Code Refactoring (no functional changes, no api changes)
- [X] Build related changes
- [ ] Community Operator listing 
- [ ] Other (please describe): 

## How risky is this change?
- [X] Small, isolated change
- [ ] Medium, requires regression testing
- [ ] Large, requires functional and regression testing 