### PR TITLE
[ release-3.1.2 ] fixes for staticpv when fs path is the volume path

### DIFF
--- a/driver/csiplugin/nodeserver.go
+++ b/driver/csiplugin/nodeserver.go
@@ -133,7 +133,7 @@ func checkGpfsType(ctx context.Context, path string) error {
 	// gpfsPaths entries are kernel-visible mount roots (e.g. /var/mnt/remote-sample).
 	// kernelPath is always a deep volume path under one of those roots.
 	for _, gpfsPath := range gpfsPaths {
-		if !strings.HasPrefix(kernelPath, gpfsPath+"/") {
+		if kernelPath != gpfsPath && !strings.HasPrefix(kernelPath, gpfsPath+"/") {
 			klog.V(4).Infof("[%s] checkGpfsType: kernelPath [%s] is not under mount [%s], skipping", loggerId, kernelPath, gpfsPath)
 			continue
 		}


### PR DESCRIPTION
Signed-off-by: badri-pathak <badri.pathak@ibm.com>

## Pull request checklist

<!-- Add your one liner release notes here -->
<!-- eg... -->
<!--   - Major functionality adds -->
<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->
<!--   - are you changing our ScaleCluster CR file? -->
```release-notes

```

```
quay.io/badri_pathak/ibm-spectrum-scale-csi-driver:v_20260907_164938
quay.io/badri_pathak/ibm-spectrum-scale-csi-operator:v_20260907_164938
```
## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [x] Bugfix
- [ ] Feature Enhancement
- [ ] Test Automation 
- [ ] Code Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Community Operator listing 
- [ ] Other (please describe): 


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying -->
-

## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->
-

## How risky is this change?
- [ ] Small, isolated change
- [ ] Medium, requires regression testing
- [ ] Large, requires functional and regression testing 

