### PR TITLE
Add flag to enable FIPS on runtime for sidecars, nodeDriverRegistrar and livenessProbe

### DIFF
--- a/operator/controllers/config/constants.go
+++ b/operator/controllers/config/constants.go
@@ -139,6 +139,11 @@ const (
 
 	DaemonSetUpgradeUpdateStrategyType = "RollingUpdate"
 
+	// ENVGoDebug is the name of the GODEBUG environment variable.
+	ENVGoDebug = "GODEBUG"
+	// ENVGoDebugFIPS is the GODEBUG value required to enable FIPS 140 mode in Go binaries.
+	ENVGoDebugFIPS = "fips140=on"
+
 	// Optional ConfigMap constants for CSI driver environment variables
 	EnvVarConfigMap = "ibm-spectrum-scale-csi-config"
 	EnvVarPrefix    = "VAR_DRIVER_"

--- a/operator/controllers/syncer/csi_node.go
+++ b/operator/controllers/syncer/csi_node.go
@@ -339,8 +339,8 @@ func envVarFromField(name, fieldPath string) corev1.EnvVar {
 func (s *csiNodeSyncer) getEnvFor(name string, CSIEnvConfig CSIEnvConfigs) []corev1.EnvVar {
 
 	fipsEnv := corev1.EnvVar{
-		Name:  "GODEBUG",
-		Value: "fips140=on",
+		Name:  config.ENVGoDebug,
+		Value: config.ENVGoDebugFIPS,
 	}
 
 	switch name {

--- a/operator/controllers/syncer/csi_node.go
+++ b/operator/controllers/syncer/csi_node.go
@@ -338,6 +338,11 @@ func envVarFromField(name, fieldPath string) corev1.EnvVar {
 // getEnvFor returns list of environment variables for given container name.
 func (s *csiNodeSyncer) getEnvFor(name string, CSIEnvConfig CSIEnvConfigs) []corev1.EnvVar {
 
+	fipsEnv := corev1.EnvVar{
+		Name:  "GODEBUG",
+		Value: "fips140=on",
+	}
+
 	switch name {
 	case nodeContainerName:
 		EnvVars := []corev1.EnvVar{}
@@ -385,6 +390,7 @@ func (s *csiNodeSyncer) getEnvFor(name string, CSIEnvConfig CSIEnvConfigs) []cor
 			},
 			envVarFromField("NODE_ID", "spec.nodeName"),
 			// envVarFromField("KUBE_NODE_NAME", "spec.nodeName"),
+			fipsEnv,
 		}...)
 
 	case nodeDriverRegistrarContainerName:
@@ -398,6 +404,7 @@ func (s *csiNodeSyncer) getEnvFor(name string, CSIEnvConfig CSIEnvConfigs) []cor
 				Value: s.driver.GetSocketPath(),
 			},
 			envVarFromField("KUBE_NODE_NAME", "spec.nodeName"),
+			fipsEnv,
 		}
 
 	case nodeLivenessProbeContainerName:
@@ -406,6 +413,7 @@ func (s *csiNodeSyncer) getEnvFor(name string, CSIEnvConfig CSIEnvConfigs) []cor
 				Name:  "ADDRESS",
 				Value: s.driver.GetSocketPath(),
 			},
+			fipsEnv,
 		}
 	}
 	return nil

--- a/operator/controllers/syncer/csi_node.go
+++ b/operator/controllers/syncer/csi_node.go
@@ -390,7 +390,6 @@ func (s *csiNodeSyncer) getEnvFor(name string, CSIEnvConfig CSIEnvConfigs) []cor
 			},
 			envVarFromField("NODE_ID", "spec.nodeName"),
 			// envVarFromField("KUBE_NODE_NAME", "spec.nodeName"),
-			fipsEnv,
 		}...)
 
 	case nodeDriverRegistrarContainerName:

--- a/operator/controllers/syncer/csi_syncer.go
+++ b/operator/controllers/syncer/csi_syncer.go
@@ -721,8 +721,8 @@ func (s *csiControllerSyncer) envVarFromSecret(sctName, name, key string, opt bo
 func (s *csiControllerSyncer) getEnvFor(name string) []corev1.EnvVar {
 
 	fipsEnv := corev1.EnvVar{
-		Name:  "GODEBUG",
-		Value: "fips140=on",
+		Name:  config.ENVGoDebug,
+		Value: config.ENVGoDebugFIPS,
 	}
 
 	switch name {

--- a/operator/controllers/syncer/csi_syncer.go
+++ b/operator/controllers/syncer/csi_syncer.go
@@ -720,6 +720,11 @@ func (s *csiControllerSyncer) envVarFromSecret(sctName, name, key string, opt bo
 // getEnvFor returns a k8s envVar object for the CSI sidecar containers.
 func (s *csiControllerSyncer) getEnvFor(name string) []corev1.EnvVar {
 
+	fipsEnv := corev1.EnvVar{
+		Name:  "GODEBUG",
+		Value: "fips140=on",
+	}
+
 	switch name {
 	case provisionerContainerName, attacherContainerName, snapshotterContainerName, resizerContainerName:
 		return []corev1.EnvVar{
@@ -739,6 +744,7 @@ func (s *csiControllerSyncer) getEnvFor(name string) []corev1.EnvVar {
 				Name:  "LEADER_ELECTION_RETRY_PERIOD",
 				Value: "26s",
 			},
+			fipsEnv,
 		}
 	}
 	return nil


### PR DESCRIPTION

## Pull request checklist

<!-- Add your one liner release notes here -->
<!-- eg... -->
<!--   - Major functionality adds -->
<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->
<!--   - are you changing our ScaleCluster CR file? -->
```release-notes

```

## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [ ] Bugfix
- [x] Feature Enhancement
- [ ] Test Automation 
- [ ] Code Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Community Operator listing 
- [ ] Other (please describe): 


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying -->
- Currently we don't have FIPS enabled with sidecars, nodeDriverRegistrar and livenessProbe as these are upstream images who's binaries are not compiled with GOFIPS=latest, so to use FIPS at runtime we need to add GODEBUG=fips140=on environment variable so it can be enabled at runtime

## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->
- With this PR GODEBUG=fips140=on  environment variable is added through `getEnvFor ` function

## How risky is this change?
- [ ] Small, isolated change
- [ ] Medium, requires regression testing
- [ ] Large, requires functional and regression testing 

