### PR TITLE
handled case when gui response empty on quota for restoresize/createsnapshot

### DIFF
--- a/driver/csiplugin/controllerserver.go
+++ b/driver/csiplugin/controllerserver.go
@@ -3894,14 +3894,14 @@ func (cs *ScaleControllerServer) getSnapRestoreSize(ctx context.Context, conn co
 	if err != nil {
 		return 0, err
 	}
-
-	if quotaResp.BlockLimit < 0 {
-		klog.Errorf("[%s] getSnapRestoreSize: Invalid block limit [%v] for fileset [%s:%s] found", utils.GetLoggerId(ctx), quotaResp.BlockLimit, filesystemName, filesetName)
-		return 0, status.Error(codes.Internal, fmt.Sprintf("invalid block limit [%v] for fileset [%s:%s] found", quotaResp.BlockLimit, filesystemName, filesetName))
+	if quotaResp.BlockLimit > 0 {
+		klog.Infof("[%s] getSnapRestoreSize: for filesystemName:fileset [%s:%s] snapshot restoreSize in blocklimit: [%v],restoreSize: [%v] ", utils.GetLoggerId(ctx), filesystemName, filesetName, quotaResp.BlockLimit, int64(quotaResp.BlockLimit*1024))
+		// REST API returns block limit in kb, convert it to bytes and return
+		return int64(quotaResp.BlockLimit * 1024), nil
+	} else {
+		klog.Errorf("[%s] getSnapRestoreSize: Invalid quota found for fileset [%s:%s] found", utils.GetLoggerId(ctx), filesystemName, filesetName)
+		return 0, status.Error(codes.Internal, fmt.Sprintf("invalid quota found for fileset [%s:%s] found", filesystemName, filesetName))
 	}
-
-	// REST API returns block limit in kb, convert it to bytes and return
-	return int64(quotaResp.BlockLimit * 1024), nil
 }
 
 func (cs *ScaleControllerServer) isExistingSnapUseableForVol(ctx context.Context, conn connectors.SpectrumScaleConnector, filesystemName string, consistencyGroup string, filesetName string, cgSnapName string) (bool, error) {


### PR DESCRIPTION

## Pull request checklist

Handles error: https://github.ibm.com/IBMSpectrumScale/scale-core/issues/11022 but actual fix should come from GUI (this is the issue for gui https://github.ibm.com/IBMSpectrumScale/scale-core/issues/10964)

Image: `quay.io/badri_pathak/ibm-spectrum-scale-csi-driver:restoresize_v2`

## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [x] Bugfix
- [ ] Feature Enhancement
- [ ] Test Automation 
- [ ] Code Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Community Operator listing 
- [ ] Other (please describe): 


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying -->
-

## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->
-

## How risky is this change?
- [ ] Small, isolated change
- [x] Medium, requires regression testing
- [ ] Large, requires functional and regression testing 

