### PR TITLE
[release-3.1] lock down ubi-minimal level for CSI driver (again)

### DIFF
--- a/driver/build/Dockerfile
+++ b/driver/build/Dockerfile
@@ -20,7 +20,7 @@ ENV REVISION $commit
 RUN CGO_ENABLED=0 GOOS=$TARGETOS GOARCH=$TARGETARCH go build -a -ldflags "-X 'main.gitCommit=${REVISION}' -extldflags '-static'" -o _output/ibm-spectrum-scale-csi ./cmd/ibm-spectrum-scale-csi
 # RUN chmod +x,u+s _output/ibm-spectrum-scale-csi
 
-FROM registry.access.redhat.com/ubi10-minimal:10.1-1776646707
+FROM registry.access.redhat.com/ubi10-minimal:10.1-1776834797
 ARG version=3.1.0
 ARG commit
 ARG build_date

--- a/generated/installer/ibm-spectrum-scale-csi-operator.yaml
+++ b/generated/installer/ibm-spectrum-scale-csi-operator.yaml
@@ -183,7 +183,7 @@ spec:
       serviceAccountName: ibm-spectrum-scale-csi-operator
       containers:
       - name: operator
-        image: quay.io/ibm-spectrum-scale-dev/ibm-spectrum-scale-csi-operator@sha256:95d48a8056b8837e75047ad2a4def23c0bfa5e07501e2138f5d7d26893a5bb38
+        image: quay.io/ibm-spectrum-scale-dev/ibm-spectrum-scale-csi-operator@sha256:2215afd085df67c4726d52fd8ef35e962501f7c0ea469aa97a81b388f1944dc6
         args:
         - --leaderElection=true
         env:
@@ -194,7 +194,7 @@ spec:
             fieldRef:
               fieldPath: metadata.namespace
         - name: CSI_DRIVER_IMAGE
-          value: quay.io/ibm-spectrum-scale-dev/ibm-spectrum-scale-csi-driver@sha256:e291d813390ba77c94030d2e817eb82ba550bb72a246529d8d36e548a877d072
+          value: quay.io/ibm-spectrum-scale-dev/ibm-spectrum-scale-csi-driver@sha256:b26e4129ac9e71ee9f9e4a12d91b85812262a85516cf79646c105bedfa650485
         - name: CSI_SNAPSHOTTER_IMAGE
           value: registry.k8s.io/sig-storage/csi-snapshotter@sha256:da081c27e8a6d91f36042c1942362d0515ced8d06e18c11b8f893e58c4d6d797
         - name: CSI_ATTACHER_IMAGE

--- a/operator/config/manager/manager.yaml
+++ b/operator/config/manager/manager.yaml
@@ -56,7 +56,7 @@ spec:
               fieldRef:
                 fieldPath: metadata.namespace
           - name: CSI_DRIVER_IMAGE
-            value: cp.icr.io/cp/gpfs/csi/ibm-spectrum-scale-csi-driver@sha256:e291d813390ba77c94030d2e817eb82ba550bb72a246529d8d36e548a877d072
+            value: cp.icr.io/cp/gpfs/csi/ibm-spectrum-scale-csi-driver@sha256:b26e4129ac9e71ee9f9e4a12d91b85812262a85516cf79646c105bedfa650485
           - name: CSI_SNAPSHOTTER_IMAGE
             value: registry.k8s.io/sig-storage/csi-snapshotter@sha256:da081c27e8a6d91f36042c1942362d0515ced8d06e18c11b8f893e58c4d6d797
           - name: CSI_ATTACHER_IMAGE
@@ -69,7 +69,7 @@ spec:
             value: registry.k8s.io/sig-storage/csi-node-driver-registrar@sha256:ab482308a4921e28a6df09a16ab99a457e9af9641ff44fb1be1a690d07ce8b70
           - name: CSI_RESIZER_IMAGE
             value: registry.k8s.io/sig-storage/csi-resizer@sha256:589e525cddef6d768e68da1f0bc9ffd0a24bf3add3dd010648eb7189976fde79
-          image: cp.icr.io/cp/gpfs/csi/ibm-spectrum-scale-csi-operator@sha256:95d48a8056b8837e75047ad2a4def23c0bfa5e07501e2138f5d7d26893a5bb38
+          image: cp.icr.io/cp/gpfs/csi/ibm-spectrum-scale-csi-operator@sha256:2215afd085df67c4726d52fd8ef35e962501f7c0ea469aa97a81b388f1944dc6
           imagePullPolicy: IfNotPresent
           livenessProbe:
             exec:

--- a/operator/config/overlays/default/kustomization.yaml
+++ b/operator/config/overlays/default/kustomization.yaml
@@ -24,9 +24,9 @@ patches:
           spec:
             containers:
               - name: operator
-                image: quay.io/ibm-spectrum-scale-dev/ibm-spectrum-scale-csi-operator@sha256:95d48a8056b8837e75047ad2a4def23c0bfa5e07501e2138f5d7d26893a5bb38
+                image: quay.io/ibm-spectrum-scale-dev/ibm-spectrum-scale-csi-operator@sha256:2215afd085df67c4726d52fd8ef35e962501f7c0ea469aa97a81b388f1944dc6
                 env:
                   - name: METRICS_BIND_ADDRESS
                   - name: WATCH_NAMESPACE
                   - name: CSI_DRIVER_IMAGE
-                    value: quay.io/ibm-spectrum-scale-dev/ibm-spectrum-scale-csi-driver@sha256:e291d813390ba77c94030d2e817eb82ba550bb72a246529d8d36e548a877d072
+                    value: quay.io/ibm-spectrum-scale-dev/ibm-spectrum-scale-csi-driver@sha256:b26e4129ac9e71ee9f9e4a12d91b85812262a85516cf79646c105bedfa650485


### PR DESCRIPTION
## Pull request checklist

I had previously locked down the `ubi-minimal` tag and updated the images on #1466, but overnight RedHat released a new tag for [ubi-minimal](https://catalog.redhat.com/en/software/containers/ubi10/ubi-minimal/66f1504a379b9c2cf23e145c) and we have not done our OSC for CNSA images...so we needed to update our images again to contain these new UBI tags.

Once again, I generated new CSI driver and operator images with this change. New shas are:

`cp.stg.icr.io/cp/gpfs/csi/ibm-spectrum-scale-csi-driver@sha256:b26e4129ac9e71ee9f9e4a12d91b85812262a85516cf79646c105bedfa650485`

and

`cp.stg.icr.io/cp/ibm-spectrum-scale-csi-operator@sha256: 2215afd085df67c4726d52fd8ef35e962501f7c0ea469aa97a81b388f1944dc6`

double checking the commit included in the CSI operator image, it matches this PR:

```
# skopeo inspect docker://cp.stg.icr.io/cp/ibm-spectrum-scale-csi-operator:v3.1.0 | jq -r '.Labels["vcs-ref"]'
95cd52e19fb5407c950203f4e7df9b20514bb0b1
```

this PR should be ready to be merged 😄 

## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [ ] Bugfix
- [ ] Feature Enhancement
- [ ] Test Automation 
- [ ] Code Refactoring (no functional changes, no api changes)
- [x] Build related changes
- [ ] Community Operator listing 
- [ ] Other (please describe): 

## How risky is this change?
- [x] Small, isolated change
- [ ] Medium, requires regression testing
- [ ] Large, requires functional and regression testing 

