### PR TITLE
go update

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -54,7 +54,7 @@ env:
 
     # Build tool versions
     - KUSTOMIZE_VERSION=4.5.2
-    - GOLANGCI_LINT_VERSION=v1.64.8
+    - GOLANGCI_LINT_VERSION=v2.9.0
 
 # Operator ENV
     - OCTOKIT_API_ENDPOINT="https://github.ibm.com/api/v3/"

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ services: docker
 dist: focal
 language: go
 go:
-  - 1.24.x
+  - 1.26.x
 
 env:
   global:

--- a/driver/build/Dockerfile
+++ b/driver/build/Dockerfile
@@ -3,7 +3,7 @@
 # Multi-arch build for IBM Storage Scale CSI Driver
 # usage: docker buildx build -f build/multi-arch.Dockerfile --platform=linux/amd64 -t my_image_tag .
 
-FROM --platform=$BUILDPLATFORM preprod.icr.io/cp/scale-devops/plumbing/golang:1.24.9 AS builder
+FROM --platform=$BUILDPLATFORM preprod.icr.io/cp/scale-devops/plumbing/golang:1.26.4 AS builder
 WORKDIR /go/src/github.com/IBM/ibm-spectrum-scale-csi/driver/
 COPY ./go.mod .
 COPY ./go.sum .

--- a/driver/go.mod
+++ b/driver/go.mod
@@ -1,6 +1,6 @@
 module github.com/IBM/ibm-spectrum-scale-csi/driver
 
-go 1.24.0
+go 1.26.4
 
 require (
 	github.com/container-storage-interface/spec v1.11.0

--- a/operator/Makefile
+++ b/operator/Makefile
@@ -56,7 +56,7 @@ SHELL = /usr/bin/env bash -o pipefail
 ## Tool Versions
 KUSTOMIZE_VERSION ?= v4.5.2
 CONTROLLER_GEN_VERSION ?= v0.17.3
-GOLANGCI_LINT_VERSION ?= v1.59.0
+GOLANGCI_LINT_VERSION ?= v2.9.0
 
 all: build
 

--- a/operator/build/Dockerfile
+++ b/operator/build/Dockerfile
@@ -1,5 +1,5 @@
 # docker build for IBM Storage Scale CSI Operator
-FROM --platform=$BUILDPLATFORM preprod.icr.io/cp/scale-devops/plumbing/golang:1.24.9 as builder
+FROM --platform=$BUILDPLATFORM preprod.icr.io/cp/scale-devops/plumbing/golang:1.26.4 as builder
 
 ARG TARGETOS
 ARG TARGETARCH

--- a/operator/go.mod
+++ b/operator/go.mod
@@ -1,6 +1,6 @@
 module github.com/IBM/ibm-spectrum-scale-csi/operator
 
-go 1.24.0
+go 1.26.4
 
 require (
 	github.com/IBM/ibm-spectrum-scale-csi/driver v0.0.0-20260212153536-173dbe7bfaef

--- a/tools/ansible/common/dev-env.yaml
+++ b/tools/ansible/common/dev-env.yaml
@@ -3,7 +3,7 @@
   set_fact:
     OPERATOR_SDK_VER: "v1.36.1"
     OPERATOR_VERSION: "3.1.1"
-    GO_VERSION:       "go1.22"
+    GO_VERSION:       "go1.26.4"
 
 # Something is wrong with this bit.
 #- name: Ensure 'python3' is installed


### PR DESCRIPTION
Updated GO to 1.26.4 to address the critical vulnerability (CVE-2026-39834) reported in Twistlock scan in 3.1.1. 



Please check the type of change your PR introduces:
- [x] Bugfix
- [ ] Feature Enhancement
- [ ] Test Automation 
- [ ] Code Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Community Operator listing 
- [ ] Other (please describe): 



## How risky is this change?
- [x] Small, isolated change
- [ ] Medium, requires regression testing
- [ ] Large, requires functional and regression testing 

