### PR TITLE
make consistencyGroupPrefix more predictable for vanilla k8s based deployments

### DIFF
--- a/generated/installer/ibm-spectrum-scale-csi-operator-dev.yaml
+++ b/generated/installer/ibm-spectrum-scale-csi-operator-dev.yaml
@@ -1328,10 +1328,10 @@ spec:
                 description: |-
                   consistencyGroupPrefix is a prefix of consistency group of an application.
                   This is expected to be an RFC4122 UUID value (xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx in hexadecimal values).
-                  Must be either empty (operator will auto-generate) or exactly 36 characters.
+                  Must be either empty (operator will auto-generate) or exactly 36 characters and must not start with hyphen.
                 x-kubernetes-validations:
-                - message: consistencyGroupPrefix must be either empty or exactly 36 characters
-                  rule: self == '' || size(self) == 36
+                - message: consistencyGroupPrefix must be either empty or exactly 36 characters and must not start with hyphen
+                  rule: self == '' || (size(self) == 36 && !self.startsWith('-'))
               csipspname:
                 type: string
                 description: PodSecurityPolicy name for CSI driver and sidecar pods.

--- a/generated/installer/ibm-spectrum-scale-csi-operator-dev.yaml
+++ b/generated/installer/ibm-spectrum-scale-csi-operator-dev.yaml
@@ -33,6 +33,7 @@ rules:
   verbs:
   - '*'
 - resources:
+  - namespaces
   - nodes
   apiGroups:
   - ""
@@ -1326,7 +1327,11 @@ spec:
                 type: string
                 description: |-
                   consistencyGroupPrefix is a prefix of consistency group of an application.
-                  This is expected to be an RFC4122 UUID value (xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx in hexadecimal values)
+                  This is expected to be an RFC4122 UUID value (xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx in hexadecimal values).
+                  Must be either empty (operator will auto-generate) or exactly 36 characters.
+                x-kubernetes-validations:
+                - message: consistencyGroupPrefix must be either empty or exactly 36 characters
+                  rule: self == '' || size(self) == 36
               csipspname:
                 type: string
                 description: PodSecurityPolicy name for CSI driver and sidecar pods.

--- a/generated/installer/ibm-spectrum-scale-csi-operator.yaml
+++ b/generated/installer/ibm-spectrum-scale-csi-operator.yaml
@@ -1328,10 +1328,10 @@ spec:
                 description: |-
                   consistencyGroupPrefix is a prefix of consistency group of an application.
                   This is expected to be an RFC4122 UUID value (xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx in hexadecimal values).
-                  Must be either empty (operator will auto-generate) or exactly 36 characters.
+                  Must be either empty (operator will auto-generate) or exactly 36 characters and must not start with hyphen.
                 x-kubernetes-validations:
-                - message: consistencyGroupPrefix must be either empty or exactly 36 characters
-                  rule: self == '' || size(self) == 36
+                - message: consistencyGroupPrefix must be either empty or exactly 36 characters and must not start with hyphen
+                  rule: self == '' || (size(self) == 36 && !self.startsWith('-'))
               csipspname:
                 type: string
                 description: PodSecurityPolicy name for CSI driver and sidecar pods.

--- a/generated/installer/ibm-spectrum-scale-csi-operator.yaml
+++ b/generated/installer/ibm-spectrum-scale-csi-operator.yaml
@@ -33,6 +33,7 @@ rules:
   verbs:
   - '*'
 - resources:
+  - namespaces
   - nodes
   apiGroups:
   - ""
@@ -1326,7 +1327,11 @@ spec:
                 type: string
                 description: |-
                   consistencyGroupPrefix is a prefix of consistency group of an application.
-                  This is expected to be an RFC4122 UUID value (xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx in hexadecimal values)
+                  This is expected to be an RFC4122 UUID value (xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx in hexadecimal values).
+                  Must be either empty (operator will auto-generate) or exactly 36 characters.
+                x-kubernetes-validations:
+                - message: consistencyGroupPrefix must be either empty or exactly 36 characters
+                  rule: self == '' || size(self) == 36
               csipspname:
                 type: string
                 description: PodSecurityPolicy name for CSI driver and sidecar pods.

--- a/operator/Makefile
+++ b/operator/Makefile
@@ -38,7 +38,7 @@ BUNDLE_IMG ?= $(IMAGE_TAG_BASE)-bundle:v$(VERSION)
 # Image URL to use all building/pushing image targets
 IMG ?= $(IMAGE_TAG_BASE):$(VERSION)
 # Produce CRDs that work back to Kubernetes 1.11 (no version conversion)
-CRD_OPTIONS ?= "crdVersions=v1"
+CRD_OPTIONS ?= crd
 
 # Get the currently used golang install path (in GOPATH/bin, unless GOBIN is set)
 ifeq (,$(shell go env GOBIN))

--- a/operator/api/v1/csiscaleoperator_types.go
+++ b/operator/api/v1/csiscaleoperator_types.go
@@ -133,7 +133,9 @@ type CSIScaleOperatorSpec struct {
 	CSIpspname string `json:"csipspname,omitempty"`
 
 	// consistencyGroupPrefix is a prefix of consistency group of an application.
-	// This is expected to be an RFC4122 UUID value (xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx in hexadecimal values)
+	// This is expected to be an RFC4122 UUID value (xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx in hexadecimal values).
+	// Must be either empty (operator will auto-generate) or exactly 36 characters.
+	// +kubebuilder:validation:XValidation:rule="self == '' || size(self) == 36",message="consistencyGroupPrefix must be either empty or exactly 36 characters"
 	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Consistency Group Prefix",xDescriptors="urn:alm:descriptor:com.tectonic.ui:hidden"
 	CGPrefix string `json:"consistencyGroupPrefix,omitempty"`
 }

--- a/operator/api/v1/csiscaleoperator_types.go
+++ b/operator/api/v1/csiscaleoperator_types.go
@@ -134,8 +134,8 @@ type CSIScaleOperatorSpec struct {
 
 	// consistencyGroupPrefix is a prefix of consistency group of an application.
 	// This is expected to be an RFC4122 UUID value (xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx in hexadecimal values).
-	// Must be either empty (operator will auto-generate) or exactly 36 characters.
-	// +kubebuilder:validation:XValidation:rule="self == '' || size(self) == 36",message="consistencyGroupPrefix must be either empty or exactly 36 characters"
+	// Must be either empty (operator will auto-generate) or exactly 36 characters and must not start with hyphen.
+	// +kubebuilder:validation:XValidation:rule="self == '' || (size(self) == 36 && !self.startsWith('-'))",message="consistencyGroupPrefix must be either empty or exactly 36 characters and must not start with hyphen"
 	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Consistency Group Prefix",xDescriptors="urn:alm:descriptor:com.tectonic.ui:hidden"
 	CGPrefix string `json:"consistencyGroupPrefix,omitempty"`
 }

--- a/operator/config/crd/bases/csi.ibm.com_csiscaleoperators.yaml
+++ b/operator/config/crd/bases/csi.ibm.com_csiscaleoperators.yaml
@@ -1059,8 +1059,13 @@ spec:
               consistencyGroupPrefix:
                 description: |-
                   consistencyGroupPrefix is a prefix of consistency group of an application.
-                  This is expected to be an RFC4122 UUID value (xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx in hexadecimal values)
+                  This is expected to be an RFC4122 UUID value (xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx in hexadecimal values).
+                  Must be either empty (operator will auto-generate) or exactly 36 characters.
                 type: string
+                x-kubernetes-validations:
+                - message: consistencyGroupPrefix must be either empty or exactly
+                    36 characters
+                  rule: self == '' || size(self) == 36
               csipspname:
                 description: PodSecurityPolicy name for CSI driver and sidecar pods.
                 type: string

--- a/operator/config/crd/bases/csi.ibm.com_csiscaleoperators.yaml
+++ b/operator/config/crd/bases/csi.ibm.com_csiscaleoperators.yaml
@@ -1060,12 +1060,12 @@ spec:
                 description: |-
                   consistencyGroupPrefix is a prefix of consistency group of an application.
                   This is expected to be an RFC4122 UUID value (xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx in hexadecimal values).
-                  Must be either empty (operator will auto-generate) or exactly 36 characters.
+                  Must be either empty (operator will auto-generate) or exactly 36 characters and must not start with hyphen.
                 type: string
                 x-kubernetes-validations:
                 - message: consistencyGroupPrefix must be either empty or exactly
-                    36 characters
-                  rule: self == '' || size(self) == 36
+                    36 characters and must not start with hyphen
+                  rule: self == '' || (size(self) == 36 && !self.startsWith('-'))
               csipspname:
                 description: PodSecurityPolicy name for CSI driver and sidecar pods.
                 type: string

--- a/operator/config/rbac/role.yaml
+++ b/operator/config/rbac/role.yaml
@@ -22,6 +22,7 @@ rules:
 - apiGroups:
   - ""
   resources:
+  - namespaces
   - nodes
   verbs:
   - get

--- a/operator/controllers/csiscaleoperator_controller.go
+++ b/operator/controllers/csiscaleoperator_controller.go
@@ -121,6 +121,7 @@ var watchResources = map[string]map[string]bool{corev1.ResourceConfigMaps.String
 
 // +kubebuilder:rbac:groups="",resources={pods,persistentvolumeclaims,services,endpoints,events,configmaps,secrets,secrets/status,services/finalizers,serviceaccounts},verbs=*
 // +kubebuilder:rbac:groups="",resources=nodes,verbs=get;list;watch
+// +kubebuilder:rbac:groups="",resources=namespaces,verbs=get;list;watch
 // TODO: Does the operator need to access to all the resources mentioned above?
 // TODO: Does all resources mentioned above required delete/patch/update permissions?
 
@@ -419,7 +420,16 @@ func (r *CSIScaleOperatorReconciler) Reconcile(ctx context.Context, req ctrl.Req
 	logger.Info("Final optional configmap values", "when the sent to syncer is ", cmData)
 
 	// Synchronizing node/driver daemonset
-	CGPrefix := r.GetConsistencyGroupPrefix(ctx, instance)
+	CGPrefix, err := r.GetConsistencyGroupPrefix(ctx, instance)
+	if err != nil {
+		logger.Error(err, "Failed to get consistency group prefix. Will requeue reconciliation.")
+		message := "Failed to get consistency group prefix for CSIScaleOperator resource " + instance.Name + ". Retrying..."
+		SetStatusAndRaiseEvent(instance, r.Recorder, corev1.EventTypeWarning, string(config.StatusConditionSuccess),
+			metav1.ConditionFalse, string(csiv1.GetFailed), message,
+		)
+		// Requeue after 10 seconds to retry fetching kube-system namespace UID
+		return ctrl.Result{RequeueAfter: 10 * time.Second}, nil
+	}
 
 	if instance.Spec.CGPrefix == "" {
 		logger.Info("Updating consistency group prefix in CSIScaleOperator resource.")
@@ -1903,12 +1913,12 @@ func (r *CSIScaleOperatorReconciler) deleteCSIDriver(ctx context.Context, instan
 // GetConsistencyGroupPrefix returns a universal unique ideintiier(UUID) of string format.
 // For Redhat Openshift Cluster Platform, Cluster ID as string is returned.
 // For Vanilla kubernetes cluster, generated UUID is returned.
-func (r *CSIScaleOperatorReconciler) GetConsistencyGroupPrefix(ctx context.Context, instance *csiscaleoperator.CSIScaleOperator) string {
+func (r *CSIScaleOperatorReconciler) GetConsistencyGroupPrefix(ctx context.Context, instance *csiscaleoperator.CSIScaleOperator) (string, error) {
 	logger := csiLog.FromContext(ctx).WithName("GetConsistencyGroupPrefix")
 	logger.Info("Checking if consistency group prefix is passed in CSIScaleOperator specs.")
 	if instance.Spec.CGPrefix != "" {
 		logger.Info("Consistency group prefix found in CSIScaleOperator specs.")
-		return instance.Spec.CGPrefix
+		return instance.Spec.CGPrefix, nil
 	}
 
 	logger.Info("Consistency group prefix is not found in CSIScaleOperator specs.")
@@ -1916,8 +1926,23 @@ func (r *CSIScaleOperatorReconciler) GetConsistencyGroupPrefix(ctx context.Conte
 
 	if clusterTypeData[config.ENVClusterConfigurationType] != config.ENVClusterTypeOpenshift {
 		logger.Info("Cluster is a Kubernetes Platform.")
+		// Try to get kube-system namespace UID
+		kubeSystemUID, err := r.getKubeSystemNamespaceUID(ctx)
+		if err == nil && kubeSystemUID != "" {
+			logger.Info("Successfully fetched kube-system namespace UID.", "UID", kubeSystemUID)
+			return kubeSystemUID, nil
+		}
+
+		// Check if error is retryable (API unavailable or timeout)
+		if err != nil && (errors.IsTimeout(err) || errors.IsServerTimeout(err) || errors.IsServiceUnavailable(err)) {
+			logger.Info("Retryable error encountered. Will requeue reconciliation.", "error", err.Error())
+			return "", err
+		}
+
+		// For non-retryable errors, fallback to generating a random UUID
+		logger.Info("Non-retryable error or unable to fetch kube-system namespace UID. Falling back to generating a random UUID for consistency group prefix.")
 		UUID := r.GenerateUUID(ctx)
-		return UUID.String()
+		return UUID.String(), nil
 	}
 
 	logger.Info("Cluster is Redhat Openshift Cluster Platform.")
@@ -1929,11 +1954,51 @@ func (r *CSIScaleOperatorReconciler) GetConsistencyGroupPrefix(ctx context.Conte
 	if err != nil {
 		logger.Info("Unable to fetch the cluster scoped resource.")
 		UUID := r.GenerateUUID(ctx)
-		return UUID.String()
+		return UUID.String(), nil
 	}
 	UUID := string(CV.Spec.ClusterID)
-	return UUID
+	return UUID, nil
 
+}
+
+// getKubeSystemNamespaceUID fetches the UID of the kube-system namespace.
+// It returns the UID as a string if successful, or an error if the fetch fails.
+// Retries are handled by the reconciliation loop for retryable errors.
+func (r *CSIScaleOperatorReconciler) getKubeSystemNamespaceUID(ctx context.Context) (string, error) {
+	logger := csiLog.FromContext(ctx).WithName("getKubeSystemNamespaceUID")
+	logger.Info("Attempting to fetch kube-system namespace UID.")
+
+	const kubeSystemName = "kube-system"
+
+	namespace := &corev1.Namespace{}
+	err := r.Client.Get(ctx, types.NamespacedName{Name: kubeSystemName}, namespace)
+
+	if err != nil {
+		// Log specific error types for better debugging
+		if errors.IsNotFound(err) {
+			logger.Error(err, "kube-system namespace not found. This is unexpected in a Kubernetes cluster.")
+		} else if errors.IsForbidden(err) {
+			logger.Error(err, "Access forbidden when trying to fetch kube-system namespace. Check RBAC permissions.")
+		} else if errors.IsUnauthorized(err) {
+			logger.Error(err, "Unauthorized access when trying to fetch kube-system namespace. Check service account permissions.")
+		} else if errors.IsTimeout(err) || errors.IsServerTimeout(err) || errors.IsServiceUnavailable(err) {
+			logger.Info("Retryable error encountered while fetching kube-system namespace. Reconciliation will retry.",
+				"error", err.Error())
+		} else {
+			logger.Error(err, "Unexpected error while fetching kube-system namespace.")
+		}
+		return "", err
+	}
+
+	// Successfully fetched the namespace
+	uid := string(namespace.UID)
+	if uid == "" {
+		logger.Error(nil, "kube-system namespace UID is empty.")
+		return "", fmt.Errorf("kube-system namespace UID is empty")
+	}
+
+	logger.Info("Successfully fetched kube-system namespace UID.", "UID", uid)
+	return uid, nil
 }
 
 // GenerateUUID returns a new random UUID.

--- a/operator/controllers/csiscaleoperator_controller.go
+++ b/operator/controllers/csiscaleoperator_controller.go
@@ -1974,18 +1974,14 @@ func (r *CSIScaleOperatorReconciler) getKubeSystemNamespaceUID(ctx context.Conte
 	err := r.Client.Get(ctx, types.NamespacedName{Name: kubeSystemName}, namespace)
 
 	if err != nil {
-		// Log specific error types for better debugging
+		// Log error type for debugging
 		if errors.IsNotFound(err) {
 			logger.Error(err, "kube-system namespace not found. This is unexpected in a Kubernetes cluster.")
-		} else if errors.IsForbidden(err) {
-			logger.Error(err, "Access forbidden when trying to fetch kube-system namespace. Check RBAC permissions.")
-		} else if errors.IsUnauthorized(err) {
-			logger.Error(err, "Unauthorized access when trying to fetch kube-system namespace. Check service account permissions.")
 		} else if errors.IsTimeout(err) || errors.IsServerTimeout(err) || errors.IsServiceUnavailable(err) {
 			logger.Info("Retryable error encountered while fetching kube-system namespace. Reconciliation will retry.",
 				"error", err.Error())
 		} else {
-			logger.Error(err, "Unexpected error while fetching kube-system namespace.")
+			logger.Error(err, "Error while fetching kube-system namespace.")
 		}
 		return "", err
 	}


### PR DESCRIPTION
make consistencyGroupPrefix more predictable for vanilla k8s based deployments using uid of kube-system namespace on vanilla k8s  - Using uid of kube-system namespace. 
Deletion of kube-system namespace is very rare case almost as recreating k8s cluster. 

## Pull request checklist

<!-- Add your one liner release notes here -->
<!-- eg... -->
<!--   - Major functionality adds -->
<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->
<!--   - are you changing our ScaleCluster CR file? -->
```release-notes

```

## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [ ] Bugfix
- [ ] Feature Enhancement
- [ ] Test Automation 
- [ ] Code Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Community Operator listing 
- [ ] Other (please describe): 


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying -->
-

## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->
-

## How risky is this change?
- [ ] Small, isolated change
- [ ] Medium, requires regression testing
- [ ] Large, requires functional and regression testing 

