### PR TITLE
[release-2.14] update CSI driver and operator digests

### DIFF
--- a/driver/build/Dockerfile
+++ b/driver/build/Dockerfile
@@ -20,7 +20,7 @@ ENV REVISION $commit
 RUN CGO_ENABLED=0 GOOS=$TARGETOS GOARCH=$TARGETARCH go build -a -ldflags "-X 'main.gitCommit=${REVISION}' -extldflags '-static'" -o _output/ibm-spectrum-scale-csi ./cmd/ibm-spectrum-scale-csi
 # RUN chmod +x,u+s _output/ibm-spectrum-scale-csi
 
-FROM registry.access.redhat.com/ubi9-minimal:9.8-1782366411
+FROM registry.access.redhat.com/ubi9-minimal:9.8-1782797275
 ARG version=2.14.8
 ARG commit
 ARG build_date

--- a/generated/installer/ibm-spectrum-scale-csi-operator.yaml
+++ b/generated/installer/ibm-spectrum-scale-csi-operator.yaml
@@ -170,7 +170,7 @@ spec:
       serviceAccountName: ibm-spectrum-scale-csi-operator
       containers:
       - name: operator
-        image: quay.io/ibm-spectrum-scale-dev/ibm-spectrum-scale-csi-operator@sha256:ff4a8b6a64439889d28e94c50f165c255abc67c17efa44798c76d41a6ecbd9fa
+        image: quay.io/ibm-spectrum-scale-dev/ibm-spectrum-scale-csi-operator@sha256:b98a23cabda8c19bb4e488f46487b9c17a319e12ca00d833d7de139ff373b8b9
         args:
         - --leaderElection=true
         env:
@@ -181,7 +181,7 @@ spec:
             fieldRef:
               fieldPath: metadata.namespace
         - name: CSI_DRIVER_IMAGE
-          value: quay.io/ibm-spectrum-scale-dev/ibm-spectrum-scale-csi-driver@sha256:75dd2f238268b7f2e855ed9e9a8ae356a34bb9cc3e996f81cba20d363830a2f5
+          value: quay.io/ibm-spectrum-scale-dev/ibm-spectrum-scale-csi-driver@sha256:af4de6d02421a6dfaebf071f726152cd09e53a08d9955a0b680406d323a10a12
         - name: CSI_SNAPSHOTTER_IMAGE
           value: registry.k8s.io/sig-storage/csi-snapshotter@sha256:5f4bb469fec51147ce157329dab598c758da1b018bad6dad26f0ff469326d769
         - name: CSI_ATTACHER_IMAGE

--- a/operator/config/overlays/cnsa-k8s/kustomization.yaml
+++ b/operator/config/overlays/cnsa-k8s/kustomization.yaml
@@ -41,5 +41,5 @@ patches:
                   - name: CSI_RESIZER_IMAGE
                     value: cp.icr.io/cp/gpfs/csi/csi-resizer@sha256:8ddd178ba5d08973f1607f9b84619b58320948de494b31c9d7cd5375b316d6d4
                   - name: CSI_DRIVER_IMAGE
-                    value: cp.icr.io/cp/gpfs/csi/ibm-spectrum-scale-csi-driver@sha256:75dd2f238268b7f2e855ed9e9a8ae356a34bb9cc3e996f81cba20d363830a2f5
-                image: icr.io/cpopen/ibm-spectrum-scale-csi-operator@sha256:ff4a8b6a64439889d28e94c50f165c255abc67c17efa44798c76d41a6ecbd9fa
+                    value: cp.icr.io/cp/gpfs/csi/ibm-spectrum-scale-csi-driver@sha256:af4de6d02421a6dfaebf071f726152cd09e53a08d9955a0b680406d323a10a12
+                image: icr.io/cpopen/ibm-spectrum-scale-csi-operator@sha256:b98a23cabda8c19bb4e488f46487b9c17a319e12ca00d833d7de139ff373b8b9

--- a/operator/config/overlays/cnsa/kustomization.yaml
+++ b/operator/config/overlays/cnsa/kustomization.yaml
@@ -42,5 +42,5 @@ patches:
                   - name: CSI_RESIZER_IMAGE
                     value: cp.icr.io/cp/gpfs/csi/csi-resizer@sha256:8ddd178ba5d08973f1607f9b84619b58320948de494b31c9d7cd5375b316d6d4
                   - name: CSI_DRIVER_IMAGE
-                    value: cp.icr.io/cp/gpfs/csi/ibm-spectrum-scale-csi-driver@sha256:75dd2f238268b7f2e855ed9e9a8ae356a34bb9cc3e996f81cba20d363830a2f5
-                image: icr.io/cpopen/ibm-spectrum-scale-csi-operator@sha256:ff4a8b6a64439889d28e94c50f165c255abc67c17efa44798c76d41a6ecbd9fa
+                    value: cp.icr.io/cp/gpfs/csi/ibm-spectrum-scale-csi-driver@sha256:af4de6d02421a6dfaebf071f726152cd09e53a08d9955a0b680406d323a10a12
+                image: icr.io/cpopen/ibm-spectrum-scale-csi-operator@sha256:b98a23cabda8c19bb4e488f46487b9c17a319e12ca00d833d7de139ff373b8b9

--- a/operator/config/overlays/default/kustomization.yaml
+++ b/operator/config/overlays/default/kustomization.yaml
@@ -24,9 +24,9 @@ patches:
           spec:
             containers:
               - name: operator
-                image: quay.io/ibm-spectrum-scale-dev/ibm-spectrum-scale-csi-operator@sha256:ff4a8b6a64439889d28e94c50f165c255abc67c17efa44798c76d41a6ecbd9fa
+                image: quay.io/ibm-spectrum-scale-dev/ibm-spectrum-scale-csi-operator@sha256:b98a23cabda8c19bb4e488f46487b9c17a319e12ca00d833d7de139ff373b8b9
                 env:
                   - name: METRICS_BIND_ADDRESS
                   - name: WATCH_NAMESPACE
                   - name: CSI_DRIVER_IMAGE
-                    value: quay.io/ibm-spectrum-scale-dev/ibm-spectrum-scale-csi-driver@sha256:75dd2f238268b7f2e855ed9e9a8ae356a34bb9cc3e996f81cba20d363830a2f5
+                    value: quay.io/ibm-spectrum-scale-dev/ibm-spectrum-scale-csi-driver@sha256:af4de6d02421a6dfaebf071f726152cd09e53a08d9955a0b680406d323a10a12


### PR DESCRIPTION
## Pull request checklist

we had to re-lock UBI images again for CNSA 5.2.3.9, so this PR is just to match the new ubi-minimal tag used for CSI driver, which is [9.8-1782797275](https://catalog.redhat.com/en/software/containers/ubi9/ubi-minimal/615bd9b4075b022acc111bf5?image=6a4360a1b13be05717019e25&architecture=ppc64le)

New driver and operator digests generated after the ubi-minimal update:

```
- csi-driver --> af4de6d02421a6dfaebf071f726152cd09e53a08d9955a0b680406d323a10a12
- csi-operator --> b98a23cabda8c19bb4e488f46487b9c17a319e12ca00d833d7de139ff373b8b9
```

## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [ ] Bugfix
- [ ] Feature Enhancement
- [ ] Test Automation 
- [ ] Code Refactoring (no functional changes, no api changes)
- [x] Build related changes
- [ ] Community Operator listing 
- [ ] Other (please describe): 

## How risky is this change?
- [x] Small, isolated change
- [ ] Medium, requires regression testing
- [ ] Large, requires functional and regression testing 
