### PR TITLE
Fix for nfs tuning

### DIFF
--- a/driver/csiplugin/controllerserver.go
+++ b/driver/csiplugin/controllerserver.go
@@ -2564,7 +2564,7 @@ func (cs *ScaleControllerServer) ControllerModifyVolume(ctx context.Context, req
 	loggerId := utils.GetLoggerId(ctx)
 	afmTuningParams := make(map[string]interface{})
 
-	klog.Infof("[%s] ControllerModifyVolume - Volume modify req: %v", loggerId, req)
+	klog.Infof("[%s] ControllerModifyVolume - Volume modify req: %+v", loggerId, req)
 	klog.Infof("[%s] ControllerModifyVolume - Number of param: %v", loggerId, len(req.MutableParameters))
 
 	if err := cs.Driver.ValidateControllerServiceRequest(ctx, csi.ControllerServiceCapability_RPC_MODIFY_VOLUME); err != nil {
@@ -2618,6 +2618,16 @@ func (cs *ScaleControllerServer) ControllerModifyVolume(ctx context.Context, req
 		klog.Infof("ControllerModifyVolume: Fileset [%v] is not created by IBM Container Storage Interface driver, means staticVolume", filesetName)
 		isStaticPVBased = true
 	}
+
+	cacheVolId := &cacheVolumeId{}
+	cacheVolId.S3TuningParams = make(map[string]interface{})
+	cacheVolId.NfsTuningParams = make(map[string]interface{})
+	if strings.Contains(filesetInfo.AFM.AFMTarget, "nfs:") {
+		cacheVolId.IsNfsSupported = true
+	}else{
+		cacheVolId.IsNfsSupported = false
+	}
+
 	if len(mutableParams) > 0 {
 		if isStaticPVBased {
 			if _, ok := mutableParams["filesetName"]; ok {
@@ -2628,19 +2638,17 @@ func (cs *ScaleControllerServer) ControllerModifyVolume(ctx context.Context, req
 			return nil, status.Error(codes.InvalidArgument, "ControllerModifyVolume: - Volume Attributes class is only supported for cacheVolumes and staticVolumes")
 		}
 	}
-	cacheVolId := &cacheVolumeId{}
+
 	err = validateVACParams(ctx, mutableParams, cacheVolId)
 	if err != nil {
 		return nil, err
 	}
 
 	setAfmAttributes := ""
-	if len(cacheVolId.NfsTuningParams) > 0 {
+	if len(cacheVolId.NfsTuningParams) > 0 && cacheVolId.IsNfsSupported {
 		setAfmAttributes = settings.NfsCache
 		afmTuningParams = cacheVolId.NfsTuningParams
-	}
-
-	if len(cacheVolId.S3TuningParams) > 0 {
+	}else if len(cacheVolId.S3TuningParams) > 0 {
 		setAfmAttributes = settings.S3Cache
 		afmTuningParams = cacheVolId.S3TuningParams
 	}


### PR DESCRIPTION
When the common parameter tuning between s3 and nfs is used in modify request then request is considered for s3 instead of nfs. Fix is provided for that.



Please check the type of change your PR introduces:
- [x] Bugfix
- [ ] Feature Enhancement
- [ ] Test Automation 
- [ ] Code Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Community Operator listing 
- [ ] Other (please describe): 




## How risky is this change?
- [ ] Small, isolated change
- [x] Medium, requires regression testing
- [ ] Large, requires functional and regression testing 

