### PR TITLE
changes for makeActive parameter

### DIFF
--- a/driver/csiplugin/connectors/resources.go
+++ b/driver/csiplugin/connectors/resources.go
@@ -640,6 +640,7 @@ type CreateFilesetRequest struct {
 	AfmReadSparseThreshold       string `json:"afmReadSparseThreshold,omitempty"`
 	AfmObjectFastReaddir         string `json:"afmObjectFastReaddir,omitempty"`
 	AfmFileOpenRefreshInterval   string `json:"afmFileOpenRefreshInterval,omitempty"`
+	MakeActive				     bool   `json:"makeActive,omitempty"`
 }
 
 type CreateS3CacheFilesetRequest struct {

--- a/driver/csiplugin/connectors/rest_v2.go
+++ b/driver/csiplugin/connectors/rest_v2.go
@@ -723,6 +723,7 @@ func (s *SpectrumRestV2) CreateFileset(ctx context.Context, filesystemName strin
 		filesetreq.AfmMode = mode
 		nfsTarget := fmt.Sprintf("nfs://%s%s", exportMapName, nfsInfo[NfsPath])
 		filesetreq.AfmTarget = nfsTarget
+		filesetreq.MakeActive = true
 	}
 
 	uid, uidSpecified := opts[UserSpecifiedUID]


### PR DESCRIPTION
MakeActive parameter is added to the create fileset request for nfs cache fileset.



Please check the type of change your PR introduces:
- [x] Bugfix
- [ ] Feature Enhancement
- [ ] Test Automation 
- [ ] Code Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Community Operator listing 
- [ ] Other (please describe): 




## How risky is this change?
- [x] Small, isolated change
- [ ] Medium, requires regression testing
- [ ] Large, requires functional and regression testing 

