### PR TITLE
[release-3.1.1] lock down ubi-minimal level for CSI driver

### DIFF
--- a/driver/build/Dockerfile
+++ b/driver/build/Dockerfile
@@ -20,7 +20,7 @@ ENV REVISION $commit
 RUN CGO_ENABLED=0 GOOS=$TARGETOS GOARCH=$TARGETARCH go build -a -ldflags "-X 'main.gitCommit=${REVISION}' -extldflags '-static'" -o _output/ibm-spectrum-scale-csi ./cmd/ibm-spectrum-scale-csi
 # RUN chmod +x,u+s _output/ibm-spectrum-scale-csi
 
-FROM registry.access.redhat.com/ubi10-minimal:10.1-1772441549
+FROM registry.access.redhat.com/ubi10-minimal:10.2-1781509346
 ARG version=3.1.1
 ARG commit
 ARG build_date

--- a/generated/installer/ibm-spectrum-scale-csi-operator.yaml
+++ b/generated/installer/ibm-spectrum-scale-csi-operator.yaml
@@ -183,7 +183,7 @@ spec:
       serviceAccountName: ibm-spectrum-scale-csi-operator
       containers:
       - name: operator
-        image: quay.io/ibm-spectrum-scale-dev/ibm-spectrum-scale-csi-operator@sha256:de0027696b54d29880e8b4c96183b04c1c7872a78d98b1e20f374208f82e2666
+        image: quay.io/ibm-spectrum-scale-dev/ibm-spectrum-scale-csi-operator@sha256:65f0912074de24476d6c0d4b5dcb1519fbb245c1c50f761b75bb74f3e1e3e3a4
         args:
         - --leaderElection=true
         env:
@@ -194,7 +194,7 @@ spec:
             fieldRef:
               fieldPath: metadata.namespace
         - name: CSI_DRIVER_IMAGE
-          value: quay.io/ibm-spectrum-scale-dev/ibm-spectrum-scale-csi-driver@sha256:4178d546c92cac71ac785e00052693a7aaa70eb7c768c41a7bf00499aa84b565
+          value: quay.io/ibm-spectrum-scale-dev/ibm-spectrum-scale-csi-driver@sha256:e2f5d8cae83eb7bb4c755acd7648ed1519834e1244544ac77213190b676144fc
         - name: CSI_SNAPSHOTTER_IMAGE
           value: registry.k8s.io/sig-storage/csi-snapshotter@sha256:da081c27e8a6d91f36042c1942362d0515ced8d06e18c11b8f893e58c4d6d797
         - name: CSI_ATTACHER_IMAGE

--- a/operator/config/manager/manager.yaml
+++ b/operator/config/manager/manager.yaml
@@ -56,7 +56,7 @@ spec:
               fieldRef:
                 fieldPath: metadata.namespace
           - name: CSI_DRIVER_IMAGE
-            value: cp.icr.io/cp/gpfs/csi/ibm-spectrum-scale-csi-driver@sha256:4178d546c92cac71ac785e00052693a7aaa70eb7c768c41a7bf00499aa84b565
+            value: cp.icr.io/cp/gpfs/csi/ibm-spectrum-scale-csi-driver@sha256:e2f5d8cae83eb7bb4c755acd7648ed1519834e1244544ac77213190b676144fc
           - name: CSI_SNAPSHOTTER_IMAGE
             value: registry.k8s.io/sig-storage/csi-snapshotter@sha256:da081c27e8a6d91f36042c1942362d0515ced8d06e18c11b8f893e58c4d6d797
           - name: CSI_ATTACHER_IMAGE
@@ -69,7 +69,7 @@ spec:
             value: registry.k8s.io/sig-storage/csi-node-driver-registrar@sha256:ab482308a4921e28a6df09a16ab99a457e9af9641ff44fb1be1a690d07ce8b70
           - name: CSI_RESIZER_IMAGE
             value: registry.k8s.io/sig-storage/csi-resizer@sha256:589e525cddef6d768e68da1f0bc9ffd0a24bf3add3dd010648eb7189976fde79
-          image: cp.icr.io/cp/gpfs/csi/ibm-spectrum-scale-csi-operator@sha256:de0027696b54d29880e8b4c96183b04c1c7872a78d98b1e20f374208f82e2666
+          image: cp.icr.io/cp/gpfs/csi/ibm-spectrum-scale-csi-operator@sha256:65f0912074de24476d6c0d4b5dcb1519fbb245c1c50f761b75bb74f3e1e3e3a4
           imagePullPolicy: IfNotPresent
           livenessProbe:
             exec:

--- a/operator/config/overlays/default/kustomization.yaml
+++ b/operator/config/overlays/default/kustomization.yaml
@@ -24,9 +24,9 @@ patches:
           spec:
             containers:
               - name: operator
-                image: quay.io/ibm-spectrum-scale-dev/ibm-spectrum-scale-csi-operator@sha256:de0027696b54d29880e8b4c96183b04c1c7872a78d98b1e20f374208f82e2666
+                image: quay.io/ibm-spectrum-scale-dev/ibm-spectrum-scale-csi-operator@sha256:65f0912074de24476d6c0d4b5dcb1519fbb245c1c50f761b75bb74f3e1e3e3a4
                 env:
                   - name: METRICS_BIND_ADDRESS
                   - name: WATCH_NAMESPACE
                   - name: CSI_DRIVER_IMAGE
-                    value: quay.io/ibm-spectrum-scale-dev/ibm-spectrum-scale-csi-driver@sha256:4178d546c92cac71ac785e00052693a7aaa70eb7c768c41a7bf00499aa84b565
+                    value: quay.io/ibm-spectrum-scale-dev/ibm-spectrum-scale-csi-driver@sha256:e2f5d8cae83eb7bb4c755acd7648ed1519834e1244544ac77213190b676144fc


### PR DESCRIPTION
## Pull request checklist

locking down ubi-minimal to latest available [ubi-minimal:10.2-1781509346](https://catalog.redhat.com/en/software/containers/ubi10/ubi-minimal/66f1504a379b9c2cf23e145c?image=6a2fb7358ca98abb34cf43d2&architecture=amd64) as of today, June 18th 2026.

This is in preparation for our CNSA 6.0.1.1 lock down
## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [ ] Bugfix
- [ ] Feature Enhancement
- [ ] Test Automation 
- [ ] Code Refactoring (no functional changes, no api changes)
- [x] Build related changes
- [ ] Community Operator listing 
- [ ] Other (please describe): 

## How risky is this change?
- [x] Small, isolated change
- [ ] Medium, requires regression testing
- [ ] Large, requires functional and regression testing 