### PR TITLE
ControllerPublishVolume: include nodesMountedReadOnly in mounted-node checks

### DIFF
--- a/driver/csiplugin/connectors/resources.go
+++ b/driver/csiplugin/connectors/resources.go
@@ -397,11 +397,11 @@ type MountInfo struct {
 	AdditionalMountOptions string `json:"additionalMountOptions,omitempty"`
 	MountPriority          int    `json:"mountPriority,omitempty"`
 	//	DriveLetter            string `json:"driveLetter,omitempty"`
-	RemoteDeviceName    string   `json:"remoteDeviceName,omitempty"`
-	NodesMounted        []string `json:"nodesMountedReadWrite,omitempty"`
+	RemoteDeviceName     string   `json:"remoteDeviceName,omitempty"`
+	NodesMounted         []string `json:"nodesMountedReadWrite,omitempty"`
 	NodesMountedReadOnly []string `json:"nodesMountedReadOnly,omitempty"`
-	ReadOnly            bool     `json:"readOnly,omitempty"`
-	Status              string   `json:"status,omitempty"`
+	ReadOnly             bool     `json:"readOnly,omitempty"`
+	Status               string   `json:"status,omitempty"`
 }
 
 type QuotaInfo struct {

--- a/driver/csiplugin/connectors/resources.go
+++ b/driver/csiplugin/connectors/resources.go
@@ -397,10 +397,11 @@ type MountInfo struct {
 	AdditionalMountOptions string `json:"additionalMountOptions,omitempty"`
 	MountPriority          int    `json:"mountPriority,omitempty"`
 	//	DriveLetter            string `json:"driveLetter,omitempty"`
-	RemoteDeviceName string   `json:"remoteDeviceName,omitempty"`
-	NodesMounted     []string `json:"nodesMountedReadWrite,omitempty"`
-	ReadOnly         bool     `json:"readOnly,omitempty"`
-	Status           string   `json:"status,omitempty"`
+	RemoteDeviceName    string   `json:"remoteDeviceName,omitempty"`
+	NodesMounted        []string `json:"nodesMountedReadWrite,omitempty"`
+	NodesMountedReadOnly []string `json:"nodesMountedReadOnly,omitempty"`
+	ReadOnly            bool     `json:"readOnly,omitempty"`
+	Status              string   `json:"status,omitempty"`
 }
 
 type QuotaInfo struct {

--- a/driver/csiplugin/controllerserver.go
+++ b/driver/csiplugin/controllerserver.go
@@ -3377,7 +3377,8 @@ func (cs *ScaleControllerServer) ControllerPublishVolume(ctx context.Context, re
 	}
 
 	klog.Infof("[%s] fsName:%s, fsMount:%+v, scalenodeID:%s", loggerId, fsName, fsMount, scalenodeID)
-	klog.Infof("[%s] ControllerPublishVolume : FS is mounted on %v", loggerId, fsMount.NodesMounted)
+	mountedNodes := getMountedNodes(fsMount)
+	klog.Infof("[%s] ControllerPublishVolume : FS is mounted on %v", loggerId, mountedNodes)
 	klog.V(4).Infof("[%s] ControllerPublishVolume : Volume is from Filesystem %s", loggerId, fsName)
 
 	if !strings.HasPrefix(volumePath, fsMount.MountPoint) {
@@ -3409,11 +3410,11 @@ func (cs *ScaleControllerServer) ControllerPublishVolume(ctx context.Context, re
 	// This means node mapping must be to admin names.
 	// Unless shortnameNodeMapping=="yes", then we should check shortname portion matches.
 	if shortnameNodeMapping == yes {
-		isFsMounted = shortnameInSlice(scalenodeID, fsMount.NodesMounted)
+		isFsMounted = shortnameInSlice(scalenodeID, mountedNodes)
 	} else {
-		isFsMounted = utils.StringInSlice(scalenodeID, fsMount.NodesMounted)
+		isFsMounted = utils.StringInSlice(scalenodeID, mountedNodes)
 	}
-	klog.Infof("[%s] ControllerPublishVolume : Volume Source FS is mounted on %v", loggerId, fsMount.NodesMounted)
+	klog.Infof("[%s] ControllerPublishVolume : Volume Source FS is mounted on %v", loggerId, mountedNodes)
 	klog.Infof("[%s] ControllerPublishVolume : Mount Status of fs [ %t ]", loggerId, isFsMounted)
 
 	var isFsMountedOnGateway bool
@@ -3447,10 +3448,11 @@ func (cs *ScaleControllerServer) ControllerPublishVolume(ctx context.Context, re
 			klog.V(4).Infof("[%s] ControllerPublishVolume : filesystem:[%s] is a local mount", loggerId, fsName)
 		}
 
-		klog.V(4).Infof("[%s] ControllerPublishVolume : filesystem:[%s] or fsNameRemote:[%s] is mounted on these nodes %v", loggerId, fsName, fsNameRemote, fsRemoteMountDetails.NodesMounted)
+		remoteMountedNodes := getMountedNodes(fsRemoteMountDetails)
+		klog.V(4).Infof("[%s] ControllerPublishVolume : filesystem:[%s] or fsNameRemote:[%s] is mounted on these nodes %v", loggerId, fsName, fsNameRemote, remoteMountedNodes)
 
 		// check whether FS is mounted on all the gateway nodes or not
-		isFsMountedOnGateway = isSubset(gatewayNodeNames, fsRemoteMountDetails.NodesMounted)
+		isFsMountedOnGateway = isSubset(gatewayNodeNames, remoteMountedNodes)
 
 		//sucess when FS is mounted primary , volumeFS and on all the gatewayNodes for "cache" volume
 		if isFsMounted && isFsMountedOnGateway {

--- a/driver/csiplugin/gpfs_util.go
+++ b/driver/csiplugin/gpfs_util.go
@@ -825,3 +825,28 @@ func isSubset(subset []string, superset []string) bool {
 	}
 	return false
 }
+
+// getMountedNodes returns a de-duplicated list of nodes where the filesystem is mounted,
+// combining both read-write and read-only REST fields.
+func getMountedNodes(mountInfo connectors.MountInfo) []string {
+	mountedNodes := make([]string, 0, len(mountInfo.NodesMounted)+len(mountInfo.NodesMountedReadOnly))
+	nodeSet := make(map[string]struct{})
+
+	for _, node := range mountInfo.NodesMounted {
+		if _, seen := nodeSet[node]; seen {
+			continue
+		}
+		nodeSet[node] = struct{}{}
+		mountedNodes = append(mountedNodes, node)
+	}
+
+	for _, node := range mountInfo.NodesMountedReadOnly {
+		if _, seen := nodeSet[node]; seen {
+			continue
+		}
+		nodeSet[node] = struct{}{}
+		mountedNodes = append(mountedNodes, node)
+	}
+
+	return mountedNodes
+}


### PR DESCRIPTION
## Pull request checklist

```release-notes
- Fix ControllerPublishVolume mount detection for read-only remote mounts by including nodesMountedReadOnly in mounted-node checks.
```

## Pull request type

Please check the type of change your PR introduces:
- [x] Bugfix
- [x] Feature Enhancement
- [ ] Test Automation
- [ ] Code Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Community Operator listing
- [ ] Other (please describe):

## What is the current behavior?
- For static provisioning on a filesystem remote-mounted read-only on k8s nodes, `ControllerPublishVolume` can fail attach with `filesystem <fs> is not mounted on node <node>`.
- The failure occurs because mount detection uses `nodesMountedReadWrite` only; when that list is empty and `nodesMountedReadOnly` is populated, mount status is incorrectly evaluated as false.
- Issue reference: #1515.

## What is the new behavior?
- `MountInfo` now parses `nodesMountedReadOnly`.
- `ControllerPublishVolume` uses a merged/de-duplicated mounted-node set from both `nodesMountedReadWrite` and `nodesMountedReadOnly`.
- The same merged-node logic is used in cache/gateway mount checks.
- In read-only remote mount scenarios, attach succeeds when the node is present in read-only mounted-node data.
- Validated in POC: pod transitions to `Running`, mounts remain `ro`, and write attempts fail as expected.

## How risky is this change?
- [x] Small, isolated change
- [ ] Medium, requires regression testing
- [ ] Large, requires functional and regression testing