### PR TITLE
removing the images_manifest.yaml as no longer being used in cnsa

### DIFF
--- a/operator/config/overlays/default/images_manifest.yaml
+++ b/operator/config/overlays/default/images_manifest.yaml
@@ -1,8 +1,0 @@
-version: 3.2.0
-images:
-  csiSnapshotter: cp.icr.io/cp/gpfs/csi/csi-snapshotter@sha256:da081c27e8a6d91f36042c1942362d0515ced8d06e18c11b8f893e58c4d6d797
-  csiAttacher: cp.icr.io/cp/gpfs/csi/csi-attacher@sha256:b74b05b39501565022883fc128002b4cb857a7bb6c858606bcb3fdedba0b0b80
-  csiProvisioner: cp.icr.io/cp/gpfs/csi/csi-provisioner@sha256:6be9f63ca4caa6c46aae55aa372500949d8a21473d72f819da1f746076b32d4e
-  csiLivenessprobe: cp.icr.io/cp/gpfs/csi/livenessprobe@sha256:c4cc074199c045dd73ab85f28897e2a32f4d6f38ffdba4f3b13b8007ccbd3570
-  csiNodeRegistrar: cp.icr.io/cp/gpfs/csi/csi-node-driver-registrar@sha256:ab482308a4921e28a6df09a16ab99a457e9af9641ff44fb1be1a690d07ce8b70
-  csiResizer: cp.icr.io/cp/gpfs/csi/csi-resizer@sha256:589e525cddef6d768e68da1f0bc9ffd0a24bf3add3dd010648eb7189976fde79


### PR DESCRIPTION
## Pull request checklist

<!-- Add your one liner release notes here -->
<!-- eg... -->
<!--   - Major functionality adds -->
<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->
<!--   - are you changing our ScaleCluster CR file? -->
```release-notes

```

with the reference to the PR [Disconnect CSI_REPO from images as pipeline is handling the builds and sidecars in versions.yaml](https://github.ibm.com/IBMSpectrumScale/scale-core/pull/11928) the images_manifect.yaml is no longer being used to update csi sidecars image updates in the cnsa. 

With the introduction of the versions.yaml file and it will be a single source of truth. Team needs to update directly `versions.yaml`  for cnsa and `operator/config/manager/manager.yaml` for standalone csi before release cycle to pick right csi images. 

## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [ ] Bugfix
- [ ] Feature Enhancement
- [ ] Test Automation 
- [ ] Code Refactoring (no functional changes, no api changes)
- [x] Build related changes
- [ ] Community Operator listing 
- [ ] Other (please describe): 


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying -->
-

## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->
-

## How risky is this change?
- [x] Small, isolated change
- [ ] Medium, requires regression testing
- [ ] Large, requires functional and regression testing 

