### PR TITLE
Fix for mount in NodePublish volume

### DIFF
--- a/driver/csiplugin/mount_utils.go
+++ b/driver/csiplugin/mount_utils.go
@@ -22,33 +22,43 @@ package scale
 import (
 	"fmt"
 	"os/exec"
+	"strings"
 
 	"golang.org/x/sys/unix"
 )
 
-// bindMount performs a bind mount of source onto target using the system
+// bindMount performs a bind mount of hostSource onto target using the system
 // mount(8) binary, mirroring the behaviour of mount.Mounter.Mount with the
 // "bind" option:
 //
-//  1. First pass: mount --bind <source> <target>
-//  2. Second pass: mount --bind --remount <source> <target>
+//  1. First pass: mount --bind <hostSource> <target>
+//  2. Second pass: mount -o remount,bind[,ro,nodev,…] <hostSource> <target>
 //     with any read-only / nodev / noexec / nosuid / noatime / relatime /
 //     nodiratime flags inherited from the source filesystem via statfs(2).
 //
-// Using the /host-prefixed source path ensures that the statfs(2) call
-// succeeds inside the container (the container filesystem only exposes
-// paths under /host).
-func bindMount(source, target string) error {
-	// First pass: establish the bind mount.
-	if out, err := exec.Command("mount", "--bind", source, target).CombinedOutput(); err != nil {
-		return fmt.Errorf("mount --bind %s %s failed: %v\nOutput: %s", source, target, err, string(out))
+// hostSource is the bare host path (e.g. /ibm/fs1/pvc-…/data) passed to the
+// mount(8) binary — the external process resolves paths in the host mount
+// namespace and does not see the /host prefix used inside the container.
+//
+// statfsSource is the /host-prefixed path (e.g. /host/ibm/fs1/pvc-…/data)
+// used only for the in-process statfs(2) call, which succeeds because the
+// container filesystem exposes host paths under /host.
+func bindMount(hostSource, statfsSource, target string) error {
+	// First pass: establish the bind mount using the bare host path.
+	if out, err := exec.Command("mount", "--bind", hostSource, target).CombinedOutput(); err != nil {
+		return fmt.Errorf("mount --bind %s %s failed: %v\nOutput: %s", hostSource, target, err, string(out))
 	}
 
-	// Derive the mount flags that are active on the source filesystem so that
-	// the bind mount inherits them (e.g. ro, nodev, nosuid, noexec, …).
-	remountOpts := []string{"--bind", "--remount"}
+	// Derive the mount flags active on the source filesystem so the bind mount
+	// inherits them (e.g. ro, nodev, nosuid, noexec, …). Use the /host-prefixed
+	// path so statfs(2) resolves correctly inside the container.
+	//
+	// All options — including "remount" and "bind" — are passed as a single
+	// comma-separated -o argument, which is the correct mount(8) syntax.
+	// "--remount" is not a valid standalone flag for mount(8).
+	mountOpts := []string{"remount", "bind"}
 	var st unix.Statfs_t
-	if err := unix.Statfs(source, &st); err == nil {
+	if err := unix.Statfs(statfsSource, &st); err == nil {
 		flagMap := map[int]string{
 			unix.MS_RDONLY:     "ro",
 			unix.MS_NODEV:      "nodev",
@@ -60,15 +70,15 @@ func bindMount(source, target string) error {
 		}
 		for flag, opt := range flagMap {
 			if int(st.Flags)&flag == flag {
-				remountOpts = append(remountOpts, "-o", opt)
+				mountOpts = append(mountOpts, opt)
 			}
 		}
 	}
 
-	// Second pass: remount to propagate inherited flags.
-	remountArgs := append(remountOpts, source, target)
-	if out, err := exec.Command("mount", remountArgs...).CombinedOutput(); err != nil {
-		return fmt.Errorf("mount --bind --remount %s %s failed: %v\nOutput: %s", source, target, err, string(out))
+	// Second pass: remount with inherited flags.
+	opts := strings.Join(mountOpts, ",")
+	if out, err := exec.Command("mount", "-o", opts, hostSource, target).CombinedOutput(); err != nil {
+		return fmt.Errorf("mount -o %s %s %s failed: %v\nOutput: %s", opts, hostSource, target, err, string(out))
 	}
 
 	return nil

--- a/driver/csiplugin/mount_utils.go
+++ b/driver/csiplugin/mount_utils.go
@@ -1,0 +1,75 @@
+//go:build linux
+// +build linux
+
+/**
+ * Copyright 2019, 2024 IBM Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package scale
+
+import (
+	"fmt"
+	"os/exec"
+
+	"golang.org/x/sys/unix"
+)
+
+// bindMount performs a bind mount of source onto target using the system
+// mount(8) binary, mirroring the behaviour of mount.Mounter.Mount with the
+// "bind" option:
+//
+//  1. First pass: mount --bind <source> <target>
+//  2. Second pass: mount --bind --remount <source> <target>
+//     with any read-only / nodev / noexec / nosuid / noatime / relatime /
+//     nodiratime flags inherited from the source filesystem via statfs(2).
+//
+// Using the /host-prefixed source path ensures that the statfs(2) call
+// succeeds inside the container (the container filesystem only exposes
+// paths under /host).
+func bindMount(source, target string) error {
+	// First pass: establish the bind mount.
+	if out, err := exec.Command("mount", "--bind", source, target).CombinedOutput(); err != nil {
+		return fmt.Errorf("mount --bind %s %s failed: %v\nOutput: %s", source, target, err, string(out))
+	}
+
+	// Derive the mount flags that are active on the source filesystem so that
+	// the bind mount inherits them (e.g. ro, nodev, nosuid, noexec, …).
+	remountOpts := []string{"--bind", "--remount"}
+	var st unix.Statfs_t
+	if err := unix.Statfs(source, &st); err == nil {
+		flagMap := map[int]string{
+			unix.MS_RDONLY:     "ro",
+			unix.MS_NODEV:      "nodev",
+			unix.MS_NOEXEC:     "noexec",
+			unix.MS_NOSUID:     "nosuid",
+			unix.MS_NOATIME:    "noatime",
+			unix.MS_RELATIME:   "relatime",
+			unix.MS_NODIRATIME: "nodiratime",
+		}
+		for flag, opt := range flagMap {
+			if int(st.Flags)&flag == flag {
+				remountOpts = append(remountOpts, "-o", opt)
+			}
+		}
+	}
+
+	// Second pass: remount to propagate inherited flags.
+	remountArgs := append(remountOpts, source, target)
+	if out, err := exec.Command("mount", remountArgs...).CombinedOutput(); err != nil {
+		return fmt.Errorf("mount --bind --remount %s %s failed: %v\nOutput: %s", source, target, err, string(out))
+	}
+
+	return nil
+}

--- a/driver/csiplugin/nodeserver.go
+++ b/driver/csiplugin/nodeserver.go
@@ -271,15 +271,14 @@ func (ns *ScaleNodeServer) NodePublishVolume(ctx context.Context, req *csi.NodeP
 		}
 
 		// create bind mount
-		// Use volScalePathInContainer (/host + volScalePath) as the bind-mount source so
-		// that the statfs(2) call in bindMount succeeds inside the container
-		// (the container filesystem only exposes paths under /host).
-		// The privileged container shares the host mount namespace, so the kernel resolves
-		// /host/... to the same inode as the bare host path, producing an identical bind mount.
-		klog.V(4).Infof("[%s] NodePublishVolume - creating bind mount [%v] -> [%v]", loggerId, targetPath, volScalePathInContainer)
-		if err := bindMount(volScalePathInContainer, targetPath); err != nil {
-			klog.Errorf("[%s] NodePublishVolume - mounting [%s] at [%s] failed with error [%v]", loggerId, volScalePathInContainer, targetPath, err)
-			return nil, fmt.Errorf("NodePublishVolume - mounting [%s] at [%s] failed with error [%v]", volScalePathInContainer, targetPath, err)
+		// volScalePath (bare host path) is passed to the mount(8) binary, which
+		// runs as a child process in the host mount namespace and cannot see /host.
+		// volScalePathInContainer (/host + volScalePath) is used only for the
+		// in-process statfs(2) call inside bindMount, where /host is visible.
+		klog.V(4).Infof("[%s] NodePublishVolume - creating bind mount [%v] -> [%v]", loggerId, targetPath, volScalePath)
+		if err := bindMount(volScalePath, volScalePathInContainer, targetPath); err != nil {
+			klog.Errorf("[%s] NodePublishVolume - mounting [%s] at [%s] failed with error [%v]", loggerId, volScalePath, targetPath, err)
+			return nil, fmt.Errorf("NodePublishVolume - mounting [%s] at [%s] failed with error [%v]", volScalePath, targetPath, err)
 		}
 
 		//check for the gpfs type again, if not gpfs type, unmount and return error.

--- a/driver/csiplugin/nodeserver.go
+++ b/driver/csiplugin/nodeserver.go
@@ -274,9 +274,9 @@ func (ns *ScaleNodeServer) NodePublishVolume(ctx context.Context, req *csi.NodeP
 		// volScalePath (bare host path) is passed to the mount(8) binary, which
 		// runs as a child process in the host mount namespace and cannot see /host.
 		// volScalePathInContainer (/host + volScalePath) is used only for the
-		// in-process statfs(2) call inside bindMount, where /host is visible.
+		// in-process statfs(2) call inside BindMount, where /host is visible.
 		klog.V(4).Infof("[%s] NodePublishVolume - creating bind mount [%v] -> [%v]", loggerId, targetPath, volScalePath)
-		if err := bindMount(volScalePath, volScalePathInContainer, targetPath); err != nil {
+		if err := utils.BindMount(volScalePath, volScalePathInContainer, targetPath); err != nil {
 			klog.Errorf("[%s] NodePublishVolume - mounting [%s] at [%s] failed with error [%v]", loggerId, volScalePath, targetPath, err)
 			return nil, fmt.Errorf("NodePublishVolume - mounting [%s] at [%s] failed with error [%v]", volScalePath, targetPath, err)
 		}

--- a/driver/csiplugin/nodeserver.go
+++ b/driver/csiplugin/nodeserver.go
@@ -26,12 +26,12 @@ import (
 	"k8s.io/klog/v2"
 
 	"github.com/IBM/ibm-spectrum-scale-csi/driver/csiplugin/utils"
-	"golang.org/x/net/context"
-	"k8s.io/mount-utils"
-    "google.golang.org/protobuf/proto"
 	"github.com/container-storage-interface/spec/lib/go/csi"
+	"golang.org/x/net/context"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
+	"google.golang.org/protobuf/proto"
+	"k8s.io/mount-utils"
 )
 
 type ScaleNodeServer struct {
@@ -271,11 +271,15 @@ func (ns *ScaleNodeServer) NodePublishVolume(ctx context.Context, req *csi.NodeP
 		}
 
 		// create bind mount
-		options := []string{"bind"}
-		klog.V(4).Infof("[%s] NodePublishVolume - creating bind mount [%v] -> [%v]", loggerId, targetPath, volScalePath)
-		if err := mounter.Mount(volScalePath, targetPath, "", options); err != nil {
-			klog.Errorf("[%s] NodePublishVolume - mounting [%s] at [%s] failed with error [%v]", loggerId, volScalePath, targetPath, err)
-			return nil, fmt.Errorf("NodePublishVolume - mounting [%s] at [%s] failed with error [%v]", volScalePath, targetPath, err)
+		// Use volScalePathInContainer (/host + volScalePath) as the bind-mount source so
+		// that the statfs(2) call in bindMount succeeds inside the container
+		// (the container filesystem only exposes paths under /host).
+		// The privileged container shares the host mount namespace, so the kernel resolves
+		// /host/... to the same inode as the bare host path, producing an identical bind mount.
+		klog.V(4).Infof("[%s] NodePublishVolume - creating bind mount [%v] -> [%v]", loggerId, targetPath, volScalePathInContainer)
+		if err := bindMount(volScalePathInContainer, targetPath); err != nil {
+			klog.Errorf("[%s] NodePublishVolume - mounting [%s] at [%s] failed with error [%v]", loggerId, volScalePathInContainer, targetPath, err)
+			return nil, fmt.Errorf("NodePublishVolume - mounting [%s] at [%s] failed with error [%v]", volScalePathInContainer, targetPath, err)
 		}
 
 		//check for the gpfs type again, if not gpfs type, unmount and return error.

--- a/driver/csiplugin/utils/mount_utils.go
+++ b/driver/csiplugin/utils/mount_utils.go
@@ -1,5 +1,3 @@
-//go:build linux
-// +build linux
 
 /**
  * Copyright 2019, 2024 IBM Corp.
@@ -17,7 +15,7 @@
  * limitations under the License.
  */
 
-package scale
+package utils
 
 import (
 	"fmt"
@@ -27,7 +25,7 @@ import (
 	"golang.org/x/sys/unix"
 )
 
-// bindMount performs a bind mount of hostSource onto target using the system
+// BindMount performs a bind mount of hostSource onto target using the system
 // mount(8) binary, mirroring the behaviour of mount.Mounter.Mount with the
 // "bind" option:
 //
@@ -43,7 +41,7 @@ import (
 // statfsSource is the /host-prefixed path (e.g. /host/ibm/fs1/pvc-…/data)
 // used only for the in-process statfs(2) call, which succeeds because the
 // container filesystem exposes host paths under /host.
-func bindMount(hostSource, statfsSource, target string) error {
+func BindMount(hostSource, statfsSource, target string) error {
 	// First pass: establish the bind mount using the bare host path.
 	if out, err := exec.Command("mount", "--bind", hostSource, target).CombinedOutput(); err != nil {
 		return fmt.Errorf("mount --bind %s %s failed: %v\nOutput: %s", hostSource, target, err, string(out))


### PR DESCRIPTION
Fix for mount in NodePublishVolume. Addresses Issue https://github.ibm.com/IBMSpectrumScale/scale-core/issues/11642 and https://github.ibm.com/IBMSpectrumScale/scale-core/issues/10216

Please check the type of change your PR introduces:
- [x] Bugfix
- [ ] Feature Enhancement
- [ ] Test Automation 
- [ ] Code Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Community Operator listing 
- [ ] Other (please describe): 


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying -->
- Stat in mount_utils.go (in k8s) fails as the path variable passed to function is host path

## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->
- Included Mount function locally to make it work

## How risky is this change?
- [ ] Small, isolated change
- [x] Medium, requires regression testing
- [ ] Large, requires functional and regression testing 

