### PR TITLE
Fixes for gosec issues

### DIFF
--- a/driver/csiplugin/nodeserver.go
+++ b/driver/csiplugin/nodeserver.go
@@ -162,8 +162,14 @@ func isGPFS(ctx context.Context, path string) (bool, error) {
 		klog.Errorf("[%s] isGPFS: statfs %q failed: %v", loggerId, path, err)
 		return false, err
 	}
-	klog.V(4).Infof("[%s] isGPFS: fsType 0x%x for path %s", loggerId, uint64(st.Type), path)
+
+	if st.Type < 0 {
+		return false, fmt.Errorf("isGPFS: statfs %q returned negative filesystem type: %d", path, st.Type)
+	}
+
+	klog.V(4).Infof("[%s] isGPFS: fsType 0x%x for path %s", loggerId, uint64(st.Type), path) //#nosec G115
 	// GPFS magic number: 0x47504653 ("GPFS")
+	//#nosec G115 safe and required conversion
 	return uint64(st.Type) == gpfsmagicNumber, nil
 }
 

--- a/driver/csiplugin/settings/scale_config.go
+++ b/driver/csiplugin/settings/scale_config.go
@@ -160,7 +160,8 @@ func HandleSecretsAndCerts(ctx context.Context, cmap *ScaleSettingsConfigMap) er
 
 				// Read file contents
 				// #nosec G122 - Safe to read as path has RBAC and could be modified by only operator SA and mounted as ReadOnly volume inside the container
-				data, err := os.ReadFile(path) // #nosec G304 Valid Path is generated internally
+				// #nosec G304 Valid Path is generated internally
+				data, err := os.ReadFile(path)
 				if err != nil {
 					return fmt.Errorf("failed to read the IBM Storage Scale CA certificate directory:%s - error: %v", path, err)
 				}

--- a/driver/csiplugin/settings/scale_config.go
+++ b/driver/csiplugin/settings/scale_config.go
@@ -159,6 +159,7 @@ func HandleSecretsAndCerts(ctx context.Context, cmap *ScaleSettingsConfigMap) er
 				}
 
 				// Read file contents
+				// #nosec G122 - Safe to read as path has RBAC and could be modified by only operator SA and mounted as ReadOnly volume inside the container
 				data, err := os.ReadFile(path) // #nosec G304 Valid Path is generated internally
 				if err != nil {
 					return fmt.Errorf("failed to read the IBM Storage Scale CA certificate directory:%s - error: %v", path, err)

--- a/driver/csiplugin/utils/mount_utils.go
+++ b/driver/csiplugin/utils/mount_utils.go
@@ -47,6 +47,7 @@ import (
 func BindMount(ctx context.Context, hostSource, statfsSource, target string) error {
 	loggerId := GetLoggerId(ctx)
 	// First pass: establish the bind mount using the bare host path.
+	// #nosec G204 - Using exec.Command to call mount is safe here because the arguments are controlled and not user input.
 	if out, err := exec.Command("mount", "--bind", hostSource, target).CombinedOutput(); err != nil {
 		klog.Errorf("[%s] mount --bind source [%s] target [%s] failed, Error: %v, Output: %s", loggerId, hostSource, target, err, string(out))
 		return fmt.Errorf("mount --bind source [%s] target [%s] failed, Error: %v, Output: %s", hostSource, target, err, string(out))
@@ -80,6 +81,7 @@ func BindMount(ctx context.Context, hostSource, statfsSource, target string) err
 
 	// Second pass: remount with inherited flags.
 	opts := strings.Join(mountOpts, ",")
+	// #nosec G204 - Using exec.Command to call mount is safe here because the arguments are controlled and not user input.
 	if out, err := exec.Command("mount", "-o", opts, hostSource, target).CombinedOutput(); err != nil {
 		klog.Errorf("[%s] mount -o %s %s %s failed: %v, Output: %s", loggerId, opts, hostSource, target, err, string(out))
 		return fmt.Errorf("mount -o %s %s %s failed: %v, Output: %s", opts, hostSource, target, err, string(out))


### PR DESCRIPTION
**Issues Reported:**

`{
	"Golang errors": {},
	"Issues": [
		{
			"severity": "HIGH",
			"confidence": "MEDIUM",
			"cwe": {
				"id": "190",
				"url": "https://cwe.mitre.org/data/definitions/190.html"
			},
			"rule_id": "G115",
			"details": "integer overflow conversion int64 -\u003e uint64",
			"file": "/root/ibm-spectrum-scale-csi/driver/csiplugin/nodeserver.go",
			"code": "166: \t// GPFS magic number: 0x47504653 (\"GPFS\")\n167: \treturn uint64(st.Type) == gpfsmagicNumber, nil\n168: }\n",
			"line": "167",
			"column": "15",
			"nosec": false,
			"suppressions": null
		},
		{
			"severity": "HIGH",
			"confidence": "MEDIUM",
			"cwe": {
				"id": "190",
				"url": "https://cwe.mitre.org/data/definitions/190.html"
			},
			"rule_id": "G115",
			"details": "integer overflow conversion int64 -\u003e uint64",
			"file": "/root/ibm-spectrum-scale-csi/driver/csiplugin/nodeserver.go",
			"code": "164: \t}\n165: \tklog.V(4).Infof(\"[%s] isGPFS: fsType 0x%x for path %s\", loggerId, uint64(st.Type), path)\n166: \t// GPFS magic number: 0x47504653 (\"GPFS\")\n",
			"line": "165",
			"column": "74",
			"nosec": false,
			"suppressions": null
		},
		{
			"severity": "HIGH",
			"confidence": "MEDIUM",
			"cwe": {
				"id": "367",
				"url": "https://cwe.mitre.org/data/definitions/367.html"
			},
			"rule_id": "G122",
			"details": "Filesystem operation in filepath.Walk/WalkDir callback uses race-prone path; consider root-scoped APIs (e.g. os.Root) to prevent symlink TOCTOU traversal",
			"file": "/root/ibm-spectrum-scale-csi/driver/csiplugin/settings/scale_config.go",
			"code": "161: \t\t\t\t// Read file contents\n162: \t\t\t\tdata, err := os.ReadFile(path) // #nosec G304 Valid Path is generated internally\n163: \t\t\t\tif err != nil {\n",
			"line": "162",
			"column": "29",
			"nosec": false,
			"suppressions": null
		},
		{
			"severity": "MEDIUM",
			"confidence": "HIGH",
			"cwe": {
				"id": "78",
				"url": "https://cwe.mitre.org/data/definitions/78.html"
			},
			"rule_id": "	",
			"details": "Subprocess launched with variable",
			"file": "/root/ibm-spectrum-scale-csi/driver/csiplugin/utils/mount_utils.go",
			"code": "82: \topts := strings.Join(mountOpts, \",\")\n83: \tif out, err := exec.Command(\"mount\", \"-o\", opts, hostSource, target).CombinedOutput(); err != nil {\n84: \t\tklog.Errorf(\"[%s] mount -o %s %s %s failed: %v, Output: %s\", loggerId, opts, hostSource, target, err, string(out))\n",
			"line": "83",
			"column": "17",
			"nosec": false,
			"suppressions": null
		},
		{
			"severity": "MEDIUM",
			"confidence": "HIGH",
			"cwe": {
				"id": "78",
				"url": "https://cwe.mitre.org/data/definitions/78.html"
			},
			"rule_id": "G204",
			"details": "Subprocess launched with variable",
			"file": "/root/ibm-spectrum-scale-csi/driver/csiplugin/utils/mount_utils.go",
			"code": "49: \t// First pass: establish the bind mount using the bare host path.\n50: \tif out, err := exec.Command(\"mount\", \"--bind\", hostSource, target).CombinedOutput(); err != nil {\n51: \t\tklog.Errorf(\"[%s] mount --bind source [%s] target [%s] failed, Error: %v, Output: %s\", loggerId, hostSource, target, err, string(out))\n",
			"line": "50",
			"column": "17",
			"nosec": false,
			"suppressions": null
		}
	],
	"Stats": {
		"files": 18,
		"lines": 11030,
		"nosec": 32,
		"found": 5
	},`



Please check the type of change your PR introduces:
- [x] Bugfix
- [ ] Feature Enhancement
- [ ] Test Automation 
- [ ] Code Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Community Operator listing 
- [ ] Other (please describe): 



## How risky is this change?
- [x] Small, isolated change
- [ ] Medium, requires regression testing
- [ ] Large, requires functional and regression testing 

