### PR TITLE
fixed issue when inode with customVolDir failed

### DIFF
--- a/driver/csiplugin/gpfs_util.go
+++ b/driver/csiplugin/gpfs_util.go
@@ -287,7 +287,7 @@ func getScaleVolumeOptions(ctx context.Context, volOptions map[string]string) (*
 		fsetType = independentFileset
 	}
 
-	if !fsetTypeSpecified && volDirPathSpecified && !isSCAdvanced && volumeType == vmdiskCloning{
+	if !fsetTypeSpecified && volDirPathSpecified && !isSCAdvanced && volumeType == vmdiskCloning {
 		fsetTypeSpecified = true
 		fsetType = independentFileset
 	}
@@ -323,7 +323,7 @@ func getScaleVolumeOptions(ctx context.Context, volOptions map[string]string) (*
 
 	/* Check if either fileset based or LW volume. */
 	if volDirPathSpecified {
-		if (fsetTypeSpecified && (fsetType == dependentFileset || fsetType == independentFileset)) || isSCAdvanced || volumeType == vmdiskCloning {
+		if (fsetTypeSpecified && (fsetType == dependentFileset || fsetType == independentFileset)) || isSCAdvanced || volumeType == vmdiskCloning || volumeType == cacheVolume {
 			scaleVol.IsFilesetBased = true
 		} else {
 			if inodeLimSpecified {


### PR DESCRIPTION
Signed-off-by: badri-pathak <badri.pathak@ibm.com>

## Pull request checklist

<!-- Add your one liner release notes here -->
<!-- eg... -->
<!--   - Major functionality adds -->
<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->
<!--   - are you changing our ScaleCluster CR file? -->
```release-notes

```
Fixes: [[Defect] Inode Limit parameter is not working with fileset link at customised path for AFM Cache Volume](https://github.ibm.com/IBMSpectrumScale/scale-core/issues/11428)
Addressed: https://github.ibm.com/IBMSpectrumScale/scale-core/issues/12088

Driver image: `quay.io/badri_pathak/ibm-spectrum-scale-csi-driver:v_20260908_194930`

## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [x] Bugfix
- [ ] Feature Enhancement
- [ ] Test Automation 
- [ ] Code Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Community Operator listing 
- [ ] Other (please describe): 


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying -->
- We were blocked with pvc creation when customVolDir and inodeLimit are being provided in the sc param. and inodelimit is not allowed for the cache vol with S3.

## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->
- We are allowing cache volume creation without inodeLimit, as inodeLimit is not a valid parameter for cache volumes

## How risky is this change?
- [ ] Small, isolated change
- [x] Medium, requires regression testing
- [ ] Large, requires functional and regression testing 

