### PR TITLE
Handle sidecar reschedule on nodepool/nodelabel changes

### DIFF
--- a/generated/installer/ibm-spectrum-scale-csi-operator-dev.yaml
+++ b/generated/installer/ibm-spectrum-scale-csi-operator-dev.yaml
@@ -33,6 +33,20 @@ rules:
   verbs:
   - '*'
 - resources:
+  - nodes
+  apiGroups:
+  - ""
+  verbs:
+  - get
+  - list
+  - watch
+- resources:
+  - pods/eviction
+  apiGroups:
+  - ""
+  verbs:
+  - create
+- resources:
   - daemonsets
   - deployments
   - replicasets
@@ -857,8 +871,8 @@ spec:
                           most preferred is the one with the greatest sum of weights, i.e.
                           for each node that meets all of the scheduling requirements (resource
                           request, requiredDuringScheduling anti-affinity expressions, etc.),
-                          compute a sum by iterating through the elements of this field and adding
-                          "weight" to the sum if the node has pods which matches the corresponding podAffinityTerm; the
+                          compute a sum by iterating through the elements of this field and subtracting
+                          "weight" from the sum if the node has pods which matches the corresponding podAffinityTerm; the
                           node(s) with the highest sum are the most preferred.
                         items:
                           type: object

--- a/generated/installer/ibm-spectrum-scale-csi-operator.yaml
+++ b/generated/installer/ibm-spectrum-scale-csi-operator.yaml
@@ -33,6 +33,20 @@ rules:
   verbs:
   - '*'
 - resources:
+  - nodes
+  apiGroups:
+  - ""
+  verbs:
+  - get
+  - list
+  - watch
+- resources:
+  - pods/eviction
+  apiGroups:
+  - ""
+  verbs:
+  - create
+- resources:
   - daemonsets
   - deployments
   - replicasets
@@ -857,8 +871,8 @@ spec:
                           most preferred is the one with the greatest sum of weights, i.e.
                           for each node that meets all of the scheduling requirements (resource
                           request, requiredDuringScheduling anti-affinity expressions, etc.),
-                          compute a sum by iterating through the elements of this field and adding
-                          "weight" to the sum if the node has pods which matches the corresponding podAffinityTerm; the
+                          compute a sum by iterating through the elements of this field and subtracting
+                          "weight" from the sum if the node has pods which matches the corresponding podAffinityTerm; the
                           node(s) with the highest sum are the most preferred.
                         items:
                           type: object

--- a/operator/config/crd/bases/csi.ibm.com_csiscaleoperators.yaml
+++ b/operator/config/crd/bases/csi.ibm.com_csiscaleoperators.yaml
@@ -621,8 +621,8 @@ spec:
                           most preferred is the one with the greatest sum of weights, i.e.
                           for each node that meets all of the scheduling requirements (resource
                           request, requiredDuringScheduling anti-affinity expressions, etc.),
-                          compute a sum by iterating through the elements of this field and adding
-                          "weight" to the sum if the node has pods which matches the corresponding podAffinityTerm; the
+                          compute a sum by iterating through the elements of this field and subtracting
+                          "weight" from the sum if the node has pods which matches the corresponding podAffinityTerm; the
                           node(s) with the highest sum are the most preferred.
                         items:
                           description: The weights of all of the matched WeightedPodAffinityTerm

--- a/operator/config/rbac/role.yaml
+++ b/operator/config/rbac/role.yaml
@@ -20,6 +20,20 @@ rules:
   verbs:
   - '*'
 - apiGroups:
+  - ""
+  resources:
+  - nodes
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - pods/eviction
+  verbs:
+  - create
+- apiGroups:
   - apps
   resources:
   - daemonsets

--- a/operator/controllers/csiscaleoperator_controller.go
+++ b/operator/controllers/csiscaleoperator_controller.go
@@ -528,7 +528,7 @@ func (r *CSIScaleOperatorReconciler) Reconcile(ctx context.Context, req ctrl.Req
 	}
 	logger.Info(fmt.Sprintf("Synchronization of ConfigMap %s is successful", config.CSIConfigMap))
 
-	// Synchronizing pods on node label changes.
+	// Synchronizing sidecar pods on node label changes. reconcile will be called again if there are any pods to evict.
 	r.evictMisplacedPods(ctx)
 
 	message := "The CSI driver resources have been created/updated successfully"
@@ -940,7 +940,7 @@ func (r *CSIScaleOperatorReconciler) evictMisplacedPods(ctx context.Context) {
 		return
 	}
 
-	// Build node map for O(1) lookup
+	// Build node map for quick lookup instead of api calls on every reconcile.
 	nodeMap := make(map[string]*corev1.Node)
 	for i := range nodeList.Items {
 		node := &nodeList.Items[i]
@@ -954,14 +954,14 @@ func (r *CSIScaleOperatorReconciler) evictMisplacedPods(ctx context.Context) {
 		return
 	}
 
-	// Known deployment names for CSI sidecars
+	// deployment names for CSI sidecars
 	deploymentNames := []config.ResourceName{
 		config.CSIControllerAttacher,
 		config.CSIControllerProvisioner,
 		config.CSIControllerSnapshotter,
 		config.CSIControllerResizer,
 	}
-
+	// will be used to store the pods that are evicted
 	const evictedAnnotationKey = "csiscale.ibm.com/evicted"
 
 	for _, csiScale := range csiScaleList.Items {
@@ -982,7 +982,7 @@ func (r *CSIScaleOperatorReconciler) evictMisplacedPods(ctx context.Context) {
 
 			// Skip if no nodeSelector (matches all nodes)
 			if len(desiredNodeSelector) == 0 {
-				logger.V(1).Info("Deployment has no nodeSelector, skipping", "Deployment", deployName)
+				logger.Info("Deployment has no nodeSelector, skipping", "Deployment", deployName)
 				continue
 			}
 
@@ -1030,17 +1030,12 @@ func (r *CSIScaleOperatorReconciler) evictMisplacedPods(ctx context.Context) {
 
 				// Check if node labels match the desired nodeSelector
 				if !r.nodeMatchesSelector(node.Labels, desiredNodeSelector) {
-					logger.Info("Pod is on node that doesn't match nodeSelector, evicting",
-						"Pod", pod.Name,
-						"Node", node.Name,
-						"Deployment", deployName,
-						"DesiredNodeSelector", desiredNodeSelector,
-						"NodeLabels", node.Labels)
+					logger.Info("Pod is on node that doesn't match nodeSelector, evicting", "Pod", pod.Name, "Node", node.Name, "Deployment", deployName, "DesiredNodeSelector", desiredNodeSelector, "NodeLabels", node.Labels)
 
 					// Mark pod as evicted before eviction to prevent loops
 					if err := r.markPodAsEvicted(ctx, &pod, evictedAnnotationKey); err != nil {
 						logger.Error(err, "Failed to mark pod as evicted", "Pod", pod.Name)
-						// Continue with eviction anyway
+						// Continue
 					}
 
 					// Evict the pod
@@ -1051,7 +1046,7 @@ func (r *CSIScaleOperatorReconciler) evictMisplacedPods(ctx context.Context) {
 	}
 }
 
-// markPodAsEvicted adds an annotation to prevent re-eviction loops
+// markPodAsEvicted annotation to prevent re-eviction
 func (r *CSIScaleOperatorReconciler) markPodAsEvicted(ctx context.Context, pod *corev1.Pod, annotationKey string) error {
 	patch := client.MergeFrom(pod.DeepCopy())
 	if pod.Annotations == nil {
@@ -1079,11 +1074,11 @@ func (r *CSIScaleOperatorReconciler) nodeMatchesSelector(nodeLabels map[string]s
 	return true
 }
 
-// evictPod evicts a single pod using the eviction API (respects PDB)
+// evictPod evicts a single pod if fails then delete the pod
 func (r *CSIScaleOperatorReconciler) evictPod(ctx context.Context, pod *corev1.Pod) {
 	logger := csiLog.FromContext(ctx).WithName("evictPod")
 	logger.Info("Checking sidecar pods for evictPod")
-	// Try eviction API first (respects PDB)
+	// Create eviction object
 	eviction := &policyv1.Eviction{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      pod.Name,

--- a/operator/controllers/csiscaleoperator_controller.go
+++ b/operator/controllers/csiscaleoperator_controller.go
@@ -35,6 +35,7 @@ import (
 	"github.com/presslabs/controller-util/pkg/syncer"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
+	policyv1 "k8s.io/api/policy/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
 	storagev1 "k8s.io/api/storage/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
@@ -69,6 +70,8 @@ import (
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
 )
+
+//+kubebuilder:rbac:groups="",resources=pods/eviction,verbs=create
 
 // CSIScaleOperatorReconciler reconciles a CSIScaleOperator object
 type CSIScaleOperatorReconciler struct {
@@ -117,6 +120,7 @@ var watchResources = map[string]map[string]bool{corev1.ResourceConfigMaps.String
 // +kubebuilder:rbac:groups=csi.ibm.com,resources=*,verbs=*
 
 // +kubebuilder:rbac:groups="",resources={pods,persistentvolumeclaims,services,endpoints,events,configmaps,secrets,secrets/status,services/finalizers,serviceaccounts},verbs=*
+// +kubebuilder:rbac:groups="",resources=nodes,verbs=get;list;watch
 // TODO: Does the operator need to access to all the resources mentioned above?
 // TODO: Does all resources mentioned above required delete/patch/update permissions?
 
@@ -524,6 +528,9 @@ func (r *CSIScaleOperatorReconciler) Reconcile(ctx context.Context, req ctrl.Req
 	}
 	logger.Info(fmt.Sprintf("Synchronization of ConfigMap %s is successful", config.CSIConfigMap))
 
+	// Synchronizing pods on node label changes.
+	r.evictMisplacedPods(ctx)
+
 	message := "The CSI driver resources have been created/updated successfully"
 	logger.Info(message)
 
@@ -872,6 +879,32 @@ func (r *CSIScaleOperatorReconciler) SetupWithManager(mgr ctrl.Manager) error {
 		}
 	}
 
+	// Predicate for Node label changes
+	nodePredicateFuncs := predicate.Funcs{
+		CreateFunc: func(e event.CreateEvent) bool {
+			// Don't reconcile on node creation
+			return false
+		},
+		UpdateFunc: func(e event.UpdateEvent) bool {
+			oldNode, okOld := e.ObjectOld.(*corev1.Node)
+			newNode, okNew := e.ObjectNew.(*corev1.Node)
+			if !okOld || !okNew {
+				return false
+			}
+			// Trigger reconciliation only if node labels have changed
+			if !reflect.DeepEqual(oldNode.Labels, newNode.Labels) {
+				logger.Info("Node labels changed, checking all pods for misplaced deployments", "Node", newNode.Name)
+				// Check all deployment pods to see if any are on nodes that don't match their nodeSelector
+				return true
+			}
+			return false
+		},
+		DeleteFunc: func(e event.DeleteEvent) bool {
+			// Don't reconcile on node deletion
+			return false
+		},
+	}
+
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&csiv1.CSIScaleOperator{}, builder.WithPredicates(predicate.GenerationChangedPredicate{})).
 		Watches(&corev1.Secret{},
@@ -883,9 +916,192 @@ func (r *CSIScaleOperatorReconciler) SetupWithManager(mgr ctrl.Manager) error {
 			handler.EnqueueRequestsFromMapFunc(CSIReconcileRequestFunc),
 			builder.WithPredicates(predicateFuncs(corev1.ResourceConfigMaps.String())),
 		).
+		Watches(
+			&corev1.Node{},
+			handler.EnqueueRequestsFromMapFunc(CSIReconcileRequestFunc),
+			builder.WithPredicates(nodePredicateFuncs),
+		).
 		Owns(&appsv1.Deployment{}).
 		Owns(&appsv1.DaemonSet{}).
 		Complete(r)
+}
+
+// evictMisplacedPods checks all CSI sidecar deployment pods and evicts any that are running
+// on nodes that don't match their deployment's nodeSelector
+// Note: DaemonSet pods are not checked as DaemonSet controller handles them automatically
+func (r *CSIScaleOperatorReconciler) evictMisplacedPods(ctx context.Context) {
+	logger := csiLog.FromContext(ctx).WithName("evictMisplacedPods")
+	logger.Info("Checking sidecar pods for nodeSelector violations")
+
+	// Cache all nodes once to avoid repeated API calls
+	nodeList := &corev1.NodeList{}
+	if err := r.Client.List(ctx, nodeList); err != nil {
+		logger.Error(err, "Failed to list nodes")
+		return
+	}
+
+	// Build node map for O(1) lookup
+	nodeMap := make(map[string]*corev1.Node)
+	for i := range nodeList.Items {
+		node := &nodeList.Items[i]
+		nodeMap[node.Name] = node
+	}
+
+	// List all CSIScaleOperator instances
+	csiScaleList := &csiv1.CSIScaleOperatorList{}
+	if err := r.Client.List(ctx, csiScaleList); err != nil {
+		logger.Error(err, "Failed to list CSIScaleOperator instances")
+		return
+	}
+
+	// Known deployment names for CSI sidecars
+	deploymentNames := []config.ResourceName{
+		config.CSIControllerAttacher,
+		config.CSIControllerProvisioner,
+		config.CSIControllerSnapshotter,
+		config.CSIControllerResizer,
+	}
+
+	const evictedAnnotationKey = "csiscale.ibm.com/evicted"
+
+	for _, csiScale := range csiScaleList.Items {
+		for _, resourceName := range deploymentNames {
+			deployName := config.GetNameForResource(resourceName, csiScale.Name)
+
+			// Get the Deployment to know its nodeSelector
+			deploy := &appsv1.Deployment{}
+			if err := r.Client.Get(ctx, types.NamespacedName{Name: deployName, Namespace: csiScale.Namespace}, deploy); err != nil {
+				if !errors.IsNotFound(err) {
+					logger.Error(err, "Failed to get Deployment", "Deployment", deployName)
+				}
+				continue
+			}
+
+			// Get the desired nodeSelector from deployment
+			desiredNodeSelector := deploy.Spec.Template.Spec.NodeSelector
+
+			// Skip if no nodeSelector (matches all nodes)
+			if len(desiredNodeSelector) == 0 {
+				logger.V(1).Info("Deployment has no nodeSelector, skipping", "Deployment", deployName)
+				continue
+			}
+
+			// List all pods for this deployment
+			podList := &corev1.PodList{}
+			listOpts := []client.ListOption{
+				client.InNamespace(csiScale.Namespace),
+				client.MatchingLabels(deploy.Spec.Selector.MatchLabels),
+			}
+
+			if err := r.Client.List(ctx, podList, listOpts...); err != nil {
+				logger.Error(err, "Failed to list pods", "Deployment", deployName)
+				continue
+			}
+
+			// Check each pod to see if it's on a node that matches the desired nodeSelector
+			for _, pod := range podList.Items {
+				// Skip pods that aren't scheduled yet
+				if pod.Spec.NodeName == "" {
+					continue
+				}
+
+				// Skip pods already being deleted
+				if pod.DeletionTimestamp != nil {
+					continue
+				}
+
+				// Skip pods not in Running phase (avoid evicting pods that are already terminating/pending)
+				if pod.Status.Phase != corev1.PodRunning {
+					continue
+				}
+
+				// Skip pods already evicted (prevent eviction loops)
+				if pod.Annotations != nil && pod.Annotations[evictedAnnotationKey] == "true" {
+					logger.V(1).Info("Pod already marked as evicted, skipping", "Pod", pod.Name)
+					continue
+				}
+
+				// Get the node from cache
+				node, exists := nodeMap[pod.Spec.NodeName]
+				if !exists {
+					logger.Error(nil, "Node not found in cache", "Node", pod.Spec.NodeName, "Pod", pod.Name)
+					continue
+				}
+
+				// Check if node labels match the desired nodeSelector
+				if !r.nodeMatchesSelector(node.Labels, desiredNodeSelector) {
+					logger.Info("Pod is on node that doesn't match nodeSelector, evicting",
+						"Pod", pod.Name,
+						"Node", node.Name,
+						"Deployment", deployName,
+						"DesiredNodeSelector", desiredNodeSelector,
+						"NodeLabels", node.Labels)
+
+					// Mark pod as evicted before eviction to prevent loops
+					if err := r.markPodAsEvicted(ctx, &pod, evictedAnnotationKey); err != nil {
+						logger.Error(err, "Failed to mark pod as evicted", "Pod", pod.Name)
+						// Continue with eviction anyway
+					}
+
+					// Evict the pod
+					r.evictPod(ctx, &pod)
+				}
+			}
+		}
+	}
+}
+
+// markPodAsEvicted adds an annotation to prevent re-eviction loops
+func (r *CSIScaleOperatorReconciler) markPodAsEvicted(ctx context.Context, pod *corev1.Pod, annotationKey string) error {
+	patch := client.MergeFrom(pod.DeepCopy())
+	if pod.Annotations == nil {
+		pod.Annotations = make(map[string]string)
+	}
+	pod.Annotations[annotationKey] = "true"
+	return r.Client.Patch(ctx, pod, patch)
+}
+
+// nodeMatchesSelector checks if node labels match the given nodeSelector
+func (r *CSIScaleOperatorReconciler) nodeMatchesSelector(nodeLabels map[string]string, nodeSelector map[string]string) bool {
+	if len(nodeSelector) == 0 {
+		return true // No selector means all nodes match
+	}
+
+	if nodeLabels == nil {
+		return false // Node has no labels, can't match selector
+	}
+
+	for key, value := range nodeSelector {
+		if nodeLabels[key] != value {
+			return false
+		}
+	}
+	return true
+}
+
+// evictPod evicts a single pod using the eviction API (respects PDB)
+func (r *CSIScaleOperatorReconciler) evictPod(ctx context.Context, pod *corev1.Pod) {
+	logger := csiLog.FromContext(ctx).WithName("evictPod")
+	logger.Info("Checking sidecar pods for evictPod")
+	// Try eviction API first (respects PDB)
+	eviction := &policyv1.Eviction{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      pod.Name,
+			Namespace: pod.Namespace,
+		},
+	}
+
+	err := r.Client.SubResource("eviction").Create(ctx, pod, eviction)
+	if err != nil {
+		// Eviction failed, try direct delete as fallback
+		logger.Error(err, "Eviction API failed, attempting direct delete", "Pod", pod.Name)
+		if deleteErr := r.Client.Delete(ctx, pod); deleteErr != nil {
+			logger.Error(deleteErr, "Failed to delete pod", "Pod", pod.Name)
+			return
+		}
+	}
+
+	logger.Info("Successfully evicted pod", "Pod", pod.Name, "Node", pod.Spec.NodeName)
 }
 
 func (r *CSIScaleOperatorReconciler) setRestartedAtValues() {


### PR DESCRIPTION
Signed-off-by: badri-pathak <badri.pathak@ibm.com>

Image:
```
quay.io/badri_pathak/ibm-spectrum-scale-csi-operator:sidecarupdates_v6
```

Fixes Issue: [CSI and sidecar pods do not reschedule on other nodes after node pool is removed from cluster CR nodeSelector](https://github.ibm.com/IBMSpectrumScale/scale-core/issues/10365)

## Pull request checklist

<!-- Add your one liner release notes here -->
<!-- eg... -->
<!--   - Major functionality adds -->
<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->
<!--   - are you changing our ScaleCluster CR file? -->
```release-notes

```

## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [x] Bugfix
- [ ] Feature Enhancement
- [ ] Test Automation 
- [ ] Code Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Community Operator listing 
- [ ] Other (please describe): 


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying -->

CSI sidecar pods were not getting rescheduled when:
- Node labels were modified, e.g.:
   ```bash
   kubectl label nodes bnp-cluster-1-worker-1.fyre.ibm.com scale-
   ```

* Existing pods continued running on old nodes
* Pods violated desired scheduling constraints
* Sidecars stuck on incorrect nodes
* No automatic correction by Kubernetes
## **Root Cause**

* Kubernetes enforces `nodeSelector` **only at scheduling time**
## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->
- Introduced a reconciliation logic to detect and correct misplaced CSI sidecar pods.
* Watch for **Node label changes**
* Reconcile loop:

  * Reads latest CSI deployments
  * Fetches current `nodeSelector`
  * Lists pods for each sidecar deployment
  * Compares pod’s node labels vs desired `nodeSelector`
  * Evicts pods running on mismatched nodes

### Fixes are:
* Controller detects change
* Identifies pods violating updated constraints
* Evicts them using eviction API
* Pods are recreated on correct nodes

## **Additional Safeguards**
* Skip:
  * unscheduled pods
  * terminating pods
  * non-running pods
* Prevent eviction loops via annotation
* Node caching to reduce API calls
* Uses eviction API


## How risky is this change?
- [ ] Small, isolated change
- [x] Medium, requires regression testing
- [ ] Large, requires functional and regression testing 

