### PR TITLE
changes for afm prefetch threshold

### DIFF
--- a/driver/csiplugin/connectors/connectors.go
+++ b/driver/csiplugin/connectors/connectors.go
@@ -150,15 +150,15 @@ const (
 	AfmFileLookupRefreshInterval string = "afmFileLookupRefreshInterval"
 
 	// default value for AFM tuning parameters
-	AfmNumFlushThreadsDefault           int      = 4
-	AfmPrefetchThresholdDefault         int      = 0
-	AfmFileOpenRefreshIntervalDefault   string   = "30"
-	AfmNumReadThreadsDefault            int      = 1
-	AfmObjectFastReaddirDefault         string   = "no"
-	AfmReadSparseThresholdDefault       string   = "128"
-	AfmDirLookupRefreshIntervalDefault  string   = "60"
-	AfmDirOpenRefreshIntervalDefault    string   = "60"
-	AfmFileLookupRefreshIntervalDefault string   = "30"
+	AfmNumFlushThreadsDefault           int    = 4
+	AfmPrefetchThresholdDefault         string = "0"
+	AfmFileOpenRefreshIntervalDefault   string = "30"
+	AfmNumReadThreadsDefault            int    = 1
+	AfmObjectFastReaddirDefault         string = "no"
+	AfmReadSparseThresholdDefault       string = "128"
+	AfmDirLookupRefreshIntervalDefault  string = "60"
+	AfmDirOpenRefreshIntervalDefault    string = "60"
+	AfmFileLookupRefreshIntervalDefault string = "30"
 )
 
 func GetSpectrumScaleConnector(ctx context.Context, config settings.Clusters) (SpectrumScaleConnector, error) {

--- a/driver/csiplugin/connectors/resources.go
+++ b/driver/csiplugin/connectors/resources.go
@@ -649,7 +649,7 @@ type CreateFilesetRequest struct {
 	AfmParallelReadThreshold     int    `json:"afmParallelReadThreshold,omitempty"`
 	AfmParallelWriteChunkSize    int    `json:"afmParallelWriteChunkSize,omitempty"`
 	AfmParallelWriteThreshold    int    `json:"afmParallelWriteThreshold,omitempty"`
-	AfmPrefetchThreshold         int    `json:"afmPrefetchThreshold,omitempty"`
+	AfmPrefetchThreshold         string `json:"afmPrefetchThreshold,omitempty"`
 	AfmPrimaryID                 string `json:"afmPrimaryID,omitempty"`
 	AfmRPO                       int    `json:"afmRPO,omitempty"`
 	AfmShowHomeSnapshots         string `json:"afmShowHomeSnapshots,omitempty"`

--- a/driver/csiplugin/connectors/rest_v2.go
+++ b/driver/csiplugin/connectors/rest_v2.go
@@ -703,7 +703,7 @@ func updateFilesetWithS3TuningParams(ctx context.Context, filesetreq *CreateFile
 
 	afmPrefetchThresholdValue, afmPrefetchThresholdFound := opts[AfmPrefetchThreshold]
 	if afmPrefetchThresholdFound {
-		filesetreq.AfmPrefetchThreshold = afmPrefetchThresholdValue.(int)
+		filesetreq.AfmPrefetchThreshold = afmPrefetchThresholdValue.(string)
 	} else {
 		filesetreq.AfmPrefetchThreshold = AfmPrefetchThresholdDefault
 	}

--- a/driver/csiplugin/controllerserver.go
+++ b/driver/csiplugin/controllerserver.go
@@ -853,7 +853,7 @@ func validateVACParams(ctx context.Context, mutableParams map[string]string, cac
 			if afmPrefetchThresholdValue < 0 || afmPrefetchThresholdValue > 100 {
 				return status.Error(codes.Internal, fmt.Sprintf("invalid value specified for the parameter[%s]", connectors.AfmPrefetchThreshold))
 			} else {
-				cacheVolId.S3TuningParams[vacKey] = afmPrefetchThresholdValue
+				cacheVolId.S3TuningParams[vacKey] = vacValue
 			}
 
 		case connectors.AfmObjectFastReaddir:


### PR DESCRIPTION
changes to address https://github.ibm.com/IBMSpectrumScale/scale-core/issues/8531


Please check the type of change your PR introduces:
- [x] Bugfix
- [ ] Feature Enhancement
- [ ] Test Automation 
- [ ] Code Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Community Operator listing 
- [ ] Other (please describe): 


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying -->
- Default value for afmPrefetchThreshold is not reflected when afmPrefetchThreshold param is removed from vac

## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->
- Default value for afmPrefetchThreshold is reflected when afmPrefetchThreshold param is removed from vac

## How risky is this change?
- [x] Small, isolated change
- [ ] Medium, requires regression testing
- [ ] Large, requires functional and regression testing 

