### PR TITLE
[release-2.14] bump ubi-minimal tag for CSI driver

### DIFF
--- a/driver/build/Dockerfile
+++ b/driver/build/Dockerfile
@@ -20,7 +20,7 @@ ENV REVISION $commit
 RUN CGO_ENABLED=0 GOOS=$TARGETOS GOARCH=$TARGETARCH go build -a -ldflags "-X 'main.gitCommit=${REVISION}' -extldflags '-static'" -o _output/ibm-spectrum-scale-csi ./cmd/ibm-spectrum-scale-csi
 # RUN chmod +x,u+s _output/ibm-spectrum-scale-csi
 
-FROM registry.access.redhat.com/ubi9-minimal:9.7-1770267347
+FROM registry.access.redhat.com/ubi9-minimal:9.7-1771346502
 ARG version=2.14.6
 ARG commit
 ARG build_date


### PR DESCRIPTION
## Pull request checklist

we have not officially locked down our UBI versions for CNSA release `5.2.3.7` and a new ubi-minimal version was released by RedHat earlier today --> [9.7-1771346502](https://catalog.redhat.com/en/software/containers/ubi9/ubi-minimal/615bd9b4075b022acc111bf5?image=6994abaa3269eaf033d5496b&gti-tabs=registry-tokens&container-tabs=gti#overview) so I figured we could take advantage of this and bump the version for the CSI driver image...

@hemalathagajendran once this PR is merged I will create new CSI images. I'll let you know so we can push them to quay 😄 

## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [ ] Bugfix
- [ ] Feature Enhancement
- [ ] Test Automation 
- [ ] Code Refactoring (no functional changes, no api changes)
- [X] Build related changes
- [ ] Community Operator listing 
- [ ] Other (please describe): 

## How risky is this change?
- [X] Small, isolated change
- [ ] Medium, requires regression testing
- [ ] Large, requires functional and regression testing 